### PR TITLE
git-gui: Revert untracked files by deleting them

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -2,13 +2,13 @@
 # Copyright (C) 2012, 2013, 2014, 2015, 2016 Alexander Shopov <ash@kambanaria.org>.
 # This file is distributed under the same license as the git package.
 # Alexander Shopov <ash@kambanaria.org>, 2012, 2013, 2014, 2015, 2016.
-#
-#
+# 
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-13 15:16+0300\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2016-10-13 15:16+0300\n"
 "Last-Translator: Alexander Shopov <ash@kambanaria.org>\n"
 "Language-Team: Bulgarian <dict@fsa-bg.org>\n"
@@ -18,42 +18,42 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: git-gui.sh:865
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Указан е неправилен шрифт в „%s“:"
 
-#: git-gui.sh:919
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Основен шрифт"
 
-#: git-gui.sh:920
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Шрифт за разликите/конзолата"
 
-#: git-gui.sh:935 git-gui.sh:949 git-gui.sh:962 git-gui.sh:1052 git-gui.sh:1071
-#: git-gui.sh:3147
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
 msgid "git-gui: fatal error"
 msgstr "git-gui: фатална грешка"
 
-#: git-gui.sh:936
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Командата git липсва в пътя (PATH)."
 
-#: git-gui.sh:963
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Низът с версията на Git не може да бъде интерпретиран:"
 
-#: git-gui.sh:988
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Версията на Git не може да бъде определена.\n"
 "\n"
@@ -63,43 +63,43 @@ msgstr ""
 "\n"
 "Да се приеме ли, че „%s“ е версия „1.5.0“?\n"
 
-#: git-gui.sh:1285
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Директорията на Git не е открита:"
 
-#: git-gui.sh:1319
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Не може да се премине към родителската  директория."
 
-#: git-gui.sh:1327
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Голо хранилище не може да се използва:"
 
-#: git-gui.sh:1335
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Работната директория липсва"
 
-#: git-gui.sh:1507 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Обновяване на състоянието на файла…"
 
-#: git-gui.sh:1567
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Проверка за променени файлове…"
 
-#: git-gui.sh:1645
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "Куката „prepare-commit-msg“ се изпълнява в момента…"
 
-#: git-gui.sh:1662
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "Подаването е отхвърлено от куката „prepare-commit-msg“."
 
-#: git-gui.sh:1820 lib/browser.tcl:252
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Готово."
 
-#: git-gui.sh:1984
+#: git-gui.sh:1966
 #, tcl-format
 msgid ""
 "Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
@@ -107,470 +107,470 @@ msgstr ""
 "Достигнат е максималният размер на списъка за извеждане(gui."
 "maxfilesdisplayed = %s), съответно не са показани всички %s файла."
 
-#: git-gui.sh:2107
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Непроменен"
 
-#: git-gui.sh:2109
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Променен, но не е в индекса"
 
-#: git-gui.sh:2110 git-gui.sh:2122
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "В индекса за подаване"
 
-#: git-gui.sh:2111 git-gui.sh:2123
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Части са в индекса за подаване"
 
-#: git-gui.sh:2112 git-gui.sh:2124
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "В индекса за подаване, но липсва"
 
-#: git-gui.sh:2114
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Видът на файла е сменен, но не е в индекса"
 
-#: git-gui.sh:2115 git-gui.sh:2116
+#: git-gui.sh:2097 git-gui.sh:2098
 msgid "File type changed, old type staged for commit"
 msgstr "Видът на файла е сменен, но новият вид не е в индекса"
 
-#: git-gui.sh:2117
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Видът на файла е сменен и е в индекса"
 
-#: git-gui.sh:2118
+#: git-gui.sh:2100
 msgid "File type change staged, modification not staged"
 msgstr "Видът на файла е сменен в индекса, но не и съдържанието"
 
-#: git-gui.sh:2119
+#: git-gui.sh:2101
 msgid "File type change staged, file missing"
 msgstr "Видът на файла е сменен в индекса, но файлът липсва"
 
-#: git-gui.sh:2121
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Неследен"
 
-#: git-gui.sh:2126
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Липсващ"
 
-#: git-gui.sh:2127
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "В индекса за изтриване"
 
-#: git-gui.sh:2128
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "В индекса за изтриване, но още го има"
 
-#: git-gui.sh:2130 git-gui.sh:2131 git-gui.sh:2132 git-gui.sh:2133
-#: git-gui.sh:2134 git-gui.sh:2135
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Изисква коригиране при сливане"
 
-#: git-gui.sh:2170
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Стартиране на „gitk“…, изчакайте…"
 
-#: git-gui.sh:2182
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Командата „gitk“ липсва в пътищата, определени от променливата PATH."
 
-#: git-gui.sh:2241
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr ""
 "Командата „git gui“ липсва в пътищата, определени от променливата PATH."
 
-#: git-gui.sh:2676 lib/choose_repository.tcl:41
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Хранилище"
 
-#: git-gui.sh:2677
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Редактиране"
 
-#: git-gui.sh:2679 lib/choose_rev.tcl:567
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Клон"
 
-#: git-gui.sh:2682 lib/choose_rev.tcl:554
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Подаване"
 
-#: git-gui.sh:2685 lib/merge.tcl:127 lib/merge.tcl:174
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Сливане"
 
-#: git-gui.sh:2686 lib/choose_rev.tcl:563
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Отдалечено хранилище"
 
-#: git-gui.sh:2689
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Команди"
 
-#: git-gui.sh:2698
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Разглеждане на работното копие"
 
-#: git-gui.sh:2704
+#: git-gui.sh:2686
 msgid "Git Bash"
 msgstr "Bash за Git"
 
-#: git-gui.sh:2714
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Разглеждане на файловете в текущия клон"
 
-#: git-gui.sh:2718
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Разглеждане на текущия клон…"
 
-#: git-gui.sh:2723
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Визуализация на историята на текущия клон"
 
-#: git-gui.sh:2727
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Визуализация на историята на всички клонове"
 
-#: git-gui.sh:2734
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Разглеждане на файловете в „%s“"
 
-#: git-gui.sh:2736
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Визуализация на историята на „%s“"
 
-#: git-gui.sh:2741 lib/database.tcl:40
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Статистика на базата от данни"
 
-#: git-gui.sh:2744 lib/database.tcl:33
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Компресиране на базата от данни"
 
-#: git-gui.sh:2747
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Проверка на базата от данни"
 
-#: git-gui.sh:2754 git-gui.sh:2758 git-gui.sh:2762
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Добавяне на икона на работния плот"
 
-#: git-gui.sh:2770 lib/choose_repository.tcl:193 lib/choose_repository.tcl:201
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Спиране на програмата"
 
-#: git-gui.sh:2778
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Отмяна"
 
-#: git-gui.sh:2781
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Повторение"
 
-#: git-gui.sh:2785 git-gui.sh:3399
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Отрязване"
 
-#: git-gui.sh:2788 git-gui.sh:3402 git-gui.sh:3476 git-gui.sh:3562
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Копиране"
 
-#: git-gui.sh:2791 git-gui.sh:3405
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Поставяне"
 
-#: git-gui.sh:2794 git-gui.sh:3408 lib/branch_delete.tcl:28
-#: lib/remote_branch_delete.tcl:39
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Изтриване"
 
-#: git-gui.sh:2798 git-gui.sh:3412 git-gui.sh:3566 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Избиране на всичко"
 
-#: git-gui.sh:2807
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Създаване…"
 
-#: git-gui.sh:2813
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Изтегляне…"
 
-#: git-gui.sh:2819
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Преименуване…"
 
-#: git-gui.sh:2824
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Изтриване…"
 
-#: git-gui.sh:2829
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Отмяна на промените…"
 
-#: git-gui.sh:2839
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Готово"
 
-#: git-gui.sh:2841
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Подаване"
 
-#: git-gui.sh:2850 git-gui.sh:3335
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Ново подаване"
 
-#: git-gui.sh:2858 git-gui.sh:3342
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Поправяне на последното подаване"
 
-#: git-gui.sh:2868 git-gui.sh:3296 lib/remote_branch_delete.tcl:101
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Обновяване"
 
-#: git-gui.sh:2874
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Към индекса за подаване"
 
-#: git-gui.sh:2880
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Всички променени файлове към индекса за подаване"
 
-#: git-gui.sh:2886
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Изваждане от индекса за подаване"
 
-#: git-gui.sh:2892 lib/index.tcl:442
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Връщане на оригинала"
 
-#: git-gui.sh:2900 git-gui.sh:3613 git-gui.sh:3644
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "По-малко контекст"
 
-#: git-gui.sh:2904 git-gui.sh:3617 git-gui.sh:3648
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Повече контекст"
 
-#: git-gui.sh:2911 git-gui.sh:3309 git-gui.sh:3423
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Подписване"
 
-#: git-gui.sh:2927
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Локално сливане…"
 
-#: git-gui.sh:2932
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Преустановяване на сливане…"
 
-#: git-gui.sh:2944 git-gui.sh:2972
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Добавяне…"
 
-#: git-gui.sh:2948
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Изтласкване…"
 
-#: git-gui.sh:2952
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Изтриване на клон…"
 
-#: git-gui.sh:2962 git-gui.sh:3595
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Опции…"
 
-#: git-gui.sh:2973
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Премахване…"
 
-#: git-gui.sh:2982 lib/choose_repository.tcl:55
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Помощ"
 
-#: git-gui.sh:2986 git-gui.sh:2990 lib/about.tcl:14
-#: lib/choose_repository.tcl:49 lib/choose_repository.tcl:58
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Относно %s"
 
-#: git-gui.sh:3014
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Документация в Интернет"
 
-#: git-gui.sh:3017 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Показване на ключа за SSH"
 
-#: git-gui.sh:3032 git-gui.sh:3164
+#: git-gui.sh:3014 git-gui.sh:3146
 msgid "usage:"
 msgstr "употреба:"
 
-#: git-gui.sh:3036 git-gui.sh:3168
+#: git-gui.sh:3018 git-gui.sh:3150
 msgid "Usage"
 msgstr "Употреба"
 
-#: git-gui.sh:3117 lib/blame.tcl:573
+#: git-gui.sh:3099 lib/blame.tcl:573
 msgid "Error"
 msgstr "Грешка"
 
-#: git-gui.sh:3148
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "ФАТАЛНА ГРЕШКА: пътят %s не може да бъде открит: такъв файл или директория "
 "няма"
 
-#: git-gui.sh:3181
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Текущ клон:"
 
-#: git-gui.sh:3206
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Промени извън индекса"
 
-#: git-gui.sh:3228
+#: git-gui.sh:3210
 msgid "Staged Changes (Will Commit)"
 msgstr "Промени в индекса (за подаване)"
 
-#: git-gui.sh:3302
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Индексът е променен"
 
-#: git-gui.sh:3321 lib/transport.tcl:137
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Изтласкване"
 
-#: git-gui.sh:3356
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Първоначално съобщение при подаване:"
 
-#: git-gui.sh:3357
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Поправено съобщение при подаване:"
 
-#: git-gui.sh:3358
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Поправено първоначално съобщение при подаване:"
 
-#: git-gui.sh:3359
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Поправено съобщение при подаване със сливане:"
 
-#: git-gui.sh:3360
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Съобщение при подаване със сливане:"
 
-#: git-gui.sh:3361
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Съобщение при подаване:"
 
-#: git-gui.sh:3415 git-gui.sh:3570 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Копиране на всичко"
 
-#: git-gui.sh:3439 lib/blame.tcl:105
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Файл:"
 
-#: git-gui.sh:3558
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Обновяване"
 
-#: git-gui.sh:3579
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "По-едър шрифт"
 
-#: git-gui.sh:3583
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "По-дребен шрифт"
 
-#: git-gui.sh:3591 lib/blame.tcl:294
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Кодиране"
 
-#: git-gui.sh:3602
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Прилагане/връщане на парче"
 
-#: git-gui.sh:3607
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Прилагане/връщане на ред"
 
-#: git-gui.sh:3626
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Изпълнение на програмата за сливане"
 
-#: git-gui.sh:3631
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Версия от отдалеченото хранилище"
 
-#: git-gui.sh:3635
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Локална версия"
 
-#: git-gui.sh:3639
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Връщане към родителската версия"
 
-#: git-gui.sh:3657
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Визуализиране на промените в подмодула"
 
-#: git-gui.sh:3661
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Визуализация на историята на текущия клон в историята за подмодула"
 
-#: git-gui.sh:3665
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Визуализация на историята на всички клони в историята за подмодула"
 
-#: git-gui.sh:3670
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Стартиране на „git gui“ за подмодула"
 
-#: git-gui.sh:3705
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Изваждане на парчето от подаването"
 
-#: git-gui.sh:3707
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Изваждане на редовете от подаването"
 
-#: git-gui.sh:3709
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Изваждане на реда от подаването"
 
-#: git-gui.sh:3712
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Добавяне на парчето за подаване"
 
-#: git-gui.sh:3714
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Добавяне на редовете за подаване"
 
-#: git-gui.sh:3716
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Добавяне на реда за подаване"
 
-#: git-gui.sh:3741
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Инициализиране…"
 
-#: git-gui.sh:3886
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Възможно е да има проблем със средата.\n"
 "\n"
@@ -579,25 +579,26 @@ msgstr ""
 "от %s:\n"
 "\n"
 
-#: git-gui.sh:3915
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Това е познат проблем и се дължи на\n"
 "версията на Tcl включена в Cygwin."
 
-#: git-gui.sh:3920
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -605,341 +606,30 @@ msgstr ""
 "е да поставите настройките „user.name“ и\n"
 "„user.email“ в личния си файл „~/.gitconfig“.\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui — графичен интерфейс за Git."
-
-#: lib/blame.tcl:73
-#, tcl-format
-msgid "%s (%s): File Viewer"
-msgstr "%s (%s): Преглед на файлове"
-
-#: lib/blame.tcl:79
-msgid "Commit:"
-msgstr "Подаване:"
-
-#: lib/blame.tcl:280
-msgid "Copy Commit"
-msgstr "Копиране на подаване"
-
-#: lib/blame.tcl:284
-msgid "Find Text..."
-msgstr "Търсене на текст…"
-
-#: lib/blame.tcl:288
-msgid "Goto Line..."
-msgstr "Към ред…"
-
-#: lib/blame.tcl:297
-msgid "Do Full Copy Detection"
-msgstr "Пълно търсене на копиране"
-
-#: lib/blame.tcl:301
-msgid "Show History Context"
-msgstr "Показване на контекста от историята"
-
-#: lib/blame.tcl:304
-msgid "Blame Parent Commit"
-msgstr "Анотиране на родителското подаване"
-
-#: lib/blame.tcl:466
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Чете се „%s“…"
-
-#: lib/blame.tcl:594
-msgid "Loading copy/move tracking annotations..."
-msgstr "Зареждане на анотациите за проследяване на копирането/преместването…"
-
-#: lib/blame.tcl:614
-msgid "lines annotated"
-msgstr "реда анотирани"
-
-#: lib/blame.tcl:806
-msgid "Loading original location annotations..."
-msgstr "Зареждане на анотациите за първоначалното местоположение…"
-
-#: lib/blame.tcl:809
-msgid "Annotation complete."
-msgstr "Анотирането завърши."
-
-#: lib/blame.tcl:839
-msgid "Busy"
-msgstr "Операцията не е завършила"
-
-#: lib/blame.tcl:840
-msgid "Annotation process is already running."
-msgstr "В момента тече процес на анотиране."
-
-#: lib/blame.tcl:879
-msgid "Running thorough copy detection..."
-msgstr "Изпълнява се цялостен процес на откриване на копиране…"
-
-#: lib/blame.tcl:947
-msgid "Loading annotation..."
-msgstr "Зареждане на анотации…"
-
-#: lib/blame.tcl:1000
-msgid "Author:"
-msgstr "Автор:"
-
-#: lib/blame.tcl:1004
-msgid "Committer:"
-msgstr "Подал:"
-
-#: lib/blame.tcl:1009
-msgid "Original File:"
-msgstr "Първоначален файл:"
-
-#: lib/blame.tcl:1057
-msgid "Cannot find HEAD commit:"
-msgstr "Подаването за връх „HEAD“ не може да се открие:"
-
-#: lib/blame.tcl:1112
-msgid "Cannot find parent commit:"
-msgstr "Родителското подаване не може да бъде открито"
-
-#: lib/blame.tcl:1127
-msgid "Unable to display parent"
-msgstr "Родителят не може да бъде показан"
-
-#: lib/blame.tcl:1128 lib/diff.tcl:358
-msgid "Error loading diff:"
-msgstr "Грешка при зареждане на разлика:"
-
-#: lib/blame.tcl:1269
-msgid "Originally By:"
-msgstr "Първоначално от:"
-
-#: lib/blame.tcl:1275
-msgid "In File:"
-msgstr "Във файл:"
-
-#: lib/blame.tcl:1280
-msgid "Copied Or Moved Here By:"
-msgstr "Копирано или преместено тук от:"
-
-#: lib/branch_checkout.tcl:16
-#, tcl-format
-msgid "%s (%s): Checkout Branch"
-msgstr "%s (%s): Клон за изтегляне"
-
-#: lib/branch_checkout.tcl:21
-msgid "Checkout Branch"
-msgstr "Клон за изтегляне"
-
-#: lib/branch_checkout.tcl:26
-msgid "Checkout"
-msgstr "Изтегляне"
-
-#: lib/branch_checkout.tcl:30 lib/branch_create.tcl:37 lib/branch_delete.tcl:34
-#: lib/branch_rename.tcl:32 lib/browser.tcl:292 lib/checkout_op.tcl:579
-#: lib/choose_font.tcl:45 lib/merge.tcl:178 lib/option.tcl:127
-#: lib/remote_add.tcl:34 lib/remote_branch_delete.tcl:43 lib/tools_dlg.tcl:41
-#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/transport.tcl:141
-msgid "Cancel"
-msgstr "Отказване"
-
-#: lib/branch_checkout.tcl:35 lib/browser.tcl:297 lib/tools_dlg.tcl:321
-msgid "Revision"
-msgstr "Версия"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:69 lib/option.tcl:310
-msgid "Options"
-msgstr "Опции"
-
-#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Изтегляне на промените от следения клон"
-
-#: lib/branch_checkout.tcl:47
-msgid "Detach From Local Branch"
-msgstr "Изтриване от локалния клон"
-
-#: lib/branch_create.tcl:23
-#, tcl-format
-msgid "%s (%s): Create Branch"
-msgstr "%s (%s): Създаване на клон"
-
-#: lib/branch_create.tcl:28
-msgid "Create New Branch"
-msgstr "Създаване на нов клон"
-
-#: lib/branch_create.tcl:33 lib/choose_repository.tcl:407
-msgid "Create"
-msgstr "Създаване"
-
-#: lib/branch_create.tcl:42
-msgid "Branch Name"
-msgstr "Име на клона"
-
-#: lib/branch_create.tcl:44 lib/remote_add.tcl:41 lib/tools_dlg.tcl:51
-msgid "Name:"
-msgstr "Име:"
-
-#: lib/branch_create.tcl:57
-msgid "Match Tracking Branch Name"
-msgstr "Съвпадане по името на следения клон"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Начална версия"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Обновяване на съществуващ клон:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Не"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Само тривиално превъртащо сливане"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr "Отначало"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Преминаване към клона след създаването му"
-
-#: lib/branch_create.tcl:132
-msgid "Please select a tracking branch."
-msgstr "Изберете клон за следени."
-
-#: lib/branch_create.tcl:141
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "Следящият клон — „%s“, не съществува в отдалеченото хранилище."
-
-#: lib/branch_create.tcl:154 lib/branch_rename.tcl:92
-msgid "Please supply a branch name."
-msgstr "Дайте име на клона."
-
-#: lib/branch_create.tcl:165 lib/branch_rename.tcl:112
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "„%s“ не може да се използва за име на клон."
-
-#: lib/branch_delete.tcl:16
-#, tcl-format
-msgid "%s (%s): Delete Branch"
-msgstr "%s (%s): Изтриване на клон"
-
-#: lib/branch_delete.tcl:21
-msgid "Delete Local Branch"
-msgstr "Изтриване на локален клон"
-
-#: lib/branch_delete.tcl:39
-msgid "Local Branches"
-msgstr "Локални клони"
-
-#: lib/branch_delete.tcl:51
-msgid "Delete Only If Merged Into"
-msgstr "Изтриване, само ако промените са слети и другаде"
-
-#: lib/branch_delete.tcl:53 lib/remote_branch_delete.tcl:120
-msgid "Always (Do not perform merge checks)"
-msgstr "Винаги (без проверка за сливане)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Не всички промени в клоните са слети в „%s“:"
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:218
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr ""
-"Възстановяването на изтрити клони може да е трудно.\n"
-"\n"
-"Сигурни ли сте, че искате да триете?"
-
-#: lib/branch_delete.tcl:131
-#, tcl-format
-msgid " - %s:"
-msgstr " — „%s:“"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-"Неуспешно триене на клони:\n"
-"%s"
-
-#: lib/branch_rename.tcl:15
-#, tcl-format
-msgid "%s (%s): Rename Branch"
-msgstr "%s (%s): Преименуване на клон"
-
-#: lib/branch_rename.tcl:23
-msgid "Rename Branch"
-msgstr "Преименуване на клон"
-
-#: lib/branch_rename.tcl:28
-msgid "Rename"
-msgstr "Преименуване"
-
-#: lib/branch_rename.tcl:38
-msgid "Branch:"
-msgstr "Клон:"
-
-#: lib/branch_rename.tcl:46
-msgid "New Name:"
-msgstr "Ново име:"
-
-#: lib/branch_rename.tcl:81
-msgid "Please select a branch to rename."
-msgstr "Изберете клон за преименуване."
-
-#: lib/branch_rename.tcl:102 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "Клонът „%s“ вече съществува."
-
-#: lib/branch_rename.tcl:123
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Неуспешно преименуване на „%s“."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Стартиране…"
-
-#: lib/browser.tcl:27
-#, tcl-format
-msgid "%s (%s): File Browser"
-msgstr "%s (%s): Файлов браузър"
-
-#: lib/browser.tcl:132 lib/browser.tcl:149
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Зареждане на „%s“…"
-
-#: lib/browser.tcl:193
-msgid "[Up To Parent]"
-msgstr "[Към родителя]"
-
-#: lib/browser.tcl:275
-#, tcl-format
-msgid "%s (%s): Browse Branch Files"
-msgstr "%s (%s): Разглеждане на файловете в клона"
-
-#: lib/browser.tcl:282
-msgid "Browse Branch Files"
-msgstr "Разглеждане на файловете в клона"
-
-#: lib/browser.tcl:288 lib/choose_repository.tcl:422
-#: lib/choose_repository.tcl:509 lib/choose_repository.tcl:518
-#: lib/choose_repository.tcl:1074
-msgid "Browse"
-msgstr "Разглеждане"
+#: lib/line.tcl:17
+msgid "Goto Line:"
+msgstr "Към ред:"
+
+#: lib/line.tcl:23
+msgid "Go"
+msgstr "Придвижване"
+
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "В момента се извършва действие, изчакайте…"
+
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Затваряне"
+
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Успех"
+
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Грешка: неуспешно изпълнение на команда"
 
 #: lib/checkout_op.tcl:85
 #, tcl-format
@@ -951,11 +641,6 @@ msgstr "Доставяне на „%s“ от „%s“"
 msgid "fatal: Cannot resolve %s"
 msgstr "фатална грешка: „%s“ не може да се открие"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:30
-#: lib/sshkey.tcl:55
-msgid "Close"
-msgstr "Затваряне"
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -965,6 +650,11 @@ msgstr "Клонът „%s“ не съществува."
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Неуспешно настройване на опростен git-pull за „%s“."
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "Клонът „%s“ вече съществува."
 
 #: lib/checkout_op.tcl:229
 #, tcl-format
@@ -994,13 +684,14 @@ msgid "Staging area (index) is already locked."
 msgstr "Индексът вече е заключен."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Състоянието при последната проверка не отговаря на състоянието на "
 "хранилището.\n"
@@ -1035,9 +726,10 @@ msgid "Staying on branch '%s'."
 msgstr "Оставане върху клона „%s“."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -1069,14 +761,27 @@ msgstr "Зануляване на „%s“?"
 msgid "Visualize"
 msgstr "Визуализация"
 
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Отначало"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Отказване"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Неуспешно задаване на текущия клон.\n"
@@ -1087,599 +792,482 @@ msgstr ""
 "Това състояние е аварийно и не трябва да се случва. Програмата „%s“ ще "
 "преустанови работа."
 
-#: lib/choose_font.tcl:41
-msgid "Select"
-msgstr "Избор"
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "доставяне на „%s“"
 
-#: lib/choose_font.tcl:55
-msgid "Font Family"
-msgstr "Шрифт"
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "Доставяне на промените от „%s“"
 
-#: lib/choose_font.tcl:76
-msgid "Font Size"
-msgstr "Размер"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "окастряне на следящите клони към „%s“"
 
-#: lib/choose_font.tcl:93
-msgid "Font Example"
-msgstr "Мостра"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Окастряне на следящите клони на изтритите клони от „%s“"
 
-#: lib/choose_font.tcl:105
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
+msgstr "доставяне от всички отдалечени"
+
+#: lib/transport.tcl:26
+msgid "Fetching new changes from all remotes"
+msgstr "Доставяне на промените от всички отдалечени хранилища"
+
+#: lib/transport.tcl:40
+msgid "remote prune all remotes"
+msgstr "окастряне на следящите изтрити"
+
+#: lib/transport.tcl:41
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr ""
+"Окастряне на следящите клони на изтритите клони от всички отдалечени "
+"хранилища"
+
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
+#, tcl-format
+msgid "push %s"
+msgstr "изтласкване на „%s“"
+
+#: lib/transport.tcl:55
+#, tcl-format
+msgid "Pushing changes to %s"
+msgstr "Изтласкване на промените към „%s“"
+
+#: lib/transport.tcl:93
+#, tcl-format
+msgid "Mirroring to %s"
+msgstr "Изтласкване на всичко към „%s“"
+
+#: lib/transport.tcl:111
+#, tcl-format
+msgid "Pushing %s %s to %s"
+msgstr "Изтласкване на %s „%s“ към „%s“"
+
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Клони за изтласкване"
+
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Клони-източници"
+
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Целево хранилище"
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Отдалечено хранилище:"
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Произволно местоположение:"
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Настройки при пренасянето"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr ""
+"Изрично презаписване на съществуващ клон (някои промени може да бъдат "
+"загубени)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Максимална компресия (за бавни мрежови връзки)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Включване на етикетите"
+
+#: lib/transport.tcl:229
+#, tcl-format
+msgid "%s (%s): Push"
+msgstr "%s (%s): Изтласкване"
+
+#: lib/remote_add.tcl:20
+#, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "%s (%s): Добавяне на отдалечено хранилище"
+
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Добавяне на отдалечено хранилище"
+
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Добавяне"
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Данни за отдалеченото хранилище"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Име:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Местоположение:"
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Следващо действие"
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Незабавно доставяне"
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Инициализиране на отдалеченото хранилище и изтласкване на промените"
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr "Да не се прави нищо"
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Задайте име за отдалеченото хранилище."
+
+#: lib/remote_add.tcl:113
+#, tcl-format
+msgid "'%s' is not an acceptable remote name."
+msgstr "Отдалечено хранилище не може да се казва „%s“."
+
+#: lib/remote_add.tcl:124
+#, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Неуспешно добавяне на отдалеченото хранилище „%s“ от адрес „%s“."
+
+#: lib/remote_add.tcl:133
+#, tcl-format
+msgid "Fetching the %s"
+msgstr "Доставяне на „%s“"
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "Хранилището с местоположение „%s“ не може да бъде инициализирано."
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr "Добавяне на хранилище „%s“ (с адрес „%s“)"
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Стартиране…"
+
+#: lib/browser.tcl:27
+#, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "%s (%s): Файлов браузър"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr "Зареждане на „%s“…"
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Към родителя]"
+
+#: lib/browser.tcl:275
+#, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "%s (%s): Разглеждане на файловете в клона"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Разглеждане на файловете в клона"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Разглеждане"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Версия"
+
+#: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
-"Това е примерен текст.\n"
-"Ако ви харесва как изглежда, изберете шрифта."
-
-#: lib/choose_repository.tcl:33
-msgid "Git Gui"
-msgstr "ГПИ на Git"
-
-#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:412
-msgid "Create New Repository"
-msgstr "Създаване на ново хранилище"
-
-#: lib/choose_repository.tcl:98
-msgid "New..."
-msgstr "Ново…"
-
-#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:496
-msgid "Clone Existing Repository"
-msgstr "Клониране на съществуващо хранилище"
-
-#: lib/choose_repository.tcl:116
-msgid "Clone..."
-msgstr "Клониране…"
-
-#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1064
-msgid "Open Existing Repository"
-msgstr "Отваряне на съществуващо хранилище"
-
-#: lib/choose_repository.tcl:129
-msgid "Open..."
-msgstr "Отваряне…"
-
-#: lib/choose_repository.tcl:142
-msgid "Recent Repositories"
-msgstr "Скоро ползвани"
-
-#: lib/choose_repository.tcl:148
-msgid "Open Recent Repository:"
-msgstr "Отваряне на хранилище ползвано наскоро:"
-
-#: lib/choose_repository.tcl:316 lib/choose_repository.tcl:323
-#: lib/choose_repository.tcl:330
-#, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Неуспешно създаване на хранилището „%s“:"
-
-#: lib/choose_repository.tcl:417
-msgid "Directory:"
-msgstr "Директория:"
-
-#: lib/choose_repository.tcl:447 lib/choose_repository.tcl:573
-#: lib/choose_repository.tcl:1098
-msgid "Git Repository"
-msgstr "Хранилище на Git"
-
-#: lib/choose_repository.tcl:472
-#, tcl-format
-msgid "Directory %s already exists."
-msgstr "Вече съществува директория „%s“."
-
-#: lib/choose_repository.tcl:476
-#, tcl-format
-msgid "File %s already exists."
-msgstr "Вече съществува файл „%s“."
-
-#: lib/choose_repository.tcl:491
-msgid "Clone"
-msgstr "Клониране"
-
-#: lib/choose_repository.tcl:504
-msgid "Source Location:"
-msgstr "Адрес на източника:"
-
-#: lib/choose_repository.tcl:513
-msgid "Target Directory:"
-msgstr "Целева директория:"
-
-#: lib/choose_repository.tcl:523
-msgid "Clone Type:"
-msgstr "Вид клониране:"
-
-#: lib/choose_repository.tcl:528
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Стандартно (бързо, частично споделяне на файлове, твърди връзки)"
-
-#: lib/choose_repository.tcl:533
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Пълно (бавно, пълноценно резервно копие)"
-
-#: lib/choose_repository.tcl:538
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Споделено (най-бързо, не се препоръчва, не прави резервно копие)"
-
-#: lib/choose_repository.tcl:545
-msgid "Recursively clone submodules too"
-msgstr "Рекурсивно клониране и на подмодулите"
-
-#: lib/choose_repository.tcl:579 lib/choose_repository.tcl:626
-#: lib/choose_repository.tcl:772 lib/choose_repository.tcl:842
-#: lib/choose_repository.tcl:1104 lib/choose_repository.tcl:1112
-#, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Това не е хранилище на Git: %s"
-
-#: lib/choose_repository.tcl:615
-msgid "Standard only available for local repository."
-msgstr "Само локални хранилища могат да се клонират стандартно"
-
-#: lib/choose_repository.tcl:619
-msgid "Shared only available for local repository."
-msgstr "Само локални хранилища могат да се клонират споделено"
-
-#: lib/choose_repository.tcl:640
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "Местоположението „%s“ вече съществува."
-
-#: lib/choose_repository.tcl:651
-msgid "Failed to configure origin"
-msgstr "Неуспешно настройване на хранилището-източник"
-
-#: lib/choose_repository.tcl:663
-msgid "Counting objects"
-msgstr "Преброяване на обекти"
-
-#: lib/choose_repository.tcl:664
-msgid "buckets"
-msgstr "клетки"
-
-#: lib/choose_repository.tcl:688
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Обектите/информацията/синонимите не могат да бъдат копирани: %s"
-
-#: lib/choose_repository.tcl:724
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Няма какво да се клонира от „%s“."
-
-#: lib/choose_repository.tcl:726 lib/choose_repository.tcl:940
-#: lib/choose_repository.tcl:952
-msgid "The 'master' branch has not been initialized."
-msgstr "Основният клон — „master“ не е инициализиран."
-
-#: lib/choose_repository.tcl:739
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Не се поддържат твърди връзки. Преминава се към копиране."
-
-#: lib/choose_repository.tcl:751
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Клониране на „%s“"
-
-#: lib/choose_repository.tcl:782
-msgid "Copying objects"
-msgstr "Копиране на обекти"
-
-#: lib/choose_repository.tcl:783
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:807
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Неуспешно копиране на обект: %s"
-
-#: lib/choose_repository.tcl:817
-msgid "Linking objects"
-msgstr "Създаване на връзки към обектите"
-
-#: lib/choose_repository.tcl:818
-msgid "objects"
-msgstr "обекти"
-
-#: lib/choose_repository.tcl:826
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Неуспешно създаване на твърда връзка към обект: %s"
-
-#: lib/choose_repository.tcl:881
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr ""
-"Клоните и обектите не могат да бъдат изтеглени. За повече информация "
-"погледнете изхода на конзолата."
-
-#: lib/choose_repository.tcl:892
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-"Етикетите не могат да бъдат изтеглени. За повече информация погледнете "
-"изхода на конзолата."
-
-#: lib/choose_repository.tcl:916
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-"Върхът „HEAD“ не може да бъде определен. За повече информация погледнете "
-"изхода на конзолата."
-
-#: lib/choose_repository.tcl:925
-#, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "„%s“ не може да се зачисти"
-
-#: lib/choose_repository.tcl:931
-msgid "Clone failed."
-msgstr "Неуспешно клониране."
-
-#: lib/choose_repository.tcl:938
-msgid "No default branch obtained."
-msgstr "Не е получен клон по подразбиране."
-
-#: lib/choose_repository.tcl:949
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Няма подаване отговарящо на „%s“."
-
-#: lib/choose_repository.tcl:961
-msgid "Creating working directory"
-msgstr "Създаване на работната директория"
-
-#: lib/choose_repository.tcl:962 lib/index.tcl:70 lib/index.tcl:136
-#: lib/index.tcl:207
-msgid "files"
-msgstr "файлове"
-
-#: lib/choose_repository.tcl:981
-msgid "Cannot clone submodules."
-msgstr "Подмодулите не могат да се клонират."
-
-#: lib/choose_repository.tcl:990
-msgid "Cloning submodules"
-msgstr "Клониране на подмодули"
-
-#: lib/choose_repository.tcl:1015
-msgid "Initial file checkout failed."
-msgstr "Неуспешно първоначално изтегляне."
-
-#: lib/choose_repository.tcl:1059
-msgid "Open"
-msgstr "Отваряне"
-
-#: lib/choose_repository.tcl:1069
-msgid "Repository:"
-msgstr "Хранилище:"
-
-#: lib/choose_repository.tcl:1118
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Неуспешно отваряне на хранилището „%s“:"
-
-#: lib/choose_rev.tcl:52
-msgid "This Detached Checkout"
-msgstr "Това несвързано изтегляне"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Израз за версия:"
-
-#: lib/choose_rev.tcl:72
-msgid "Local Branch"
-msgstr "Локален клон"
-
-#: lib/choose_rev.tcl:77
-msgid "Tracking Branch"
-msgstr "Следящ клон"
-
-#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
-msgid "Tag"
-msgstr "Етикет"
-
-#: lib/choose_rev.tcl:321
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Неправилна версия: %s"
-
-#: lib/choose_rev.tcl:342
-msgid "No revision selected."
-msgstr "Не е избрана версия."
-
-#: lib/choose_rev.tcl:350
-msgid "Revision expression is empty."
-msgstr "Изразът за версия е празен."
-
-#: lib/choose_rev.tcl:537
-msgid "Updated"
-msgstr "Обновен"
-
-#: lib/choose_rev.tcl:565
-msgid "URL"
-msgstr "Адрес"
-
-#: lib/commit.tcl:9
+"По време на поправяне не може да сливане.\n"
+"\n"
+"Трябва да завършите поправянето на текущото подаване, преди да започнете "
+"сливане.\n"
+
+#: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"Няма какво да се поправи.\n"
-"\n"
-"Ще създадете първоначалното подаване. Преди него няма други подавания, които "
-"да поправите.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"По време на сливане не може да поправяте.\n"
-"\n"
-"В момента все още не сте завършили операция по сливане. Не може да поправите "
-"предишното подаване, освен ако първо не преустановите текущото сливане.\n"
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Грешка при зареждане на данните от подаване, които да се поправят:"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Идентификацията ви не може да бъде определена:"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Неправилно поле „GIT_COMMITTER_IDENT“:"
-
-#: lib/commit.tcl:129
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "предупреждение: Tcl не поддържа кодирането „%s“."
-
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
-"Състоянието при последната проверка не отговаря на състоянието на "
-"хранилището.\n"
+"Последно установеното състояние не отговаря на това в хранилището.\n"
 "\n"
 "Някой друг процес за Git е променил хранилището междувременно. Състоянието "
-"трябва да бъде проверено преди ново подаване.\n"
+"трябва да бъде проверено, преди да се извърши сливане.\n"
 "\n"
 "Автоматично ще започне нова проверка.\n"
+"\n"
 
-#: lib/commit.tcl:173
-#, tcl-format
+#: lib/merge.tcl:45
+#, fuzzy, tcl-format
 msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
+"You must resolve them, stage the file, and commit to complete the current "
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
-"Неслетите файлове не могат да бъдат подавани.\n"
+"В момента тече сливане, но има конфликти.\n"
 "\n"
-"Във файла „%s“ има конфликти при сливане. За да го подадете, трябва първо да "
-"коригирате конфликтите и да добавите файла към индекса за подаване.\n"
-
-#: lib/commit.tcl:181
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
+"Погледнете файла „%s“.\n"
 "\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Непознато състояние на файл „%s“.\n"
-"\n"
-"Файлът „%s“ не може да бъде подаден чрез текущата програма.\n"
-
-#: lib/commit.tcl:189
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Няма промени за подаване.\n"
-"\n"
-"Трябва да добавите поне един файл към индекса, за да подадете.\n"
-
-#: lib/commit.tcl:204
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Задайте добро съобщение при подаване.\n"
-"\n"
-"Използвайте следния формат:\n"
-"\n"
-"● Първи ред: описание в едно изречение на промяната.\n"
-"● Втори ред: празен.\n"
-"● Останалите редове: опишете защо се налага тази промяна.\n"
-
-#: lib/commit.tcl:235
-msgid "Calling pre-commit hook..."
-msgstr "Изпълняване на куката преди подаване…"
-
-#: lib/commit.tcl:250
-msgid "Commit declined by pre-commit hook."
-msgstr "Подаването е отхвърлено от куката преди подаване."
-
-#: lib/commit.tcl:269
-msgid ""
-"You are about to commit on a detached head. This is a potentially dangerous "
-"thing to do because if you switch to another branch you will lose your "
-"changes and it can be difficult to retrieve them later from the reflog. You "
-"should probably cancel this commit and create a new branch to continue.\n"
-" \n"
-" Do you really want to proceed with your Commit?"
-msgstr ""
-"Ще подадете към несвързан, отделѐн указател „HEAD“. Това е опасно, защото "
-"при преминаването към клон ще загубите промените си, като единственият начин "
-"да ги върнете ще е чрез журнала на указателите (reflog). Най-вероятно трябва "
-"да не правите това подаване, а да създадете нов клон, преди да продължите.\n"
-" \n"
-"Сигурни ли сте, че искате да извършите текущото подаване?"
-
-#: lib/commit.tcl:290
-msgid "Calling commit-msg hook..."
-msgstr "Изпълняване на куката за съобщението при подаване…"
-
-#: lib/commit.tcl:305
-msgid "Commit declined by commit-msg hook."
-msgstr "Подаването е отхвърлено от куката за съобщението при подаване."
-
-#: lib/commit.tcl:318
-msgid "Committing changes..."
-msgstr "Подаване на промените…"
-
-#: lib/commit.tcl:334
-msgid "write-tree failed:"
-msgstr "неуспешно запазване на дървото (write-tree):"
-
-#: lib/commit.tcl:335 lib/commit.tcl:382 lib/commit.tcl:403
-msgid "Commit failed."
-msgstr "Неуспешно подаване."
-
-#: lib/commit.tcl:352
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Подаването „%s“ изглежда повредено"
-
-#: lib/commit.tcl:357
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Няма промени за подаване.\n"
-"\n"
-"В това подаване не са променяни никакви файлове, а и не е подаване със "
+"Трябва да коригирате конфликтите в него, да го добавите към индекса и да "
+"завършите текущото сливане чрез подаване. Чак тогава може да започнете ново "
 "сливане.\n"
-"\n"
-"Автоматично ще започне нова проверка.\n"
 
-#: lib/commit.tcl:364
-msgid "No changes to commit."
-msgstr "Няма промени за подаване."
-
-#: lib/commit.tcl:381
-msgid "commit-tree failed:"
-msgstr "неуспешно подаване на дървото (commit-tree):"
-
-#: lib/commit.tcl:402
-msgid "update-ref failed:"
-msgstr "неуспешно обновяване на указателите (update-ref):"
-
-#: lib/commit.tcl:495
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Успешно подаване %s: %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "В момента се извършва действие, изчакайте…"
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Успех"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Грешка: неуспешно изпълнение на команда"
-
-#: lib/database.tcl:42
-msgid "Number of loose objects"
-msgstr "Брой непакетирани обекти"
-
-#: lib/database.tcl:43
-msgid "Disk space used by loose objects"
-msgstr "Дисково пространство заето от непакетирани обекти"
-
-#: lib/database.tcl:44
-msgid "Number of packed objects"
-msgstr "Брой пакетирани обекти"
-
-#: lib/database.tcl:45
-msgid "Number of packs"
-msgstr "Брой пакети"
-
-#: lib/database.tcl:46
-msgid "Disk space used by packed objects"
-msgstr "Дисково пространство заето от пакетирани обекти"
-
-#: lib/database.tcl:47
-msgid "Packed objects waiting for pruning"
-msgstr "Пакетирани обекти за окастряне"
-
-#: lib/database.tcl:48
-msgid "Garbage files"
-msgstr "Файлове за боклука"
-
-#: lib/database.tcl:57 lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220
-#: lib/option.tcl:282
-#, tcl-format
-msgid "%s:"
-msgstr "%s:"
-
-#: lib/database.tcl:66
-#, tcl-format
-msgid "%s (%s): Database Statistics"
-msgstr "%s (%s): Статистика на базата от данни"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Компресиране на базата с данни за обектите"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Проверка на базата с данни за обектите с програмата „fsck-objects“"
-
-#: lib/database.tcl:107
-#, tcl-format
+#: lib/merge.tcl:55
+#, fuzzy, tcl-format
 msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
+"You should complete the current commit before starting a merge.  Doing so "
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
-"В това хранилище в момента има към %i непакетирани обекти.\n"
+"В момента тече подаване.\n"
 "\n"
-"За добра производителност се препоръчва да компресирате базата с данни за "
-"обектите.\n"
+"Файлът „%s“ е променен.\n"
 "\n"
-"Да се започне ли компресирането?"
+"Трябва да завършите текущото подаване, преди да започнете сливане. Така ще "
+"можете лесно да преустановите сливането, ако възникне нужда.\n"
 
-#: lib/date.tcl:25
+#: lib/merge.tcl:108
 #, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Неправилни данни от Git: %s"
+msgid "%s of %s"
+msgstr "%s от общо %s"
+
+#: lib/merge.tcl:126
+#, tcl-format
+msgid "Merging %s and %s..."
+msgstr "Сливане на „%s“ и „%s“…"
+
+#: lib/merge.tcl:137
+msgid "Merge completed successfully."
+msgstr "Сливането завърши успешно."
+
+#: lib/merge.tcl:139
+msgid "Merge failed.  Conflict resolution is required."
+msgstr "Неуспешно сливане — има конфликти за коригиране."
+
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr "%s (%s): Сливане"
+
+#: lib/merge.tcl:164
+#, tcl-format
+msgid "Merge Into %s"
+msgstr "Сливане в „%s“"
+
+#: lib/merge.tcl:183
+msgid "Revision To Merge"
+msgstr "Версия за сливане"
+
+#: lib/merge.tcl:218
+#, fuzzy
+msgid ""
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
+msgstr ""
+"Поправянето не може да бъде преустановено.\n"
+"\n"
+"Трябва да завършите поправката на това подаване.\n"
+
+#: lib/merge.tcl:228
+#, fuzzy
+msgid ""
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
+"Continue with aborting the current merge?"
+msgstr ""
+"Да се преустанови ли сливането?\n"
+"\n"
+"В такъв случай ●ВСИЧКИ● неподадени промени ще бъдат безвъзвратно загубени.\n"
+"\n"
+"Наистина ли да се преустанови сливането?"
+
+#: lib/merge.tcl:234
+#, fuzzy
+msgid ""
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
+"Continue with resetting the current changes?"
+msgstr ""
+"Да се занулят ли промените?\n"
+"\n"
+"В такъв случай ●ВСИЧКИ● неподадени промени ще бъдат безвъзвратно загубени.\n"
+"\n"
+"Наистина ли да се занулят промените?"
+
+#: lib/merge.tcl:245
+msgid "Aborting"
+msgstr "Преустановяване"
+
+#: lib/merge.tcl:245
+msgid "files reset"
+msgstr "файла със занулени промени"
+
+#: lib/merge.tcl:273
+msgid "Abort failed."
+msgstr "Неуспешно преустановяване."
+
+#: lib/merge.tcl:275
+msgid "Abort completed.  Ready."
+msgstr "Успешно преустановяване. Готовност за следващо действие."
+
+#: lib/tools.tcl:76
+#, tcl-format
+msgid "Running %s requires a selected file."
+msgstr "За изпълнението на „%s“ трябва да изберете файл."
+
+#: lib/tools.tcl:92
+#, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Сигурни ли сте, че искате да изпълните „%1$s“ върху файла „%2$s“?"
+
+#: lib/tools.tcl:96
+#, tcl-format
+msgid "Are you sure you want to run %s?"
+msgstr "Сигурни ли сте, че искате да изпълните „%s“?"
+
+#: lib/tools.tcl:118
+#, tcl-format
+msgid "Tool: %s"
+msgstr "Команда: %s"
+
+#: lib/tools.tcl:119
+#, tcl-format
+msgid "Running: %s"
+msgstr "Изпълнение: %s"
+
+#: lib/tools.tcl:158
+#, tcl-format
+msgid "Tool completed successfully: %s"
+msgstr "Командата завърши успешно: %s"
+
+#: lib/tools.tcl:160
+#, tcl-format
+msgid "Tool failed: %s"
+msgstr "Командата върна грешка: %s"
+
+#: lib/branch_checkout.tcl:16
+#, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "%s (%s): Клон за изтегляне"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Клон за изтегляне"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Изтегляне"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Опции"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Изтегляне на промените от следения клон"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Изтриване от локалния клон"
+
+#: lib/spellcheck.tcl:57
+msgid "Unsupported spell checker"
+msgstr "Тази програма за проверка на правописа не се поддържа"
+
+#: lib/spellcheck.tcl:65
+msgid "Spell checking is unavailable"
+msgstr "Липсва програма за проверка на правописа"
+
+#: lib/spellcheck.tcl:68
+msgid "Invalid spell checking configuration"
+msgstr "Неправилни настройки на проверката на правописа"
+
+#: lib/spellcheck.tcl:70
+#, tcl-format
+msgid "Reverting dictionary to %s."
+msgstr "Ползване на речник за език „%s“."
+
+#: lib/spellcheck.tcl:73
+msgid "Spell checker silently failed on startup"
+msgstr "Програмата за правопис даже не стартира успешно."
+
+#: lib/spellcheck.tcl:80
+msgid "Unrecognized spell checker"
+msgstr "Непозната програма за проверка на правописа"
+
+#: lib/spellcheck.tcl:186
+msgid "No Suggestions"
+msgstr "Няма предложения"
+
+#: lib/spellcheck.tcl:388
+msgid "Unexpected EOF from spell checker"
+msgstr "Неочакван край на файл от програмата за проверка на правописа"
+
+#: lib/spellcheck.tcl:392
+msgid "Spell Checker Failed"
+msgstr "Грешка в програмата за проверка на правописа"
+
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s… %*i от общо %*i %s (%3i%%)"
 
 #: lib/diff.tcl:77
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
 "The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
+"the content within the file was not changed.\r\n"
+"\r\n"
 "A rescan will be automatically started to find other files which may have "
 "the same state."
 msgstr ""
@@ -1739,25 +1327,24 @@ msgstr "Хранилище на Git (подмодул)"
 msgid "* Binary file (not showing content)."
 msgstr "● Двоичен файл (съдържанието не се показва)."
 
-#: lib/diff.tcl:244
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
+#: lib/diff.tcl:243
+msgid "\r"
 msgstr ""
-"● Неследеният файл е %d байта.\n"
-"● Показват се само първите %d байта.\n"
 
 #: lib/diff.tcl:250
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
 msgstr ""
 "\n"
 "● Неследеният файл е отрязан дотук от програмата „%s“.\n"
 "● Използвайте външен редактор, за да видите целия файл.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Грешка при зареждане на разлика:"
 
 #: lib/diff.tcl:580
 msgid "Failed to unstage selected hunk."
@@ -1775,374 +1362,49 @@ msgstr "Избраният ред не може да бъде изваден о�
 msgid "Failed to stage selected line."
 msgstr "Избраният ред не може да бъде добавен към индекса."
 
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Стандартното"
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Изтласкване към"
 
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Системното (%s)"
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Премахване на отдалечено хранилище"
 
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Друго"
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Окастряне от"
 
-#: lib/error.tcl:20
-#, tcl-format
-msgid "%s: error"
-msgstr "%s: грешка"
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Доставяне от"
 
-#: lib/error.tcl:36
-#, tcl-format
-msgid "%s: warning"
-msgstr "%s: предупреждение"
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr "Всички"
 
-#: lib/error.tcl:80
-#, tcl-format
-msgid "%s hook failed:"
-msgstr "%s: грешка от куката"
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Избор"
 
-#: lib/error.tcl:96
-msgid "You must correct the above errors before committing."
-msgstr "Преди да можете да подадете, коригирайте горните грешки."
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Шрифт"
 
-#: lib/error.tcl:116
-#, tcl-format
-msgid "%s (%s): error"
-msgstr "%s (%s): грешка"
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Размер"
 
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Индексът не може да бъде отключен."
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Мостра"
 
-#: lib/index.tcl:17
-msgid "Index Error"
-msgstr "Грешка в индекса"
-
-#: lib/index.tcl:19
+#: lib/choose_font.tcl:105
 msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
+"This is example text.\n"
+"If you like this text, it can be your font."
 msgstr ""
-"Неуспешно обновяване на индекса на Git. Автоматично ще започне нова проверка "
-"за синхронизирането на git-gui."
-
-#: lib/index.tcl:30
-msgid "Continue"
-msgstr "Продължаване"
-
-#: lib/index.tcl:33
-msgid "Unlock Index"
-msgstr "Отключване на индекса"
-
-#: lib/index.tcl:294
-msgid "Unstaging selected files from commit"
-msgstr "Изваждане на избраните файлове от подаването"
-
-#: lib/index.tcl:298
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Изваждане на „%s“ от подаването"
-
-#: lib/index.tcl:337
-msgid "Ready to commit."
-msgstr "Готовност за подаване."
-
-#: lib/index.tcl:346
-msgid "Adding selected files"
-msgstr "Добавяне на избраните файлове"
-
-#: lib/index.tcl:350
-#, tcl-format
-msgid "Adding %s"
-msgstr "Добавяне на „%s“"
-
-#: lib/index.tcl:380
-#, tcl-format
-msgid "Stage %d untracked files?"
-msgstr "Да се добавят ли %d неследени файла към индекса?"
-
-#: lib/index.tcl:388
-msgid "Adding all changed files"
-msgstr "Добавяне на всички променени файлове"
-
-#: lib/index.tcl:428
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Да се махнат ли промените във файла „%s“?"
-
-#: lib/index.tcl:430
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Да се махнат ли промените в тези %i файла?"
-
-#: lib/index.tcl:438
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Всички промени, които не са били вкарани в индекса, ще бъдат безвъзвратно "
-"загубени."
-
-#: lib/index.tcl:441
-msgid "Do Nothing"
-msgstr "Нищо да не се прави"
-
-#: lib/index.tcl:459
-msgid "Reverting selected files"
-msgstr "Махане на промените в избраните файлове"
-
-#: lib/index.tcl:463
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Махане на промените в „%s“"
-
-#: lib/line.tcl:17
-msgid "Goto Line:"
-msgstr "Към ред:"
-
-#: lib/line.tcl:23
-msgid "Go"
-msgstr "Придвижване"
-
-#: lib/merge.tcl:13
-msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
-msgstr ""
-"По време на поправяне не може да сливане.\n"
-"\n"
-"Трябва да завършите поправянето на текущото подаване, преди да започнете "
-"сливане.\n"
-
-#: lib/merge.tcl:27
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"Последно установеното състояние не отговаря на това в хранилището.\n"
-"\n"
-"Някой друг процес за Git е променил хранилището междувременно. Състоянието "
-"трябва да бъде проверено, преди да се извърши сливане.\n"
-"\n"
-"Автоматично ще започне нова проверка.\n"
-"\n"
-
-#: lib/merge.tcl:45
-#, tcl-format
-msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
-"You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
-msgstr ""
-"В момента тече сливане, но има конфликти.\n"
-"\n"
-"Погледнете файла „%s“.\n"
-"\n"
-"Трябва да коригирате конфликтите в него, да го добавите към индекса и да "
-"завършите текущото сливане чрез подаване. Чак тогава може да започнете ново "
-"сливане.\n"
-
-#: lib/merge.tcl:55
-#, tcl-format
-msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
-"You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
-msgstr ""
-"В момента тече подаване.\n"
-"\n"
-"Файлът „%s“ е променен.\n"
-"\n"
-"Трябва да завършите текущото подаване, преди да започнете сливане. Така ще "
-"можете лесно да преустановите сливането, ако възникне нужда.\n"
-
-#: lib/merge.tcl:108
-#, tcl-format
-msgid "%s of %s"
-msgstr "%s от общо %s"
-
-#: lib/merge.tcl:126
-#, tcl-format
-msgid "Merging %s and %s..."
-msgstr "Сливане на „%s“ и „%s“…"
-
-#: lib/merge.tcl:137
-msgid "Merge completed successfully."
-msgstr "Сливането завърши успешно."
-
-#: lib/merge.tcl:139
-msgid "Merge failed.  Conflict resolution is required."
-msgstr "Неуспешно сливане — има конфликти за коригиране."
-
-#: lib/merge.tcl:156
-#, tcl-format
-msgid "%s (%s): Merge"
-msgstr "%s (%s): Сливане"
-
-#: lib/merge.tcl:164
-#, tcl-format
-msgid "Merge Into %s"
-msgstr "Сливане в „%s“"
-
-#: lib/merge.tcl:183
-msgid "Revision To Merge"
-msgstr "Версия за сливане"
-
-#: lib/merge.tcl:218
-msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
-msgstr ""
-"Поправянето не може да бъде преустановено.\n"
-"\n"
-"Трябва да завършите поправката на това подаване.\n"
-
-#: lib/merge.tcl:228
-msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with aborting the current merge?"
-msgstr ""
-"Да се преустанови ли сливането?\n"
-"\n"
-"В такъв случай ●ВСИЧКИ● неподадени промени ще бъдат безвъзвратно загубени.\n"
-"\n"
-"Наистина ли да се преустанови сливането?"
-
-#: lib/merge.tcl:234
-msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with resetting the current changes?"
-msgstr ""
-"Да се занулят ли промените?\n"
-"\n"
-"В такъв случай ●ВСИЧКИ● неподадени промени ще бъдат безвъзвратно загубени.\n"
-"\n"
-"Наистина ли да се занулят промените?"
-
-#: lib/merge.tcl:245
-msgid "Aborting"
-msgstr "Преустановяване"
-
-#: lib/merge.tcl:245
-msgid "files reset"
-msgstr "файла със занулени промени"
-
-#: lib/merge.tcl:273
-msgid "Abort failed."
-msgstr "Неуспешно преустановяване."
-
-#: lib/merge.tcl:275
-msgid "Abort completed.  Ready."
-msgstr "Успешно преустановяване. Готовност за следващо действие."
-
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Да се използва базовата версия"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Да се използва версията от този клон"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Да се използва версията от другия клон"
-
-#: lib/mergetool.tcl:14
-#, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Разликата показва само разликите с конфликт.\n"
-"\n"
-"Файлът „%s“ ще бъде презаписан.\n"
-"\n"
-"Тази операция може да бъде отменена само чрез започване на сливането наново."
-
-#: lib/mergetool.tcl:45
-#, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-"Изглежда, че все още има некоригирани конфликти във файла „%s“. Да се добави "
-"ли файлът към индекса?"
-
-#: lib/mergetool.tcl:60
-#, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Добавяне на корекция на конфликтите в „%s“"
-
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-"Конфликтите при символни връзки или изтриване не могат да бъдат коригирани с "
-"външна програма."
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "Файлът, в който е конфликтът, не съществува"
-
-#: lib/mergetool.tcl:246
-#, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "Това не е графична програма за сливане: „%s“"
-
-#: lib/mergetool.tcl:275
-#, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "Неподдържана програма за сливане: „%s“"
-
-#: lib/mergetool.tcl:310
-msgid "Merge tool is already running, terminate it?"
-msgstr "Програмата за сливане вече е стартирана. Да бъде ли изключена?"
-
-#: lib/mergetool.tcl:330
-#, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Грешка при изтеглянето на версии:\n"
-"%s"
-
-#: lib/mergetool.tcl:350
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-"Програмата за сливане не може да бъде стартирана:\n"
-"\n"
-"%s"
-
-#: lib/mergetool.tcl:354
-msgid "Running merge tool..."
-msgstr "Стартиране на програмата за сливане…"
-
-#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
-msgid "Merge tool failed."
-msgstr "Грешка в програмата за сливане."
+"Това е примерен текст.\n"
+"Ако ви харесва как изглежда, изберете шрифта."
 
 #: lib/option.tcl:11
 #, tcl-format
@@ -2263,6 +1525,12 @@ msgstr "Показване на неследените файлове"
 msgid "Tab spacing"
 msgstr "Ширина на табулацията"
 
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr "%s:"
+
 #: lib/option.tcl:210
 msgid "Change"
 msgstr "Смяна"
@@ -2292,336 +1560,96 @@ msgstr "Настройки"
 msgid "Failed to completely save options:"
 msgstr "Неуспешно запазване на настройките:"
 
-#: lib/remote.tcl:200
-msgid "Push to"
-msgstr "Изтласкване към"
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Да се използва базовата версия"
 
-#: lib/remote.tcl:218
-msgid "Remove Remote"
-msgstr "Премахване на отдалечено хранилище"
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Да се използва версията от този клон"
 
-#: lib/remote.tcl:223
-msgid "Prune from"
-msgstr "Окастряне от"
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Да се използва версията от другия клон"
 
-#: lib/remote.tcl:228
-msgid "Fetch from"
-msgstr "Доставяне от"
-
-#: lib/remote.tcl:253 lib/remote.tcl:258
-msgid "All"
-msgstr "Всички"
-
-#: lib/remote_add.tcl:20
-#, tcl-format
-msgid "%s (%s): Add Remote"
-msgstr "%s (%s): Добавяне на отдалечено хранилище"
-
-#: lib/remote_add.tcl:25
-msgid "Add New Remote"
-msgstr "Добавяне на отдалечено хранилище"
-
-#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
-msgid "Add"
-msgstr "Добавяне"
-
-#: lib/remote_add.tcl:39
-msgid "Remote Details"
-msgstr "Данни за отдалеченото хранилище"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Местоположение:"
-
-#: lib/remote_add.tcl:60
-msgid "Further Action"
-msgstr "Следващо действие"
-
-#: lib/remote_add.tcl:63
-msgid "Fetch Immediately"
-msgstr "Незабавно доставяне"
-
-#: lib/remote_add.tcl:69
-msgid "Initialize Remote Repository and Push"
-msgstr "Инициализиране на отдалеченото хранилище и изтласкване на промените"
-
-#: lib/remote_add.tcl:75
-msgid "Do Nothing Else Now"
-msgstr "Да не се прави нищо"
-
-#: lib/remote_add.tcl:100
-msgid "Please supply a remote name."
-msgstr "Задайте име за отдалеченото хранилище."
-
-#: lib/remote_add.tcl:113
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "Отдалечено хранилище не може да се казва „%s“."
-
-#: lib/remote_add.tcl:124
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Неуспешно добавяне на отдалеченото хранилище „%s“ от адрес „%s“."
-
-#: lib/remote_add.tcl:132 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "доставяне на „%s“"
-
-#: lib/remote_add.tcl:133
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "Доставяне на „%s“"
-
-#: lib/remote_add.tcl:156
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Хранилището с местоположение „%s“ не може да бъде инициализирано."
-
-#: lib/remote_add.tcl:162 lib/transport.tcl:54 lib/transport.tcl:92
-#: lib/transport.tcl:110
-#, tcl-format
-msgid "push %s"
-msgstr "изтласкване на „%s“"
-
-#: lib/remote_add.tcl:163
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "Добавяне на хранилище „%s“ (с адрес „%s“)"
-
-#: lib/remote_branch_delete.tcl:29
-#, tcl-format
-msgid "%s (%s): Delete Branch Remotely"
-msgstr "%s (%s): Изтриване на отдалечения клон"
-
-#: lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Изтриване на отдалечения клон"
-
-#: lib/remote_branch_delete.tcl:48
-msgid "From Repository"
-msgstr "От хранилище"
-
-#: lib/remote_branch_delete.tcl:51 lib/transport.tcl:165
-msgid "Remote:"
-msgstr "Отдалечено хранилище:"
-
-#: lib/remote_branch_delete.tcl:72 lib/transport.tcl:187
-msgid "Arbitrary Location:"
-msgstr "Произволно местоположение:"
-
-#: lib/remote_branch_delete.tcl:88
-msgid "Branches"
-msgstr "Клони"
-
-#: lib/remote_branch_delete.tcl:110
-msgid "Delete Only If"
-msgstr "Изтриване, само ако"
-
-#: lib/remote_branch_delete.tcl:112
-msgid "Merged Into:"
-msgstr "Слят в:"
-
-#: lib/remote_branch_delete.tcl:153
-msgid "A branch is required for 'Merged Into'."
-msgstr "За данните „Слят в“ е необходимо да зададете клон."
-
-#: lib/remote_branch_delete.tcl:185
-#, tcl-format
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
 msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
 msgstr ""
-"Следните клони не са слети напълно в „%s“:\n"
+"Разликата показва само разликите с конфликт.\n"
 "\n"
-" ● %s"
+"Файлът „%s“ ще бъде презаписан.\n"
+"\n"
+"Тази операция може да бъде отменена само чрез започване на сливането наново."
 
-#: lib/remote_branch_delete.tcl:190
+#: lib/mergetool.tcl:45
 #, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
+msgid "File %s seems to have unresolved conflicts, still stage?"
 msgstr ""
-"Поне една от пробите за сливане е неуспешна, защото не сте доставили всички "
-"необходими подавания. Пробвайте първо да доставите подаванията от „%s“."
+"Изглежда, че все още има некоригирани конфликти във файла „%s“. Да се добави "
+"ли файлът към индекса?"
 
-#: lib/remote_branch_delete.tcl:208
-msgid "Please select one or more branches to delete."
-msgstr "Изберете поне един клон за изтриване."
-
-#: lib/remote_branch_delete.tcl:227
+#: lib/mergetool.tcl:60
 #, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Изтриване на клони от „%s“"
+msgid "Adding resolution for %s"
+msgstr "Добавяне на корекция на конфликтите в „%s“"
 
-#: lib/remote_branch_delete.tcl:300
-msgid "No repository selected."
-msgstr "Не е избрано хранилище."
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+"Конфликтите при символни връзки или изтриване не могат да бъдат коригирани с "
+"външна програма."
 
-#: lib/remote_branch_delete.tcl:305
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "Файлът, в който е конфликтът, не съществува"
+
+#: lib/mergetool.tcl:246
 #, tcl-format
-msgid "Scanning %s..."
-msgstr "Претърсване на „%s“…"
+msgid "Not a GUI merge tool: '%s'"
+msgstr "Това не е графична програма за сливане: „%s“"
 
-#: lib/search.tcl:48
-msgid "Find:"
-msgstr "Търсене:"
-
-#: lib/search.tcl:50
-msgid "Next"
-msgstr "Следваща поява"
-
-#: lib/search.tcl:51
-msgid "Prev"
-msgstr "Предишна поява"
-
-#: lib/search.tcl:52
-msgid "RegExp"
-msgstr "РегИзр"
-
-#: lib/search.tcl:54
-msgid "Case"
-msgstr "Главни/малки"
-
-#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#: lib/mergetool.tcl:275
 #, tcl-format
-msgid "%s (%s): Create Desktop Icon"
-msgstr "%s (%s): Добавяне на икона на работния плот"
+msgid "Unsupported merge tool '%s'"
+msgstr "Неподдържана програма за сливане: „%s“"
 
-#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
-msgid "Cannot write shortcut:"
-msgstr "Клавишната комбинация не може да бъде запазена:"
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "Програмата за сливане вече е стартирана. Да бъде ли изключена?"
 
-#: lib/shortcut.tcl:140
-msgid "Cannot write icon:"
-msgstr "Иконата не може да бъде запазена:"
-
-#: lib/spellcheck.tcl:57
-msgid "Unsupported spell checker"
-msgstr "Тази програма за проверка на правописа не се поддържа"
-
-#: lib/spellcheck.tcl:65
-msgid "Spell checking is unavailable"
-msgstr "Липсва програма за проверка на правописа"
-
-#: lib/spellcheck.tcl:68
-msgid "Invalid spell checking configuration"
-msgstr "Неправилни настройки на проверката на правописа"
-
-#: lib/spellcheck.tcl:70
-#, tcl-format
-msgid "Reverting dictionary to %s."
-msgstr "Ползване на речник за език „%s“."
-
-#: lib/spellcheck.tcl:73
-msgid "Spell checker silently failed on startup"
-msgstr "Програмата за правопис даже не стартира успешно."
-
-#: lib/spellcheck.tcl:80
-msgid "Unrecognized spell checker"
-msgstr "Непозната програма за проверка на правописа"
-
-#: lib/spellcheck.tcl:186
-msgid "No Suggestions"
-msgstr "Няма предложения"
-
-#: lib/spellcheck.tcl:388
-msgid "Unexpected EOF from spell checker"
-msgstr "Неочакван край на файл от програмата за проверка на правописа"
-
-#: lib/spellcheck.tcl:392
-msgid "Spell Checker Failed"
-msgstr "Грешка в програмата за проверка на правописа"
-
-#: lib/sshkey.tcl:31
-msgid "No keys found."
-msgstr "Не са открити ключове."
-
-#: lib/sshkey.tcl:34
-#, tcl-format
-msgid "Found a public key in: %s"
-msgstr "Открит е публичен ключ в „%s“"
-
-#: lib/sshkey.tcl:40
-msgid "Generate Key"
-msgstr "Генериране на ключ"
-
-#: lib/sshkey.tcl:58
-msgid "Copy To Clipboard"
-msgstr "Копиране към системния буфер"
-
-#: lib/sshkey.tcl:72
-msgid "Your OpenSSH Public Key"
-msgstr "Публичният ви ключ за OpenSSH"
-
-#: lib/sshkey.tcl:80
-msgid "Generating..."
-msgstr "Генериране…"
-
-#: lib/sshkey.tcl:86
+#: lib/mergetool.tcl:330
 #, tcl-format
 msgid ""
-"Could not start ssh-keygen:\n"
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Грешка при изтеглянето на версии:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
 "\n"
 "%s"
 msgstr ""
-"Програмата „ssh-keygen“ не може да бъде стартирана:\n"
+"Програмата за сливане не може да бъде стартирана:\n"
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:113
-msgid "Generation failed."
-msgstr "Неуспешно генериране."
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "Стартиране на програмата за сливане…"
 
-#: lib/sshkey.tcl:120
-msgid "Generation succeeded, but no keys found."
-msgstr "Генерирането завърши успешно, а не са намерени ключове."
-
-#: lib/sshkey.tcl:123
-#, tcl-format
-msgid "Your key is in: %s"
-msgstr "Ключът ви е в „%s“"
-
-#: lib/status_bar.tcl:87
-#, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s… %*i от общо %*i %s (%3i%%)"
-
-#: lib/tools.tcl:76
-#, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "За изпълнението на „%s“ трябва да изберете файл."
-
-#: lib/tools.tcl:92
-#, tcl-format
-msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
-msgstr "Сигурни ли сте, че искате да изпълните „%1$s“ върху файла „%2$s“?"
-
-#: lib/tools.tcl:96
-#, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Сигурни ли сте, че искате да изпълните „%s“?"
-
-#: lib/tools.tcl:118
-#, tcl-format
-msgid "Tool: %s"
-msgstr "Команда: %s"
-
-#: lib/tools.tcl:119
-#, tcl-format
-msgid "Running: %s"
-msgstr "Изпълнение: %s"
-
-#: lib/tools.tcl:158
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Командата завърши успешно: %s"
-
-#: lib/tools.tcl:160
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "Командата върна грешка: %s"
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "Грешка в програмата за сливане."
 
 #: lib/tools_dlg.tcl:22
 #, tcl-format
@@ -2723,85 +1751,1098 @@ msgstr "Аргументи"
 msgid "OK"
 msgstr "Добре"
 
-#: lib/transport.tcl:7
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Търсене:"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Следваща поява"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Предишна поява"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr "РегИзр"
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr "Главни/малки"
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Доставяне на промените от „%s“"
+msgid "%s (%s): Create Desktop Icon"
+msgstr "%s (%s): Добавяне на икона на работния плот"
 
-#: lib/transport.tcl:18
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Клавишната комбинация не може да бъде запазена:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Иконата не може да бъде запазена:"
+
+#: lib/branch_rename.tcl:15
 #, tcl-format
-msgid "remote prune %s"
-msgstr "окастряне на следящите клони към „%s“"
+msgid "%s (%s): Rename Branch"
+msgstr "%s (%s): Преименуване на клон"
 
-#: lib/transport.tcl:19
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Преименуване на клон"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Преименуване"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Клон:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Ново име:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Изберете клон за преименуване."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Дайте име на клона."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Окастряне на следящите клони на изтритите клони от „%s“"
+msgid "'%s' is not an acceptable branch name."
+msgstr "„%s“ не може да се използва за име на клон."
 
-#: lib/transport.tcl:25
-msgid "fetch all remotes"
-msgstr "доставяне от всички отдалечени"
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Неуспешно преименуване на „%s“."
 
-#: lib/transport.tcl:26
-msgid "Fetching new changes from all remotes"
-msgstr "Доставяне на промените от всички отдалечени хранилища"
+#: lib/remote_branch_delete.tcl:29
+#, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "%s (%s): Изтриване на отдалечения клон"
 
-#: lib/transport.tcl:40
-msgid "remote prune all remotes"
-msgstr "окастряне на следящите изтрити"
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Изтриване на отдалечения клон"
 
-#: lib/transport.tcl:41
-msgid "Pruning tracking branches deleted from all remotes"
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "От хранилище"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Клони"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Изтриване, само ако"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Слят в:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Винаги (без проверка за сливане)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "За данните „Слят в“ е необходимо да зададете клон."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
 msgstr ""
-"Окастряне на следящите клони на изтритите клони от всички отдалечени "
-"хранилища"
+"Следните клони не са слети напълно в „%s“:\n"
+"\n"
+" ● %s"
 
-#: lib/transport.tcl:55
+#: lib/remote_branch_delete.tcl:190
 #, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Изтласкване на промените към „%s“"
-
-#: lib/transport.tcl:93
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr "Изтласкване на всичко към „%s“"
-
-#: lib/transport.tcl:111
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Изтласкване на %s „%s“ към „%s“"
-
-#: lib/transport.tcl:132
-msgid "Push Branches"
-msgstr "Клони за изтласкване"
-
-#: lib/transport.tcl:147
-msgid "Source Branches"
-msgstr "Клони-източници"
-
-#: lib/transport.tcl:162
-msgid "Destination Repository"
-msgstr "Целево хранилище"
-
-#: lib/transport.tcl:205
-msgid "Transfer Options"
-msgstr "Настройки при пренасянето"
-
-#: lib/transport.tcl:207
-msgid "Force overwrite existing branch (may discard changes)"
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
 msgstr ""
-"Изрично презаписване на съществуващ клон (някои промени може да бъдат "
-"загубени)"
+"Поне една от пробите за сливане е неуспешна, защото не сте доставили всички "
+"необходими подавания. Пробвайте първо да доставите подаванията от „%s“."
 
-#: lib/transport.tcl:211
-msgid "Use thin pack (for slow network connections)"
-msgstr "Максимална компресия (за бавни мрежови връзки)"
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Изберете поне един клон за изтриване."
 
-#: lib/transport.tcl:215
-msgid "Include tags"
-msgstr "Включване на етикетите"
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Възстановяването на изтрити клони може да е трудно.\n"
+"\n"
+"Сигурни ли сте, че искате да триете?"
 
-#: lib/transport.tcl:229
+#: lib/remote_branch_delete.tcl:227
 #, tcl-format
-msgid "%s (%s): Push"
-msgstr "%s (%s): Изтласкване"
+msgid "Deleting branches from %s"
+msgstr "Изтриване на клони от „%s“"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Не е избрано хранилище."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Претърсване на „%s“…"
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "ГПИ на Git"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Създаване на ново хранилище"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Ново…"
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Клониране на съществуващо хранилище"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Клониране…"
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Отваряне на съществуващо хранилище"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Отваряне…"
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Скоро ползвани"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Отваряне на хранилище ползвано наскоро:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Неуспешно създаване на хранилището „%s“:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Създаване"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Директория:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Хранилище на Git"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "Вече съществува директория „%s“."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Вече съществува файл „%s“."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Клониране"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Адрес на източника:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Целева директория:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Вид клониране:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Стандартно (бързо, частично споделяне на файлове, твърди връзки)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Пълно (бавно, пълноценно резервно копие)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Споделено (най-бързо, не се препоръчва, не прави резервно копие)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr "Рекурсивно клониране и на подмодулите"
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Това не е хранилище на Git: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Само локални хранилища могат да се клонират стандартно"
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "Само локални хранилища могат да се клонират споделено"
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "Местоположението „%s“ вече съществува."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Неуспешно настройване на хранилището-източник"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Преброяване на обекти"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "клетки"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Обектите/информацията/синонимите не могат да бъдат копирани: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Няма какво да се клонира от „%s“."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "Основният клон — „master“ не е инициализиран."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Не се поддържат твърди връзки. Преминава се към копиране."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Клониране на „%s“"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Копиране на обекти"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Неуспешно копиране на обект: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Създаване на връзки към обектите"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "обекти"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Неуспешно създаване на твърда връзка към обект: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Клоните и обектите не могат да бъдат изтеглени. За повече информация "
+"погледнете изхода на конзолата."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+"Етикетите не могат да бъдат изтеглени. За повече информация погледнете "
+"изхода на конзолата."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+"Върхът „HEAD“ не може да бъде определен. За повече информация погледнете "
+"изхода на конзолата."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "„%s“ не може да се зачисти"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Неуспешно клониране."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Не е получен клон по подразбиране."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Няма подаване отговарящо на „%s“."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Създаване на работната директория"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "файлове"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr "Подмодулите не могат да се клонират."
+
+#: lib/choose_repository.tcl:993
+msgid "Cloning submodules"
+msgstr "Клониране на подмодули"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Неуспешно първоначално изтегляне."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Отваряне"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Хранилище:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Неуспешно отваряне на хранилището „%s“:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui — графичен интерфейс за Git."
+
+#: lib/blame.tcl:73
+#, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "%s (%s): Преглед на файлове"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Подаване:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Копиране на подаване"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Търсене на текст…"
+
+#: lib/blame.tcl:288
+msgid "Goto Line..."
+msgstr "Към ред…"
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Пълно търсене на копиране"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Показване на контекста от историята"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Анотиране на родителското подаване"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Чете се „%s“…"
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Зареждане на анотациите за проследяване на копирането/преместването…"
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "реда анотирани"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Зареждане на анотациите за първоначалното местоположение…"
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Анотирането завърши."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Операцията не е завършила"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "В момента тече процес на анотиране."
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Изпълнява се цялостен процес на откриване на копиране…"
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Зареждане на анотации…"
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Автор:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Подал:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Първоначален файл:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Подаването за връх „HEAD“ не може да се открие:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Родителското подаване не може да бъде открито"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Родителят не може да бъде показан"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Първоначално от:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "Във файл:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Копирано или преместено тук от:"
+
+#: lib/sshkey.tcl:31
+msgid "No keys found."
+msgstr "Не са открити ключове."
+
+#: lib/sshkey.tcl:34
+#, tcl-format
+msgid "Found a public key in: %s"
+msgstr "Открит е публичен ключ в „%s“"
+
+#: lib/sshkey.tcl:40
+msgid "Generate Key"
+msgstr "Генериране на ключ"
+
+#: lib/sshkey.tcl:58
+msgid "Copy To Clipboard"
+msgstr "Копиране към системния буфер"
+
+#: lib/sshkey.tcl:72
+msgid "Your OpenSSH Public Key"
+msgstr "Публичният ви ключ за OpenSSH"
+
+#: lib/sshkey.tcl:80
+msgid "Generating..."
+msgstr "Генериране…"
+
+#: lib/sshkey.tcl:86
+#, tcl-format
+msgid ""
+"Could not start ssh-keygen:\n"
+"\n"
+"%s"
+msgstr ""
+"Програмата „ssh-keygen“ не може да бъде стартирана:\n"
+"\n"
+"%s"
+
+#: lib/sshkey.tcl:113
+msgid "Generation failed."
+msgstr "Неуспешно генериране."
+
+#: lib/sshkey.tcl:120
+msgid "Generation succeeded, but no keys found."
+msgstr "Генерирането завърши успешно, а не са намерени ключове."
+
+#: lib/sshkey.tcl:123
+#, tcl-format
+msgid "Your key is in: %s"
+msgstr "Ключът ви е в „%s“"
+
+#: lib/branch_create.tcl:23
+#, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "%s (%s): Създаване на клон"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Създаване на нов клон"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Име на клона"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Съвпадане по името на следения клон"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Начална версия"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Обновяване на съществуващ клон:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Не"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Само тривиално превъртащо сливане"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Преминаване към клона след създаването му"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Изберете клон за следени."
+
+#: lib/branch_create.tcl:141
+#, tcl-format
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "Следящият клон — „%s“, не съществува в отдалеченото хранилище."
+
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Няма какво да се поправи.\n"
+"\n"
+"Ще създадете първоначалното подаване. Преди него няма други подавания, които "
+"да поправите.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"По време на сливане не може да поправяте.\n"
+"\n"
+"В момента все още не сте завършили операция по сливане. Не може да поправите "
+"предишното подаване, освен ако първо не преустановите текущото сливане.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Грешка при зареждане на данните от подаване, които да се поправят:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Идентификацията ви не може да бъде определена:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Неправилно поле „GIT_COMMITTER_IDENT“:"
+
+#: lib/commit.tcl:132
+#, tcl-format
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "предупреждение: Tcl не поддържа кодирането „%s“."
+
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Състоянието при последната проверка не отговаря на състоянието на "
+"хранилището.\n"
+"\n"
+"Някой друг процес за Git е променил хранилището междувременно. Състоянието "
+"трябва да бъде проверено преди ново подаване.\n"
+"\n"
+"Автоматично ще започне нова проверка.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Неслетите файлове не могат да бъдат подавани.\n"
+"\n"
+"Във файла „%s“ има конфликти при сливане. За да го подадете, трябва първо да "
+"коригирате конфликтите и да добавите файла към индекса за подаване.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Непознато състояние на файл „%s“.\n"
+"\n"
+"Файлът „%s“ не може да бъде подаден чрез текущата програма.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Няма промени за подаване.\n"
+"\n"
+"Трябва да добавите поне един файл към индекса, за да подадете.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Задайте добро съобщение при подаване.\n"
+"\n"
+"Използвайте следния формат:\n"
+"\n"
+"● Първи ред: описание в едно изречение на промяната.\n"
+"● Втори ред: празен.\n"
+"● Останалите редове: опишете защо се налага тази промяна.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Изпълняване на куката преди подаване…"
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Подаването е отхвърлено от куката преди подаване."
+
+#: lib/commit.tcl:272
+#, fuzzy
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+"Ще подадете към несвързан, отделѐн указател „HEAD“. Това е опасно, защото "
+"при преминаването към клон ще загубите промените си, като единственият начин "
+"да ги върнете ще е чрез журнала на указателите (reflog). Най-вероятно трябва "
+"да не правите това подаване, а да създадете нов клон, преди да продължите.\n"
+" \n"
+"Сигурни ли сте, че искате да извършите текущото подаване?"
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Изпълняване на куката за съобщението при подаване…"
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Подаването е отхвърлено от куката за съобщението при подаване."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Подаване на промените…"
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "неуспешно запазване на дървото (write-tree):"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Неуспешно подаване."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "Подаването „%s“ изглежда повредено"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Няма промени за подаване.\n"
+"\n"
+"В това подаване не са променяни никакви файлове, а и не е подаване със "
+"сливане.\n"
+"\n"
+"Автоматично ще започне нова проверка.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Няма промени за подаване."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "неуспешно подаване на дървото (commit-tree):"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "неуспешно обновяване на указателите (update-ref):"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "Успешно подаване %s: %s"
+
+#: lib/branch_delete.tcl:16
+#, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "%s (%s): Изтриване на клон"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Изтриване на локален клон"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Локални клони"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Изтриване, само ако промените са слети и другаде"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "Не всички промени в клоните са слети в „%s“:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr " — „%s:“"
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+"Неуспешно триене на клони:\n"
+"%s"
+
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Индексът не може да бъде отключен."
+
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Грешка в индекса"
+
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Неуспешно обновяване на индекса на Git. Автоматично ще започне нова проверка "
+"за синхронизирането на git-gui."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Продължаване"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Отключване на индекса"
+
+#: lib/index.tcl:294
+msgid "Unstaging selected files from commit"
+msgstr "Изваждане на избраните файлове от подаването"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "Изваждане на „%s“ от подаването"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Готовност за подаване."
+
+#: lib/index.tcl:346
+msgid "Adding selected files"
+msgstr "Добавяне на избраните файлове"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "Добавяне на „%s“"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr "Да се добавят ли %d неследени файла към индекса?"
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr "Добавяне на всички променени файлове"
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Да се махнат ли промените във файла „%s“?"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Да се махнат ли промените в тези %i файла?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Всички промени, които не са били вкарани в индекса, ще бъдат безвъзвратно "
+"загубени."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Нищо да не се прави"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Да се добавят ли %d неследени файла към индекса?"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Да се добавят ли %d неследени файла към индекса?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Изтриване"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Махане на промените в избраните файлове"
+
+#: lib/index.tcl:532
+#, tcl-format
+msgid "Reverting %s"
+msgstr "Махане на промените в „%s“"
+
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Стандартното"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr "Системното (%s)"
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Друго"
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Неправилни данни от Git: %s"
+
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Това несвързано изтегляне"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Израз за версия:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Локален клон"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Следящ клон"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Етикет"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Неправилна версия: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Не е избрана версия."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "Изразът за версия е празен."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Обновен"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "Адрес"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Брой непакетирани обекти"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Дисково пространство заето от непакетирани обекти"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Брой пакетирани обекти"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Брой пакети"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Дисково пространство заето от пакетирани обекти"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Пакетирани обекти за окастряне"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Файлове за боклука"
+
+#: lib/database.tcl:66
+#, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "%s (%s): Статистика на базата от данни"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Компресиране на базата с данни за обектите"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Проверка на базата с данни за обектите с програмата „fsck-objects“"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"В това хранилище в момента има към %i непакетирани обекти.\n"
+"\n"
+"За добра производителност се препоръчва да компресирате базата с данни за "
+"обектите.\n"
+"\n"
+"Да се започне ли компресирането?"
+
+#: lib/error.tcl:20
+#, tcl-format
+msgid "%s: error"
+msgstr "%s: грешка"
+
+#: lib/error.tcl:36
+#, tcl-format
+msgid "%s: warning"
+msgstr "%s: предупреждение"
+
+#: lib/error.tcl:80
+#, tcl-format
+msgid "%s hook failed:"
+msgstr "%s: грешка от куката"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Преди да можете да подадете, коригирайте горните грешки."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr "%s (%s): грешка"
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "● Неследеният файл е %d байта.\n"
+#~ "● Показват се само първите %d байта.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -2,55 +2,56 @@
 # Copyright (C) 2007 Shawn Pearce, et al.
 # This file is distributed under the same license as the git package.
 # Christian Stimming <stimming@tuhh.de>, 2007
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-01-26 22:22+0100\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2010-01-26 22:25+0100\n"
 "Last-Translator: Christian Stimming <stimming@tuhh.de>\n"
 "Language-Team: German\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:41 git-gui.sh:793 git-gui.sh:807 git-gui.sh:820 git-gui.sh:903
-#: git-gui.sh:922
-msgid "git-gui: fatal error"
-msgstr "git-gui: Programmfehler"
-
-#: git-gui.sh:743
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Ungültige Zeichensatz-Angabe in %s:"
 
-#: git-gui.sh:779
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Programmschriftart"
 
-#: git-gui.sh:780
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Vergleich-Schriftart"
 
-#: git-gui.sh:794
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: Programmfehler"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Git kann im PATH nicht gefunden werden."
 
-#: git-gui.sh:821
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Git Versionsangabe kann nicht erkannt werden:"
 
-#: git-gui.sh:839
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Die Version von Git kann nicht bestimmt werden.\n"
 "\n"
@@ -60,487 +61,520 @@ msgstr ""
 "\n"
 "Soll angenommen werden, »%s« sei Version 1.5.0?\n"
 
-#: git-gui.sh:1128
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Git-Verzeichnis nicht gefunden:"
 
-#: git-gui.sh:1146
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr ""
 "Es konnte nicht in das oberste Verzeichnis der Arbeitskopie gewechselt "
 "werden:"
 
-#: git-gui.sh:1154
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Bloßes Projektarchiv kann nicht benutzt werden:"
 
-#: git-gui.sh:1162
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Kein Arbeitsverzeichnis"
 
-#: git-gui.sh:1334 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Dateistatus aktualisieren..."
 
-#: git-gui.sh:1390
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Nach geänderten Dateien suchen..."
 
-#: git-gui.sh:1454
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
-msgstr "Aufrufen der Eintragen-Vorbereiten-Kontrolle (»prepare-commit hook«)..."
+msgstr ""
+"Aufrufen der Eintragen-Vorbereiten-Kontrolle (»prepare-commit hook«)..."
 
-#: git-gui.sh:1471
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr ""
 "Eintragen abgelehnt durch Eintragen-Vorbereiten-Kontrolle (»prepare-commit "
 "hook«)."
 
-#: git-gui.sh:1629 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Bereit."
 
-#: git-gui.sh:1787
+#: git-gui.sh:1966
 #, tcl-format
-msgid "Displaying only %s of %s files."
-msgstr "Nur %s von %s Dateien werden angezeigt."
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
 
-#: git-gui.sh:1913
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Unverändert"
 
-#: git-gui.sh:1915
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Verändert, nicht bereitgestellt"
 
-#: git-gui.sh:1916 git-gui.sh:1924
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Bereitgestellt zum Eintragen"
 
-#: git-gui.sh:1917 git-gui.sh:1925
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Teilweise bereitgestellt zum Eintragen"
 
-#: git-gui.sh:1918 git-gui.sh:1926
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Bereitgestellt zum Eintragen, fehlend"
 
-#: git-gui.sh:1920
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Dateityp geändert, nicht bereitgestellt"
 
-#: git-gui.sh:1921
+#: git-gui.sh:2097 git-gui.sh:2098
+#, fuzzy
+msgid "File type changed, old type staged for commit"
+msgstr "Dateityp geändert, nicht bereitgestellt"
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Dateityp geändert, bereitgestellt"
 
-#: git-gui.sh:1923
+#: git-gui.sh:2100
+#, fuzzy
+msgid "File type change staged, modification not staged"
+msgstr "Dateityp geändert, nicht bereitgestellt"
+
+#: git-gui.sh:2101
+#, fuzzy
+msgid "File type change staged, file missing"
+msgstr "Dateityp geändert, bereitgestellt"
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Nicht unter Versionskontrolle, nicht bereitgestellt"
 
-#: git-gui.sh:1928
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Fehlend"
 
-#: git-gui.sh:1929
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Bereitgestellt zum Löschen"
 
-#: git-gui.sh:1930
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Bereitgestellt zum Löschen, trotzdem vorhanden"
 
-#: git-gui.sh:1932 git-gui.sh:1933 git-gui.sh:1934 git-gui.sh:1935
-#: git-gui.sh:1936 git-gui.sh:1937
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Konfliktauflösung nötig"
 
-#: git-gui.sh:1972
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Gitk wird gestartet... bitte warten."
 
-#: git-gui.sh:1984
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Gitk kann im PATH nicht gefunden werden."
 
-#: git-gui.sh:2043
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "»Git gui« kann im PATH nicht gefunden werden."
 
-#: git-gui.sh:2455 lib/choose_repository.tcl:36
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Projektarchiv"
 
-#: git-gui.sh:2456
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: git-gui.sh:2458 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Zweig"
 
-#: git-gui.sh:2461 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Version"
 
-#: git-gui.sh:2464 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Zusammenführen"
 
-#: git-gui.sh:2465 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Externe Archive"
 
-#: git-gui.sh:2468
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Werkzeuge"
 
-#: git-gui.sh:2477
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Arbeitskopie im Dateimanager"
 
-#: git-gui.sh:2483
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Aktuellen Zweig durchblättern"
 
-#: git-gui.sh:2487
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Einen Zweig durchblättern..."
 
-#: git-gui.sh:2492
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Aktuellen Zweig darstellen"
 
-#: git-gui.sh:2496
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Alle Zweige darstellen"
 
-#: git-gui.sh:2503
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Zweig »%s« durchblättern"
 
-#: git-gui.sh:2505
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Historie von »%s« darstellen"
 
-#: git-gui.sh:2510 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Datenbankstatistik"
 
-#: git-gui.sh:2513 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Datenbank komprimieren"
 
-#: git-gui.sh:2516
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Datenbank überprüfen"
 
-#: git-gui.sh:2523 git-gui.sh:2527 git-gui.sh:2531 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Desktop-Icon erstellen"
 
-#: git-gui.sh:2539 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Beenden"
 
-#: git-gui.sh:2547
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: git-gui.sh:2550
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Wiederholen"
 
-#: git-gui.sh:2554 git-gui.sh:3109
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: git-gui.sh:2557 git-gui.sh:3112 git-gui.sh:3186 git-gui.sh:3259
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Kopieren"
 
-#: git-gui.sh:2560 git-gui.sh:3115
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Einfügen"
 
-#: git-gui.sh:2563 git-gui.sh:3118 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Löschen"
 
-#: git-gui.sh:2567 git-gui.sh:3122 git-gui.sh:3263 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Alle auswählen"
 
-#: git-gui.sh:2576
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Erstellen..."
 
-#: git-gui.sh:2582
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Umstellen..."
 
-#: git-gui.sh:2588
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Umbenennen..."
 
-#: git-gui.sh:2593
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Löschen..."
 
-#: git-gui.sh:2598
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Zurücksetzen..."
 
-#: git-gui.sh:2608
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Fertig"
 
-#: git-gui.sh:2610
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Eintragen"
 
-#: git-gui.sh:2619 git-gui.sh:3050
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Neue Version"
 
-#: git-gui.sh:2627 git-gui.sh:3057
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Letzte nachbessern"
 
-#: git-gui.sh:2637 git-gui.sh:3011 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Neu laden"
 
-#: git-gui.sh:2643
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Zum Eintragen bereitstellen"
 
-#: git-gui.sh:2649
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Geänderte Dateien bereitstellen"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Aus der Bereitstellung herausnehmen"
 
-#: git-gui.sh:2661 lib/index.tcl:412
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Änderungen verwerfen"
 
-#: git-gui.sh:2669 git-gui.sh:3310 git-gui.sh:3341
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Weniger Zeilen anzeigen"
 
-#: git-gui.sh:2673 git-gui.sh:3314 git-gui.sh:3345
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Mehr Zeilen anzeigen"
 
-#: git-gui.sh:2680 git-gui.sh:3024 git-gui.sh:3133
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Abzeichnen"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Lokales Zusammenführen..."
 
-#: git-gui.sh:2701
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Zusammenführen abbrechen..."
 
-#: git-gui.sh:2713 git-gui.sh:2741
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Hinzufügen..."
 
-#: git-gui.sh:2717
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Versenden..."
 
-#: git-gui.sh:2721
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Zweig löschen..."
 
-#: git-gui.sh:2731 git-gui.sh:3292
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Optionen..."
 
-#: git-gui.sh:2742
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Entfernen..."
 
-#: git-gui.sh:2751 lib/choose_repository.tcl:50
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Hilfe"
 
-#: git-gui.sh:2755 git-gui.sh:2759 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Über %s"
 
-#: git-gui.sh:2783
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Online-Dokumentation"
 
-#: git-gui.sh:2786 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "SSH-Schlüssel anzeigen"
 
-#: git-gui.sh:2893
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "Fehler"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "Fehler: Verzeichnis »%s« kann nicht gelesen werden: Datei oder Verzeichnis "
 "nicht gefunden"
 
-#: git-gui.sh:2926
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Aktueller Zweig:"
 
-#: git-gui.sh:2947
-msgid "Staged Changes (Will Commit)"
-msgstr "Bereitstellung (zum Eintragen)"
-
-#: git-gui.sh:2967
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Nicht bereitgestellte Änderungen"
 
-#: git-gui.sh:3017
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Bereitstellung (zum Eintragen)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Alles bereitstellen"
 
-#: git-gui.sh:3036 lib/transport.tcl:104 lib/transport.tcl:193
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Versenden"
 
-#: git-gui.sh:3071
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Erste Versionsbeschreibung:"
 
-#: git-gui.sh:3072
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Nachgebesserte Beschreibung:"
 
-#: git-gui.sh:3073
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Nachgebesserte erste Beschreibung:"
 
-#: git-gui.sh:3074
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Nachgebesserte Zusammenführungs-Beschreibung:"
 
-#: git-gui.sh:3075
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Zusammenführungs-Beschreibung:"
 
-#: git-gui.sh:3076
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Versionsbeschreibung:"
 
-#: git-gui.sh:3125 git-gui.sh:3267 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Alle kopieren"
 
-#: git-gui.sh:3149 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Datei:"
 
-#: git-gui.sh:3255
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Schriftgröße verkleinern"
 
-#: git-gui.sh:3280
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Schriftgröße vergrößern"
 
-#: git-gui.sh:3288 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Zeichenkodierung"
 
-#: git-gui.sh:3299
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Kontext anwenden/umkehren"
 
-#: git-gui.sh:3304
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Zeile anwenden/umkehren"
 
-#: git-gui.sh:3323
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Zusammenführungswerkzeug"
 
-#: git-gui.sh:3328
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Externe Version benutzen"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Lokale Version benutzen"
 
-#: git-gui.sh:3336
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Ursprüngliche Version benutzen"
 
-#: git-gui.sh:3354
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Diese Änderungen im Untermodul darstellen"
 
-#: git-gui.sh:3358
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Aktuellen Zweig im Untermodul darstellen"
 
-#: git-gui.sh:3362
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Alle Zweige im Untermodul darstellen"
 
-#: git-gui.sh:3367
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Git gui im Untermodul starten"
 
-#: git-gui.sh:3389
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Kontext aus Bereitstellung herausnehmen"
 
-#: git-gui.sh:3391
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Zeilen aus der Bereitstellung herausnehmen"
 
-#: git-gui.sh:3393
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Zeile aus der Bereitstellung herausnehmen"
 
-#: git-gui.sh:3396
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Kontext zur Bereitstellung hinzufügen"
 
-#: git-gui.sh:3398
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Zeilen zur Bereitstellung hinzufügen"
 
-#: git-gui.sh:3400
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Zeile zur Bereitstellung hinzufügen"
 
-#: git-gui.sh:3424
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Initialisieren..."
 
-#: git-gui.sh:3541
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Möglicherweise gibt es Probleme mit manchen Umgebungsvariablen.\n"
 "\n"
@@ -548,25 +582,26 @@ msgstr ""
 "von %s an Git weitergegeben werden:\n"
 "\n"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Dies ist ein bekanntes Problem der Tcl-Version, die\n"
 "in Cygwin mitgeliefert wird."
 
-#: git-gui.sh:3575
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -574,315 +609,30 @@ msgstr ""
 "gewünschten Werte für die Einstellung user.name und \n"
 "user.email in Ihre Datei ~/.gitconfig einfügen.\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - eine grafische Oberfläche für Git."
-
-#: lib/blame.tcl:72
-msgid "File Viewer"
-msgstr "Datei-Browser"
-
-#: lib/blame.tcl:78
-msgid "Commit:"
-msgstr "Version:"
-
-#: lib/blame.tcl:271
-msgid "Copy Commit"
-msgstr "Version kopieren"
-
-#: lib/blame.tcl:275
-msgid "Find Text..."
-msgstr "Text suchen..."
-
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr "Volle Kopie-Erkennung"
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr "Historien-Kontext anzeigen"
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
-msgstr "Elternversion annotieren"
-
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr "%s lesen..."
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
-msgstr "Annotierungen für Kopieren/Verschieben werden geladen..."
-
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr "Zeilen annotiert"
-
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr "Annotierungen für ursprünglichen Ort werden geladen..."
-
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr "Annotierung vollständig."
-
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr "Verarbeitung läuft"
-
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr "Annotierung läuft bereits."
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr "Intensive Kopie-Erkennung läuft..."
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr "Annotierung laden..."
-
-#: lib/blame.tcl:963
-msgid "Author:"
-msgstr "Autor:"
-
-#: lib/blame.tcl:967
-msgid "Committer:"
-msgstr "Eintragender:"
-
-#: lib/blame.tcl:972
-msgid "Original File:"
-msgstr "Ursprüngliche Datei:"
-
-#: lib/blame.tcl:1020
-msgid "Cannot find HEAD commit:"
-msgstr "Zweigspitze (»HEAD«) kann nicht gefunden werden:"
-
-#: lib/blame.tcl:1075
-msgid "Cannot find parent commit:"
-msgstr "Elternversion kann nicht gefunden werden:"
-
-#: lib/blame.tcl:1090
-msgid "Unable to display parent"
-msgstr "Elternversion kann nicht angezeigt werden"
-
-#: lib/blame.tcl:1091 lib/diff.tcl:320
-msgid "Error loading diff:"
-msgstr "Fehler beim Laden des Vergleichs:"
-
-#: lib/blame.tcl:1231
-msgid "Originally By:"
-msgstr "Ursprünglich von:"
-
-#: lib/blame.tcl:1237
-msgid "In File:"
-msgstr "In Datei:"
-
-#: lib/blame.tcl:1242
-msgid "Copied Or Moved Here By:"
-msgstr "Kopiert oder verschoben durch:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Auf Zweig umstellen"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Umstellen"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:579 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:108
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr "Version"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr "Optionen"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Übernahmezweig anfordern"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Verbindung zu lokalem Zweig lösen"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Zweig erstellen"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Neuen Zweig erstellen"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:381
-msgid "Create"
-msgstr "Erstellen"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Zweigname"
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr "Name:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Passend zu Übernahmezweig-Name"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Anfangsversion"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Existierenden Zweig aktualisieren:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Nein"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Nur Schnellzusammenführung"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr "Zurücksetzen"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Arbeitskopie umstellen nach Erstellen"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Bitte wählen Sie einen Übernahmezweig."
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "Übernahmezweig »%s« ist kein Zweig im externen Projektarchiv."
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Bitte geben Sie einen Zweignamen an."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "»%s« ist kein zulässiger Zweigname."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Zweig löschen"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Lokalen Zweig löschen"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Lokale Zweige"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Nur löschen, wenn zusammengeführt nach"
-
-#: lib/branch_delete.tcl:54 lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Immer (Keine Zusammenführungsprüfung)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Folgende Zweige sind noch nicht mit »%s« zusammengeführt:"
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:217
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
-"Das Wiederherstellen von gelöschten Zweigen ist nur mit größerem Aufwand "
-"möglich.\n"
-"\n"
-"Sollen die ausgewählten Zweige gelöscht werden?"
 
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
-"Fehler beim Löschen der Zweige:\n"
-"%s"
 
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Zweig umbenennen"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Verarbeitung. Bitte warten..."
 
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Umbenennen"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Schließen"
 
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Zweig:"
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Erfolgreich"
 
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Neuer Name:"
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Bitte wählen Sie einen Zweig zum umbenennen."
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "Zweig »%s« existiert bereits."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Fehler beim Umbenennen von »%s«."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Starten..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "Datei-Browser"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "%s laden..."
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[Nach oben]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "Dateien des Zweigs durchblättern"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:398
-#: lib/choose_repository.tcl:486 lib/choose_repository.tcl:497
-#: lib/choose_repository.tcl:1028
-msgid "Browse"
-msgstr "Blättern"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Fehler: Kommando fehlgeschlagen"
 
 #: lib/checkout_op.tcl:85
 #, tcl-format
@@ -894,11 +644,6 @@ msgstr "Änderungen »%s« von »%s« anfordern"
 msgid "fatal: Cannot resolve %s"
 msgstr "Fehler: »%s« kann nicht als Zweig oder Version erkannt werden"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr "Schließen"
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -908,6 +653,11 @@ msgstr "Zweig »%s« existiert nicht."
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Fehler beim Einrichten der vereinfachten git-pull für »%s«."
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "Zweig »%s« existiert bereits."
 
 #: lib/checkout_op.tcl:229
 #, tcl-format
@@ -937,13 +687,14 @@ msgid "Staging area (index) is already locked."
 msgstr "Bereitstellung (»index«) ist zur Bearbeitung gesperrt (»locked«)."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Der letzte geladene Status stimmt nicht mehr mit dem Projektarchiv überein.\n"
 "\n"
@@ -978,9 +729,10 @@ msgid "Staying on branch '%s'."
 msgstr "Es wird auf Zweig »%s« verblieben."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -1010,18 +762,31 @@ msgstr ""
 msgid "Reset '%s'?"
 msgstr "»%s« zurücksetzen?"
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Darstellen"
 
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Abbrechen"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Lokaler Zweig kann nicht gesetzt werden.\n"
@@ -1032,757 +797,223 @@ msgstr ""
 "\n"
 "Dies ist ein interner Programmfehler von %s. Programm wird jetzt abgebrochen."
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Auswählen"
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "»%s« anfordern"
 
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Schriftfamilie"
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "Neue Änderungen von »%s« holen"
 
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Schriftgröße"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "Aufräumen von »%s«"
 
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Schriftbeispiel"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Übernahmezweige aufräumen und entfernen, die in »%s« gelöscht wurden"
 
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
-"Dies ist ein Beispieltext.\n"
-"Wenn Ihnen dieser Text gefällt, sollten Sie diese Schriftart wählen."
 
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
+#: lib/transport.tcl:26
+#, fuzzy
+msgid "Fetching new changes from all remotes"
+msgstr "Neue Änderungen von »%s« holen"
 
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:386
-msgid "Create New Repository"
-msgstr "Neues Projektarchiv"
+#: lib/transport.tcl:40
+#, fuzzy
+msgid "remote prune all remotes"
+msgstr "Aufräumen von »%s«"
 
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr "Neu..."
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Übernahmezweige aufräumen und entfernen, die in »%s« gelöscht wurden"
 
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:471
-msgid "Clone Existing Repository"
-msgstr "Projektarchiv klonen"
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr "Klonen..."
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:1016
-msgid "Open Existing Repository"
-msgstr "Projektarchiv öffnen"
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr "Öffnen..."
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr "Zuletzt benutzte Projektarchive"
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr "Zuletzt benutztes Projektarchiv öffnen:"
-
-#: lib/choose_repository.tcl:306 lib/choose_repository.tcl:313
-#: lib/choose_repository.tcl:320
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Projektarchiv »%s« konnte nicht erstellt werden:"
+msgid "push %s"
+msgstr "»%s« versenden..."
 
-#: lib/choose_repository.tcl:391
-msgid "Directory:"
-msgstr "Verzeichnis:"
-
-#: lib/choose_repository.tcl:423 lib/choose_repository.tcl:550
-#: lib/choose_repository.tcl:1052
-msgid "Git Repository"
-msgstr "Git Projektarchiv"
-
-#: lib/choose_repository.tcl:448
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Directory %s already exists."
-msgstr "Verzeichnis »%s« existiert bereits."
+msgid "Pushing changes to %s"
+msgstr "Änderungen nach »%s« versenden"
 
-#: lib/choose_repository.tcl:452
+#: lib/transport.tcl:93
 #, tcl-format
-msgid "File %s already exists."
-msgstr "Datei »%s« existiert bereits."
+msgid "Mirroring to %s"
+msgstr "Spiegeln nach %s"
 
-#: lib/choose_repository.tcl:466
-msgid "Clone"
-msgstr "Klonen"
-
-#: lib/choose_repository.tcl:479
-msgid "Source Location:"
-msgstr "Herkunft:"
-
-#: lib/choose_repository.tcl:490
-msgid "Target Directory:"
-msgstr "Zielverzeichnis:"
-
-#: lib/choose_repository.tcl:502
-msgid "Clone Type:"
-msgstr "Art des Klonens:"
-
-#: lib/choose_repository.tcl:508
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Standard (schnell, teilweise redundant, Hardlinks)"
-
-#: lib/choose_repository.tcl:514
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Alles kopieren (langsamer, volle Redundanz)"
-
-#: lib/choose_repository.tcl:520
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Verknüpft (schnell, nicht empfohlen, kein Backup)"
-
-#: lib/choose_repository.tcl:556 lib/choose_repository.tcl:603
-#: lib/choose_repository.tcl:749 lib/choose_repository.tcl:819
-#: lib/choose_repository.tcl:1058 lib/choose_repository.tcl:1066
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Kein Git-Projektarchiv in »%s« gefunden."
+msgid "Pushing %s %s to %s"
+msgstr "%s %s nach %s versenden"
 
-#: lib/choose_repository.tcl:592
-msgid "Standard only available for local repository."
-msgstr "Standard ist nur für lokale Projektarchive verfügbar."
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Zweige versenden"
 
-#: lib/choose_repository.tcl:596
-msgid "Shared only available for local repository."
-msgstr "Verknüpft ist nur für lokale Projektarchive verfügbar."
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Lokale Zweige"
 
-#: lib/choose_repository.tcl:617
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "Projektarchiv »%s« existiert bereits."
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Ziel-Projektarchiv"
 
-#: lib/choose_repository.tcl:628
-msgid "Failed to configure origin"
-msgstr "Der Ursprungsort konnte nicht eingerichtet werden"
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Externes Archiv:"
 
-#: lib/choose_repository.tcl:640
-msgid "Counting objects"
-msgstr "Objekte werden gezählt"
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Adresse:"
 
-#: lib/choose_repository.tcl:641
-msgid "buckets"
-msgstr "Buckets"
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Netzwerk-Einstellungen"
 
-#: lib/choose_repository.tcl:665
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Kopien von Objekten/Info/Alternates konnten nicht erstellt werden: %s"
-
-#: lib/choose_repository.tcl:701
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Von »%s« konnte nichts geklont werden."
-
-#: lib/choose_repository.tcl:703 lib/choose_repository.tcl:917
-#: lib/choose_repository.tcl:929
-msgid "The 'master' branch has not been initialized."
-msgstr "Der »master«-Zweig wurde noch nicht initialisiert."
-
-#: lib/choose_repository.tcl:716
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Hardlinks nicht verfügbar. Stattdessen wird kopiert."
-
-#: lib/choose_repository.tcl:728
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Kopieren von »%s«"
-
-#: lib/choose_repository.tcl:759
-msgid "Copying objects"
-msgstr "Objektdatenbank kopieren"
-
-#: lib/choose_repository.tcl:760
-msgid "KiB"
-msgstr "KB"
-
-#: lib/choose_repository.tcl:784
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Objekt kann nicht kopiert werden: %s"
-
-#: lib/choose_repository.tcl:794
-msgid "Linking objects"
-msgstr "Objekte verlinken"
-
-#: lib/choose_repository.tcl:795
-msgid "objects"
-msgstr "Objekte"
-
-#: lib/choose_repository.tcl:803
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Für Objekt konnte kein Hardlink erstellt werden: %s"
-
-#: lib/choose_repository.tcl:858
-msgid "Cannot fetch branches and objects.  See console output for details."
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
 msgstr ""
-"Zweige und Objekte konnten nicht angefordert werden.  Kontrollieren Sie die "
-"Ausgaben auf der Konsole für weitere Angaben."
+"Überschreiben von existierenden Zweigen erzwingen (könnte Änderungen löschen)"
 
-#: lib/choose_repository.tcl:869
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-"Markierungen konnten nicht angefordert werden.  Kontrollieren Sie die "
-"Ausgaben auf der Konsole für weitere Angaben."
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Kompaktes Datenformat benutzen (für langsame Netzverbindungen)"
 
-#: lib/choose_repository.tcl:893
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-"Die Zweigspitze (HEAD) konnte nicht gefunden werden.  Kontrollieren Sie die "
-"Ausgaben auf der Konsole für weitere Angaben."
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Mit Markierungen übertragen"
 
-#: lib/choose_repository.tcl:902
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Verzeichnis »%s« kann nicht aufgeräumt werden."
-
-#: lib/choose_repository.tcl:908
-msgid "Clone failed."
-msgstr "Klonen fehlgeschlagen."
-
-#: lib/choose_repository.tcl:915
-msgid "No default branch obtained."
-msgstr "Kein voreingestellter Zweig gefunden."
-
-#: lib/choose_repository.tcl:926
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "»%s« wurde nicht als Version gefunden."
-
-#: lib/choose_repository.tcl:938
-msgid "Creating working directory"
-msgstr "Arbeitskopie erstellen"
-
-#: lib/choose_repository.tcl:939 lib/index.tcl:67 lib/index.tcl:130
-#: lib/index.tcl:198
-msgid "files"
-msgstr "Dateien"
-
-#: lib/choose_repository.tcl:968
-msgid "Initial file checkout failed."
-msgstr "Erstellen der Arbeitskopie fehlgeschlagen."
-
-#: lib/choose_repository.tcl:1011
-msgid "Open"
-msgstr "Öffnen"
-
-#: lib/choose_repository.tcl:1021
-msgid "Repository:"
-msgstr "Projektarchiv:"
-
-#: lib/choose_repository.tcl:1072
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Projektarchiv »%s« konnte nicht geöffnet werden."
-
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "Abgetrennte Arbeitskopie-Version"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Version Regexp-Ausdruck:"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Lokaler Zweig"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Übernahmezweig"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Markierung"
-
-#: lib/choose_rev.tcl:317
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Ungültige Version: %s"
-
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Keine Version ausgewählt."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "Versions-Ausdruck ist leer."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Aktualisiert"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
+msgid "%s (%s): Push"
 msgstr ""
-"Keine Version zur Nachbesserung vorhanden.\n"
-"\n"
-"Sie sind dabei, die erste Version zu übertragen. Es gibt keine existierende "
-"Version, die Sie nachbessern könnten.\n"
 
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Nachbesserung währen Zusammenführung nicht möglich.\n"
-"\n"
-"Sie haben das Zusammenführen von Versionen angefangen, aber noch nicht "
-"beendet. Sie können keine vorige Übertragung nachbessern, solange eine "
-"unfertige Zusammenführung existiert. Dazu müssen Sie die Zusammenführung "
-"beenden oder abbrechen.\n"
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "Externes Archiv hinzufügen"
 
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Fehler beim Laden der Versionsdaten für Nachbessern:"
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Neues externes Archiv hinzufügen"
 
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Benutzername konnte nicht bestimmt werden:"
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Hinzufügen"
 
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Ungültiger Wert von GIT_COMMITTER_INDENT:"
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Einzelheiten des externen Archivs"
 
-#: lib/commit.tcl:129
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "Warning: Tcl/Tk unterstützt die Zeichencodierung »%s« nicht."
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Name:"
 
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"Der letzte geladene Status stimmt nicht mehr mit dem Projektarchiv überein.\n"
-"\n"
-"Ein anderes Git-Programm hat das Projektarchiv seit dem letzten Laden "
-"geändert.  Vor dem Eintragen einer neuen Version muss neu geladen werden.\n"
-"\n"
-"Es wird gleich neu geladen.\n"
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Adresse:"
 
-#: lib/commit.tcl:172
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"Nicht zusammengeführte Dateien können nicht eingetragen werden.\n"
-"\n"
-"Die Datei »%s« hat noch nicht aufgelöste Zusammenführungs-Konflikte. Sie "
-"müssen diese Konflikte auflösen, bevor Sie eintragen können.\n"
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Weitere Aktion jetzt"
 
-#: lib/commit.tcl:180
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Unbekannter Dateizustand »%s«.\n"
-"\n"
-"Datei »%s« kann nicht eingetragen werden.\n"
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Gleich anfordern"
 
-#: lib/commit.tcl:188
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Keine Änderungen vorhanden, die eingetragen werden könnten.\n"
-"\n"
-"Sie müssen mindestens eine Datei bereitstellen, bevor Sie eintragen können.\n"
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Externes Archiv initialisieren und dahin versenden"
 
-#: lib/commit.tcl:203
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Bitte geben Sie eine Versionsbeschreibung ein.\n"
-"\n"
-"Eine gute Versionsbeschreibung enthält folgende Abschnitte:\n"
-"\n"
-"- Erste Zeile: Eine Zusammenfassung, was man gemacht hat.\n"
-"\n"
-"- Zweite Zeile: Leerzeile\n"
-"\n"
-"- Rest: Eine ausführliche Beschreibung, warum diese Änderung hilfreich ist.\n"
-
-#: lib/commit.tcl:234
-msgid "Calling pre-commit hook..."
-msgstr "Aufrufen der Vor-Eintragen-Kontrolle (»pre-commit hook«)..."
-
-#: lib/commit.tcl:249
-msgid "Commit declined by pre-commit hook."
-msgstr "Eintragen abgelehnt durch Vor-Eintragen-Kontrolle (»pre-commit hook«)."
-
-#: lib/commit.tcl:272
-msgid "Calling commit-msg hook..."
-msgstr "Aufrufen der Versionsbeschreibungs-Kontrolle (»commit-message hook«)..."
-
-#: lib/commit.tcl:287
-msgid "Commit declined by commit-msg hook."
-msgstr ""
-"Eintragen abgelehnt durch Versionsbeschreibungs-Kontrolle (»commit-message "
-"hook«)."
-
-#: lib/commit.tcl:300
-msgid "Committing changes..."
-msgstr "Änderungen eintragen..."
-
-#: lib/commit.tcl:316
-msgid "write-tree failed:"
-msgstr "write-tree fehlgeschlagen:"
-
-#: lib/commit.tcl:317 lib/commit.tcl:361 lib/commit.tcl:382
-msgid "Commit failed."
-msgstr "Eintragen fehlgeschlagen."
-
-#: lib/commit.tcl:334
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Version »%s« scheint beschädigt zu sein"
-
-#: lib/commit.tcl:339
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Keine Änderungen einzutragen.\n"
-"\n"
-"Es gibt keine geänderte Datei bei dieser Version und es wurde auch nichts "
-"zusammengeführt.\n"
-"\n"
-"Das Arbeitsverzeichnis wird daher jetzt neu geladen.\n"
-
-#: lib/commit.tcl:346
-msgid "No changes to commit."
-msgstr "Keine Änderungen, die eingetragen werden können."
-
-#: lib/commit.tcl:360
-msgid "commit-tree failed:"
-msgstr "commit-tree fehlgeschlagen:"
-
-#: lib/commit.tcl:381
-msgid "update-ref failed:"
-msgstr "update-ref fehlgeschlagen:"
-
-#: lib/commit.tcl:469
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Version %s übertragen: %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Verarbeitung. Bitte warten..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Erfolgreich"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Fehler: Kommando fehlgeschlagen"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Anzahl unverknüpfter Objekte"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Festplattenplatz von unverknüpften Objekten"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Anzahl komprimierter Objekte"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Anzahl Komprimierungseinheiten"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "Festplattenplatz von komprimierten Objekten"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Komprimierte Objekte, die zum Aufräumen vorgesehen sind"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "Dateien im Mülleimer"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Objektdatenbank komprimieren"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Die Objektdatenbank durch »fsck-objects« überprüfen lassen"
-
-#: lib/database.tcl:107
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Dieses Projektarchiv enthält ungefähr %i nicht verknüpfte Objekte.\n"
-"\n"
-"Für eine optimale Performance wird empfohlen, die Datenbank des Projektarchivs zu komprimieren.\n"
-"\n"
-"Soll die Datenbank jetzt komprimiert werden?"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Ungültiges Datum von Git: %s"
-
-#: lib/diff.tcl:64
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Keine Änderungen feststellbar.\n"
-"\n"
-"»%s« enthält keine Änderungen. Zwar wurde das Änderungsdatum dieser Datei von "
-"einem anderen Programm modifiziert, aber der Inhalt der Datei ist "
-"unverändert.\n"
-"\n"
-"Das Arbeitsverzeichnis wird jetzt neu geladen, um diese Änderung bei allen "
-"Dateien zu prüfen."
-
-#: lib/diff.tcl:104
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Vergleich von »%s« laden..."
-
-#: lib/diff.tcl:125
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-"LOKAL: gelöscht\n"
-"ANDERES:\n"
-
-#: lib/diff.tcl:130
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-"ANDERES: gelöscht\n"
-"LOKAL:\n"
-
-#: lib/diff.tcl:137
-msgid "LOCAL:\n"
-msgstr "LOKAL:\n"
-
-#: lib/diff.tcl:140
-msgid "REMOTE:\n"
-msgstr "ANDERES:\n"
-
-#: lib/diff.tcl:202 lib/diff.tcl:319
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Datei »%s« kann nicht angezeigt werden"
-
-#: lib/diff.tcl:203
-msgid "Error loading file:"
-msgstr "Fehler beim Laden der Datei:"
-
-#: lib/diff.tcl:210
-msgid "Git Repository (subproject)"
-msgstr "Git-Projektarchiv (Unterprojekt)"
-
-#: lib/diff.tcl:222
-msgid "* Binary file (not showing content)."
-msgstr "* Binärdatei (Inhalt wird nicht angezeigt)"
-
-#: lib/diff.tcl:227
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* Datei nicht unter Versionskontrolle, Dateigröße %d Bytes.\n"
-"* Nur erste %d Bytes werden angezeigt.\n"
-
-#: lib/diff.tcl:233
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-"\n"
-"* Datei nicht unter Versionskontrolle, hier abgeschnitten durch %s.\n"
-"* Zum Ansehen der vollständigen Datei externen Editor benutzen.\n"
-
-#: lib/diff.tcl:482
-msgid "Failed to unstage selected hunk."
-msgstr ""
-"Fehler beim Herausnehmen des gewählten Kontexts aus der Bereitstellung."
-
-#: lib/diff.tcl:489
-msgid "Failed to stage selected hunk."
-msgstr "Fehler beim Bereitstellen des gewählten Kontexts."
-
-#: lib/diff.tcl:568
-msgid "Failed to unstage selected line."
-msgstr "Fehler beim Herausnehmen der gewählten Zeile aus der Bereitstellung."
-
-#: lib/diff.tcl:576
-msgid "Failed to stage selected line."
-msgstr "Fehler beim Bereitstellen der gewählten Zeile."
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Voreinstellung"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Systemweit (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Andere"
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "Fehler"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "Warnung"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr ""
-"Sie müssen die obigen Fehler zuerst beheben, bevor Sie eintragen können."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Bereitstellung kann nicht wieder freigegeben werden."
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Fehler in Bereitstellung"
-
-#: lib/index.tcl:17
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"Das Aktualisieren der Git-Bereitstellung ist fehlgeschlagen. Eine allgemeine "
-"Git-Aktualisierung wird jetzt gestartet, um git-gui wieder mit git zu "
-"synchronisieren."
-
-#: lib/index.tcl:28
-msgid "Continue"
-msgstr "Fortsetzen"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Bereitstellung freigeben"
-
-#: lib/index.tcl:289
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Datei »%s« aus der Bereitstellung herausnehmen"
-
-#: lib/index.tcl:328
-msgid "Ready to commit."
-msgstr "Bereit zum Eintragen."
-
-#: lib/index.tcl:341
-#, tcl-format
-msgid "Adding %s"
-msgstr "»%s« hinzufügen..."
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Änderungen in Datei »%s« verwerfen?"
-
-#: lib/index.tcl:400
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Änderungen in den gewählten %i Dateien verwerfen?"
-
-#: lib/index.tcl:408
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Alle nicht bereitgestellten Änderungen werden beim Verwerfen verloren gehen."
-
-#: lib/index.tcl:411
-msgid "Do Nothing"
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
 msgstr "Nichts tun"
 
-#: lib/index.tcl:429
-msgid "Reverting selected files"
-msgstr "Änderungen in gewählten Dateien verwerfen"
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Bitte geben Sie einen Namen des externen Archivs an."
 
-#: lib/index.tcl:433
+#: lib/remote_add.tcl:113
 #, tcl-format
-msgid "Reverting %s"
-msgstr "Änderungen in %s verwerfen"
+msgid "'%s' is not an acceptable remote name."
+msgstr "»%s« ist kein zulässiger Name eines externen Archivs."
+
+#: lib/remote_add.tcl:124
+#, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr ""
+"Fehler beim Hinzufügen des externen Archivs »%s« aus Herkunftsort »%s«."
+
+#: lib/remote_add.tcl:133
+#, tcl-format
+msgid "Fetching the %s"
+msgstr "»%s« anfordern"
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr ""
+"Initialisieren eines externen Archivs an Adresse »%s« ist nicht möglich."
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr "Einrichten von »%s« an »%s«"
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Starten..."
+
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Datei-Browser"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr "%s laden..."
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Nach oben]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Dateien des Zweigs durchblättern"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Dateien des Zweigs durchblättern"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Blättern"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Version"
 
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Zusammenführen kann nicht gleichzeitig mit Nachbessern durchgeführt werden.\n"
 "\n"
@@ -1790,13 +1021,14 @@ msgstr ""
 "zusammenführen können.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Der letzte geladene Status stimmt nicht mehr mit dem Projektarchiv überein.\n"
 "\n"
@@ -1806,14 +1038,14 @@ msgstr ""
 "Es wird gleich neu geladen.\n"
 
 #: lib/merge.tcl:45
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "Zusammenführung mit Konflikten.\n"
 "\n"
@@ -1823,14 +1055,14 @@ msgstr ""
 "danach kann eine neue Zusammenführung begonnen werden.\n"
 
 #: lib/merge.tcl:55
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "Es liegen Änderungen vor.\n"
 "\n"
@@ -1839,49 +1071,57 @@ msgstr ""
 "Reihenfolge können Sie mögliche Konflikte beim Zusammenführen wesentlich "
 "einfacher beheben oder abbrechen.\n"
 
-#: lib/merge.tcl:107
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s von %s"
 
-#: lib/merge.tcl:120
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Zusammenführen von %s und %s..."
 
-#: lib/merge.tcl:131
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "Zusammenführen erfolgreich abgeschlossen."
 
-#: lib/merge.tcl:133
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "Zusammenführen fehlgeschlagen. Konfliktauflösung ist notwendig."
 
-#: lib/merge.tcl:158
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Zusammenführen in »%s«"
 
-#: lib/merge.tcl:177
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Zusammenzuführende Version"
 
-#: lib/merge.tcl:212
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "Abbruch der Nachbesserung ist nicht möglich.\n"
 "\n"
 "Sie müssen die Nachbesserung der Version abschließen.\n"
 
-#: lib/merge.tcl:222
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Zusammenführen abbrechen?\n"
@@ -1891,12 +1131,13 @@ msgstr ""
 "\n"
 "Zusammenführen jetzt abbrechen?"
 
-#: lib/merge.tcl:228
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Änderungen zurücksetzen?\n"
@@ -1906,418 +1147,81 @@ msgstr ""
 "\n"
 "Änderungen jetzt zurücksetzen?"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Abbruch"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "Dateien zurückgesetzt"
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "Abbruch fehlgeschlagen."
 
-#: lib/merge.tcl:269
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "Abbruch durchgeführt. Bereit."
 
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Konflikt durch Basisversion ersetzen?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Konflikt durch diesen Zweig ersetzen?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Konflikt durch anderen Zweig ersetzen?"
-
-#: lib/mergetool.tcl:14
+#: lib/tools.tcl:76
 #, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Hinweis: Der Vergleich zeigt nur konfliktverursachende Änderungen an.\n"
-"\n"
-"»%s« wird überschrieben.\n"
-"\n"
-"Diese Operation kann nur rückgängig gemacht werden, wenn die\n"
-"Zusammenführung erneut gestartet wird."
+msgid "Running %s requires a selected file."
+msgstr "Um »%s« zu starten, muss eine Datei ausgewählt sein."
 
-#: lib/mergetool.tcl:45
+#: lib/tools.tcl:92
+#, fuzzy, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Wollen Sie %s wirklich starten?"
+
+#: lib/tools.tcl:96
 #, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr "Datei »%s« hat nicht aufgelöste Konflikte. Trotzdem bereitstellen?"
+msgid "Are you sure you want to run %s?"
+msgstr "Wollen Sie %s wirklich starten?"
 
-#: lib/mergetool.tcl:60
+#: lib/tools.tcl:118
 #, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Auflösung hinzugefügt für %s"
+msgid "Tool: %s"
+msgstr "Werkzeug: %s"
 
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-"Konflikte durch gelöschte Dateien oder symbolische Links können nicht durch "
-"das Zusamenführungswerkzeug gelöst werden."
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "Konflikt-Datei existiert nicht"
-
-#: lib/mergetool.tcl:264
+#: lib/tools.tcl:119
 #, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "Kein GUI Zusammenführungswerkzeug: »%s«"
+msgid "Running: %s"
+msgstr "Starten: %s"
 
-#: lib/mergetool.tcl:268
+#: lib/tools.tcl:158
 #, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "Unbekanntes Zusammenführungswerkzeug: »%s«"
+msgid "Tool completed successfully: %s"
+msgstr "Werkzeug erfolgreich abgeschlossen: %s"
 
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr "Zusammenführungswerkzeug läuft bereits. Soll es abgebrochen werden?"
-
-#: lib/mergetool.tcl:323
+#: lib/tools.tcl:160
 #, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Fehler beim Abrufen der Dateiversionen:\n"
-"%s"
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-"Zusammenführungswerkzeug konnte nicht gestartet werden:\n"
-"\n"
-"%s"
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr "Zusammenführungswerkzeug starten..."
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr "Zusammenführungswerkzeug fehlgeschlagen."
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr "Ungültige globale Zeichenkodierung »%s«"
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr "Ungültige Archiv-Zeichenkodierung »%s«"
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr "Voreinstellungen wiederherstellen"
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr "Speichern"
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr "Projektarchiv %s"
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr "Global (Alle Projektarchive)"
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr "Benutzername"
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr "E-Mail-Adresse"
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr "Zusammenführungs-Versionen zusammenfassen"
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr "Ausführlichkeit der Zusammenführen-Meldungen"
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr "Vergleichsstatistik nach Zusammenführen anzeigen"
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr "Zusammenführungswerkzeug"
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr "Auf Dateiänderungsdatum verlassen"
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr "Übernahmezweige aufräumen während Anforderung"
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr "Passend zu Übernahmezweig"
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr "Kopie-Annotieren nur bei geänderten Dateien"
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr "Mindestzahl Zeichen für Kopie-Annotieren"
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr "Anzahl Tage für Historien-Kontext"
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr "Anzahl der Kontextzeilen beim Vergleich"
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr "Textbreite der Versionsbeschreibung"
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr "Namensvorschlag für neue Zweige"
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr "Voreingestellte Zeichenkodierung"
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr "Ändern"
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr "Wörterbuch Rechtschreibprüfung:"
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr "Schriftart ändern"
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr "%s wählen"
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr "pt."
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr "Optionen konnten nicht gespeichert werden:"
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
-msgstr "Externes Archiv hinzufügen"
-
-#: lib/remote_add.tcl:24
-msgid "Add New Remote"
-msgstr "Neues externes Archiv hinzufügen"
-
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
-msgid "Add"
-msgstr "Hinzufügen"
-
-#: lib/remote_add.tcl:37
-msgid "Remote Details"
-msgstr "Einzelheiten des externen Archivs"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Adresse:"
-
-#: lib/remote_add.tcl:62
-msgid "Further Action"
-msgstr "Weitere Aktion jetzt"
-
-#: lib/remote_add.tcl:65
-msgid "Fetch Immediately"
-msgstr "Gleich anfordern"
-
-#: lib/remote_add.tcl:71
-msgid "Initialize Remote Repository and Push"
-msgstr "Externes Archiv initialisieren und dahin versenden"
-
-#: lib/remote_add.tcl:77
-msgid "Do Nothing Else Now"
-msgstr "Nichts tun"
-
-#: lib/remote_add.tcl:101
-msgid "Please supply a remote name."
-msgstr "Bitte geben Sie einen Namen des externen Archivs an."
-
-#: lib/remote_add.tcl:114
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "»%s« ist kein zulässiger Name eines externen Archivs."
-
-#: lib/remote_add.tcl:125
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Fehler beim Hinzufügen des externen Archivs »%s« aus Herkunftsort »%s«."
-
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "»%s« anfordern"
-
-#: lib/remote_add.tcl:134
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "»%s« anfordern"
-
-#: lib/remote_add.tcl:157
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Initialisieren eines externen Archivs an Adresse »%s« ist nicht möglich."
-
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:63
-#: lib/transport.tcl:81
-#, tcl-format
-msgid "push %s"
-msgstr "»%s« versenden..."
-
-#: lib/remote_add.tcl:164
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "Einrichten von »%s« an »%s«"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Zweig in externem Archiv löschen"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "In Projektarchiv"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:134
-msgid "Remote:"
-msgstr "Externes Archiv:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:149
-msgid "Arbitrary Location:"
-msgstr "Adresse:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Zweige"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Nur löschen, wenn"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Zusammengeführt mit:"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "Für »Zusammenführen mit« muss ein Zweig angegeben werden."
-
-#: lib/remote_branch_delete.tcl:184
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-"Folgende Zweige sind noch nicht mit »%s« zusammengeführt:\n"
-"\n"
-" - %s"
-
-#: lib/remote_branch_delete.tcl:189
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-"Ein oder mehrere Zusammenführungen sind fehlgeschlagen, da Sie nicht die "
-"notwendigen Versionen vorher angefordert haben.  Sie sollten versuchen, "
-"zuerst von »%s« anzufordern."
-
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Bitte wählen Sie mindestens einen Zweig, der gelöscht werden soll."
-
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Zweige auf »%s« werden gelöscht"
-
-#: lib/remote_branch_delete.tcl:292
-msgid "No repository selected."
-msgstr "Kein Projektarchiv ausgewählt."
-
-#: lib/remote_branch_delete.tcl:297
-#, tcl-format
-msgid "Scanning %s..."
-msgstr "»%s« laden..."
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr "Externes Archiv entfernen"
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr "Aufräumen von"
-
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr "Anfordern von"
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr "Versenden nach"
-
-#: lib/search.tcl:21
-msgid "Find:"
-msgstr "Suchen:"
-
-#: lib/search.tcl:23
-msgid "Next"
-msgstr "Nächster"
-
-#: lib/search.tcl:24
-msgid "Prev"
-msgstr "Voriger"
-
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
-msgstr "Groß-/Kleinschreibung unterscheiden"
-
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "Fehler beim Schreiben der Verknüpfung:"
-
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "Fehler beim Erstellen des Icons:"
+msgid "Tool failed: %s"
+msgstr "Werkzeug fehlgeschlagen: %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Auf Zweig umstellen"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Auf Zweig umstellen"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Umstellen"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Optionen"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Übernahmezweig anfordern"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Verbindung zu lokalem Zweig lösen"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -2356,6 +1260,1019 @@ msgstr "Unerwartetes EOF vom Rechtschreibprüfungsprogramm"
 msgid "Spell Checker Failed"
 msgstr "Rechtschreibprüfung fehlgeschlagen"
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s ... %*i von %*i %s (%3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Keine Änderungen feststellbar.\n"
+"\n"
+"»%s« enthält keine Änderungen. Zwar wurde das Änderungsdatum dieser Datei "
+"von einem anderen Programm modifiziert, aber der Inhalt der Datei ist "
+"unverändert.\n"
+"\n"
+"Das Arbeitsverzeichnis wird jetzt neu geladen, um diese Änderung bei allen "
+"Dateien zu prüfen."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Vergleich von »%s« laden..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"LOKAL: gelöscht\n"
+"ANDERES:\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"ANDERES: gelöscht\n"
+"LOKAL:\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "LOKAL:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "ANDERES:\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Datei »%s« kann nicht angezeigt werden"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Fehler beim Laden der Datei:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Git-Projektarchiv (Unterprojekt)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Binärdatei (Inhalt wird nicht angezeigt)"
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* Datei nicht unter Versionskontrolle, hier abgeschnitten durch %s.\n"
+"* Zum Ansehen der vollständigen Datei externen Editor benutzen.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Fehler beim Laden des Vergleichs:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr ""
+"Fehler beim Herausnehmen des gewählten Kontexts aus der Bereitstellung."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Fehler beim Bereitstellen des gewählten Kontexts."
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Fehler beim Herausnehmen der gewählten Zeile aus der Bereitstellung."
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Fehler beim Bereitstellen der gewählten Zeile."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Versenden nach"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Externes Archiv entfernen"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Aufräumen von"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Anfordern von"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Auswählen"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Schriftfamilie"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Schriftgröße"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Schriftbeispiel"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Dies ist ein Beispieltext.\n"
+"Wenn Ihnen dieser Text gefällt, sollten Sie diese Schriftart wählen."
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr "Ungültige globale Zeichenkodierung »%s«"
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr "Ungültige Archiv-Zeichenkodierung »%s«"
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Voreinstellungen wiederherstellen"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Speichern"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "Projektarchiv %s"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Global (Alle Projektarchive)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Benutzername"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "E-Mail-Adresse"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "Zusammenführungs-Versionen zusammenfassen"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Ausführlichkeit der Zusammenführen-Meldungen"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Vergleichsstatistik nach Zusammenführen anzeigen"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr "Zusammenführungswerkzeug"
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "Auf Dateiänderungsdatum verlassen"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr "Übernahmezweige aufräumen während Anforderung"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "Passend zu Übernahmezweig"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr "Kopie-Annotieren nur bei geänderten Dateien"
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Zuletzt benutzte Projektarchive"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr "Mindestzahl Zeichen für Kopie-Annotieren"
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr "Anzahl Tage für Historien-Kontext"
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Anzahl der Kontextzeilen beim Vergleich"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Textbreite der Versionsbeschreibung"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Namensvorschlag für neue Zweige"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr "Voreingestellte Zeichenkodierung"
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr "Ändern"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Wörterbuch Rechtschreibprüfung:"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Schriftart ändern"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "%s wählen"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "pt."
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "Optionen konnten nicht gespeichert werden:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Konflikt durch Basisversion ersetzen?"
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Konflikt durch diesen Zweig ersetzen?"
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Konflikt durch anderen Zweig ersetzen?"
+
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"Hinweis: Der Vergleich zeigt nur konfliktverursachende Änderungen an.\n"
+"\n"
+"»%s« wird überschrieben.\n"
+"\n"
+"Diese Operation kann nur rückgängig gemacht werden, wenn die\n"
+"Zusammenführung erneut gestartet wird."
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr "Datei »%s« hat nicht aufgelöste Konflikte. Trotzdem bereitstellen?"
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr "Auflösung hinzugefügt für %s"
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+"Konflikte durch gelöschte Dateien oder symbolische Links können nicht durch "
+"das Zusamenführungswerkzeug gelöst werden."
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "Konflikt-Datei existiert nicht"
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "Kein GUI Zusammenführungswerkzeug: »%s«"
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr "Unbekanntes Zusammenführungswerkzeug: »%s«"
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "Zusammenführungswerkzeug läuft bereits. Soll es abgebrochen werden?"
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Fehler beim Abrufen der Dateiversionen:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+"Zusammenführungswerkzeug konnte nicht gestartet werden:\n"
+"\n"
+"%s"
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "Zusammenführungswerkzeug starten..."
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "Zusammenführungswerkzeug fehlgeschlagen."
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "Werkzeug hinzufügen"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "Neues Kommando für Werkzeug hinzufügen"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "Global hinzufügen"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "Einzelheiten des Werkzeugs"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "Benutzen Sie einen Schrägstrich »/«, um Untermenüs zu erstellen:"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "Kommando:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "Bestätigungsfrage vor Starten anzeigen"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr "Benutzer nach Version fragen (setzt $REVISION)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "Benutzer nach zusätzlichen Argumenten fragen (setzt $ARGS)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "Kein Ausgabefenster zeigen"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "Nur starten, wenn ein Vergleich gewählt ist ($FILENAME ist nicht leer)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "Bitte geben Sie einen Werkzeugnamen an."
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "Werkzeug »%s« existiert bereits."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+"Werkzeug konnte nicht hinzugefügt werden:\n"
+"\n"
+"%s"
+
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "Werkzeug entfernen"
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "Werkzeugkommandos entfernen"
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "Entfernen"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(Werkzeuge für lokales Archiv werden in Blau angezeigt)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Systemweit (%s)"
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "Kommando aufrufen: %s"
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "Argumente"
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "Ok"
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Suchen:"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Nächster"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Voriger"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Desktop-Icon erstellen"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Fehler beim Schreiben der Verknüpfung:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Fehler beim Erstellen des Icons:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Zweig umbenennen"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Zweig umbenennen"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Umbenennen"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Zweig:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Neuer Name:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Bitte wählen Sie einen Zweig zum umbenennen."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Bitte geben Sie einen Zweignamen an."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "»%s« ist kein zulässiger Zweigname."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Fehler beim Umbenennen von »%s«."
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Zweig in externem Archiv löschen"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Zweig in externem Archiv löschen"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "In Projektarchiv"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Zweige"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Nur löschen, wenn"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Zusammengeführt mit:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Immer (Keine Zusammenführungsprüfung)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "Für »Zusammenführen mit« muss ein Zweig angegeben werden."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"Folgende Zweige sind noch nicht mit »%s« zusammengeführt:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Ein oder mehrere Zusammenführungen sind fehlgeschlagen, da Sie nicht die "
+"notwendigen Versionen vorher angefordert haben.  Sie sollten versuchen, "
+"zuerst von »%s« anzufordern."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Bitte wählen Sie mindestens einen Zweig, der gelöscht werden soll."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Das Wiederherstellen von gelöschten Zweigen ist nur mit größerem Aufwand "
+"möglich.\n"
+"\n"
+"Sollen die ausgewählten Zweige gelöscht werden?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Zweige auf »%s« werden gelöscht"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Kein Projektarchiv ausgewählt."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "»%s« laden..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Neues Projektarchiv"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Neu..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Projektarchiv klonen"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Klonen..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Projektarchiv öffnen"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Öffnen..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Zuletzt benutzte Projektarchive"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Zuletzt benutztes Projektarchiv öffnen:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Projektarchiv »%s« konnte nicht erstellt werden:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Erstellen"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Verzeichnis:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Git Projektarchiv"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "Verzeichnis »%s« existiert bereits."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Datei »%s« existiert bereits."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Klonen"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Herkunft:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Zielverzeichnis:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Art des Klonens:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Standard (schnell, teilweise redundant, Hardlinks)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Alles kopieren (langsamer, volle Redundanz)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Verknüpft (schnell, nicht empfohlen, kein Backup)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Kein Git-Projektarchiv in »%s« gefunden."
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Standard ist nur für lokale Projektarchive verfügbar."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "Verknüpft ist nur für lokale Projektarchive verfügbar."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "Projektarchiv »%s« existiert bereits."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Der Ursprungsort konnte nicht eingerichtet werden"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Objekte werden gezählt"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "Buckets"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Kopien von Objekten/Info/Alternates konnten nicht erstellt werden: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Von »%s« konnte nichts geklont werden."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "Der »master«-Zweig wurde noch nicht initialisiert."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Hardlinks nicht verfügbar. Stattdessen wird kopiert."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Kopieren von »%s«"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Objektdatenbank kopieren"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Objekt kann nicht kopiert werden: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Objekte verlinken"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "Objekte"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Für Objekt konnte kein Hardlink erstellt werden: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Zweige und Objekte konnten nicht angefordert werden.  Kontrollieren Sie die "
+"Ausgaben auf der Konsole für weitere Angaben."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+"Markierungen konnten nicht angefordert werden.  Kontrollieren Sie die "
+"Ausgaben auf der Konsole für weitere Angaben."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+"Die Zweigspitze (HEAD) konnte nicht gefunden werden.  Kontrollieren Sie die "
+"Ausgaben auf der Konsole für weitere Angaben."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Verzeichnis »%s« kann nicht aufgeräumt werden."
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Klonen fehlgeschlagen."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Kein voreingestellter Zweig gefunden."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "»%s« wurde nicht als Version gefunden."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Arbeitskopie erstellen"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "Dateien"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Kopieren von »%s«"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Erstellen der Arbeitskopie fehlgeschlagen."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Öffnen"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Projektarchiv:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Projektarchiv »%s« konnte nicht geöffnet werden."
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - eine grafische Oberfläche für Git."
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Datei-Browser"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Version:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Version kopieren"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Text suchen..."
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Klonen..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Volle Kopie-Erkennung"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Historien-Kontext anzeigen"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Elternversion annotieren"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "%s lesen..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Annotierungen für Kopieren/Verschieben werden geladen..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "Zeilen annotiert"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Annotierungen für ursprünglichen Ort werden geladen..."
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Annotierung vollständig."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Verarbeitung läuft"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "Annotierung läuft bereits."
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Intensive Kopie-Erkennung läuft..."
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Annotierung laden..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Autor:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Eintragender:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Ursprüngliche Datei:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Zweigspitze (»HEAD«) kann nicht gefunden werden:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Elternversion kann nicht gefunden werden:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Elternversion kann nicht angezeigt werden"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Ursprünglich von:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "In Datei:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Kopiert oder verschoben durch:"
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr "Keine Schlüssel gefunden."
@@ -2369,19 +2286,19 @@ msgstr "Öffentlicher Schlüssel gefunden in: %s"
 msgid "Generate Key"
 msgstr "Schlüssel erzeugen"
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "In Zwischenablage kopieren"
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "Ihr OpenSSH öffenlicher Schlüssel"
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Erzeugen..."
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2392,201 +2309,558 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr "Schlüsselerzeugung fehlgeschlagen."
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr "Schlüsselerzeugung erfolgreich, aber keine Schlüssel gefunden."
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "Ihr Schlüssel ist abgelegt in: %s"
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Zweig erstellen"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Neuen Zweig erstellen"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Zweigname"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Passend zu Übernahmezweig-Name"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Anfangsversion"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Existierenden Zweig aktualisieren:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Nein"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Nur Schnellzusammenführung"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Arbeitskopie umstellen nach Erstellen"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Bitte wählen Sie einen Übernahmezweig."
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s ... %*i von %*i %s (%3i%%)"
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "Übernahmezweig »%s« ist kein Zweig im externen Projektarchiv."
 
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "Werkzeug hinzufügen"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "Neues Kommando für Werkzeug hinzufügen"
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr "Global hinzufügen"
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr "Einzelheiten des Werkzeugs"
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "Benutzen Sie einen Schrägstrich »/«, um Untermenüs zu erstellen:"
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr "Kommando:"
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr "Bestätigungsfrage vor Starten anzeigen"
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr "Benutzer nach Version fragen (setzt $REVISION)"
-
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "Benutzer nach zusätzlichen Argumenten fragen (setzt $ARGS)"
-
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr "Kein Ausgabefenster zeigen"
-
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "Nur starten, wenn ein Vergleich gewählt ist ($FILENAME ist nicht leer)"
-
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr "Bitte geben Sie einen Werkzeugnamen an."
-
-#: lib/tools_dlg.tcl:129
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "Werkzeug »%s« existiert bereits."
-
-#: lib/tools_dlg.tcl:151
-#, tcl-format
+#: lib/commit.tcl:9
+#, fuzzy
 msgid ""
-"Could not add tool:\n"
-"%s"
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
 msgstr ""
-"Werkzeug konnte nicht hinzugefügt werden:\n"
+"Keine Version zur Nachbesserung vorhanden.\n"
 "\n"
-"%s"
+"Sie sind dabei, die erste Version zu übertragen. Es gibt keine existierende "
+"Version, die Sie nachbessern könnten.\n"
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
-msgstr "Werkzeug entfernen"
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Nachbesserung währen Zusammenführung nicht möglich.\n"
+"\n"
+"Sie haben das Zusammenführen von Versionen angefangen, aber noch nicht "
+"beendet. Sie können keine vorige Übertragung nachbessern, solange eine "
+"unfertige Zusammenführung existiert. Dazu müssen Sie die Zusammenführung "
+"beenden oder abbrechen.\n"
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
-msgstr "Werkzeugkommandos entfernen"
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Fehler beim Laden der Versionsdaten für Nachbessern:"
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
-msgstr "Entfernen"
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Benutzername konnte nicht bestimmt werden:"
 
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
-msgstr "(Werkzeuge für lokales Archiv werden in Blau angezeigt)"
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Ungültiger Wert von GIT_COMMITTER_INDENT:"
 
-#: lib/tools_dlg.tcl:297
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Run Command: %s"
-msgstr "Kommando aufrufen: %s"
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "Warning: Tcl/Tk unterstützt die Zeichencodierung »%s« nicht."
 
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
-msgstr "Argumente"
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Der letzte geladene Status stimmt nicht mehr mit dem Projektarchiv überein.\n"
+"\n"
+"Ein anderes Git-Programm hat das Projektarchiv seit dem letzten Laden "
+"geändert.  Vor dem Eintragen einer neuen Version muss neu geladen werden.\n"
+"\n"
+"Es wird gleich neu geladen.\n"
 
-#: lib/tools_dlg.tcl:348
-msgid "OK"
-msgstr "Ok"
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Nicht zusammengeführte Dateien können nicht eingetragen werden.\n"
+"\n"
+"Die Datei »%s« hat noch nicht aufgelöste Zusammenführungs-Konflikte. Sie "
+"müssen diese Konflikte auflösen, bevor Sie eintragen können.\n"
 
-#: lib/tools.tcl:75
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Unbekannter Dateizustand »%s«.\n"
+"\n"
+"Datei »%s« kann nicht eingetragen werden.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Keine Änderungen vorhanden, die eingetragen werden könnten.\n"
+"\n"
+"Sie müssen mindestens eine Datei bereitstellen, bevor Sie eintragen können.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Bitte geben Sie eine Versionsbeschreibung ein.\n"
+"\n"
+"Eine gute Versionsbeschreibung enthält folgende Abschnitte:\n"
+"\n"
+"- Erste Zeile: Eine Zusammenfassung, was man gemacht hat.\n"
+"\n"
+"- Zweite Zeile: Leerzeile\n"
+"\n"
+"- Rest: Eine ausführliche Beschreibung, warum diese Änderung hilfreich ist.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Aufrufen der Vor-Eintragen-Kontrolle (»pre-commit hook«)..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Eintragen abgelehnt durch Vor-Eintragen-Kontrolle (»pre-commit hook«)."
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr ""
+"Aufrufen der Versionsbeschreibungs-Kontrolle (»commit-message hook«)..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr ""
+"Eintragen abgelehnt durch Versionsbeschreibungs-Kontrolle (»commit-message "
+"hook«)."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Änderungen eintragen..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "write-tree fehlgeschlagen:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Eintragen fehlgeschlagen."
+
+#: lib/commit.tcl:356
 #, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "Um »%s« zu starten, muss eine Datei ausgewählt sein."
+msgid "Commit %s appears to be corrupt"
+msgstr "Version »%s« scheint beschädigt zu sein"
 
-#: lib/tools.tcl:90
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Keine Änderungen einzutragen.\n"
+"\n"
+"Es gibt keine geänderte Datei bei dieser Version und es wurde auch nichts "
+"zusammengeführt.\n"
+"\n"
+"Das Arbeitsverzeichnis wird daher jetzt neu geladen.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Keine Änderungen, die eingetragen werden können."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree fehlgeschlagen:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref fehlgeschlagen:"
+
+#: lib/commit.tcl:508
 #, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Wollen Sie %s wirklich starten?"
+msgid "Created commit %s: %s"
+msgstr "Version %s übertragen: %s"
 
-#: lib/tools.tcl:110
-#, tcl-format
-msgid "Tool: %s"
-msgstr "Werkzeug: %s"
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Zweig löschen"
 
-#: lib/tools.tcl:111
-#, tcl-format
-msgid "Running: %s"
-msgstr "Starten: %s"
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Lokalen Zweig löschen"
 
-#: lib/tools.tcl:149
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Werkzeug erfolgreich abgeschlossen: %s"
-
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "Werkzeug fehlgeschlagen: %s"
-
-#: lib/transport.tcl:7
-#, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Neue Änderungen von »%s« holen"
-
-#: lib/transport.tcl:18
-#, tcl-format
-msgid "remote prune %s"
-msgstr "Aufräumen von »%s«"
-
-#: lib/transport.tcl:19
-#, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Übernahmezweige aufräumen und entfernen, die in »%s« gelöscht wurden"
-
-#: lib/transport.tcl:26
-#, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Änderungen nach »%s« versenden"
-
-#: lib/transport.tcl:64
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr "Spiegeln nach %s"
-
-#: lib/transport.tcl:82
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "%s %s nach %s versenden"
-
-#: lib/transport.tcl:100
-msgid "Push Branches"
-msgstr "Zweige versenden"
-
-#: lib/transport.tcl:114
-msgid "Source Branches"
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
 msgstr "Lokale Zweige"
 
-#: lib/transport.tcl:131
-msgid "Destination Repository"
-msgstr "Ziel-Projektarchiv"
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Nur löschen, wenn zusammengeführt nach"
 
-#: lib/transport.tcl:169
-msgid "Transfer Options"
-msgstr "Netzwerk-Einstellungen"
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "Folgende Zweige sind noch nicht mit »%s« zusammengeführt:"
 
-#: lib/transport.tcl:171
-msgid "Force overwrite existing branch (may discard changes)"
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
 msgstr ""
-"Überschreiben von existierenden Zweigen erzwingen (könnte Änderungen löschen)"
 
-#: lib/transport.tcl:175
-msgid "Use thin pack (for slow network connections)"
-msgstr "Kompaktes Datenformat benutzen (für langsame Netzverbindungen)"
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+"Fehler beim Löschen der Zweige:\n"
+"%s"
 
-#: lib/transport.tcl:179
-msgid "Include tags"
-msgstr "Mit Markierungen übertragen"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Bereitstellung kann nicht wieder freigegeben werden."
+
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Fehler in Bereitstellung"
+
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Das Aktualisieren der Git-Bereitstellung ist fehlgeschlagen. Eine allgemeine "
+"Git-Aktualisierung wird jetzt gestartet, um git-gui wieder mit git zu "
+"synchronisieren."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Fortsetzen"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Bereitstellung freigeben"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Datei »%s« aus der Bereitstellung herausnehmen"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "Datei »%s« aus der Bereitstellung herausnehmen"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Bereit zum Eintragen."
+
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Änderungen in gewählten Dateien verwerfen"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "»%s« hinzufügen..."
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr ""
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Änderungen in Datei »%s« verwerfen?"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Änderungen in den gewählten %i Dateien verwerfen?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Alle nicht bereitgestellten Änderungen werden beim Verwerfen verloren gehen."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Nichts tun"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Zweige auf »%s« werden gelöscht"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Änderungen in den gewählten %i Dateien verwerfen?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Löschen"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Änderungen in gewählten Dateien verwerfen"
+
+#: lib/index.tcl:532
+#, tcl-format
+msgid "Reverting %s"
+msgstr "Änderungen in %s verwerfen"
+
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Voreinstellung"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr "Systemweit (%s)"
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Andere"
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Ungültiges Datum von Git: %s"
+
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Abgetrennte Arbeitskopie-Version"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Version Regexp-Ausdruck:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Lokaler Zweig"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Übernahmezweig"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Markierung"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Ungültige Version: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Keine Version ausgewählt."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "Versions-Ausdruck ist leer."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Aktualisiert"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Anzahl unverknüpfter Objekte"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Festplattenplatz von unverknüpften Objekten"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Anzahl komprimierter Objekte"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Anzahl Komprimierungseinheiten"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Festplattenplatz von komprimierten Objekten"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Komprimierte Objekte, die zum Aufräumen vorgesehen sind"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Dateien im Mülleimer"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Datenbankstatistik"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Objektdatenbank komprimieren"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Die Objektdatenbank durch »fsck-objects« überprüfen lassen"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Dieses Projektarchiv enthält ungefähr %i nicht verknüpfte Objekte.\n"
+"\n"
+"Für eine optimale Performance wird empfohlen, die Datenbank des "
+"Projektarchivs zu komprimieren.\n"
+"\n"
+"Soll die Datenbank jetzt komprimiert werden?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "Fehler"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "Warnung"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "Werkzeug fehlgeschlagen: %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr ""
+"Sie müssen die obigen Fehler zuerst beheben, bevor Sie eintragen können."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Displaying only %s of %s files."
+#~ msgstr "Nur %s von %s Dateien werden angezeigt."
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Datei nicht unter Versionskontrolle, Dateigröße %d Bytes.\n"
+#~ "* Nur erste %d Bytes werden angezeigt.\n"
+
+#~ msgid "Case-Sensitive"
+#~ msgstr "Groß-/Kleinschreibung unterscheiden"

--- a/po/el.po
+++ b/po/el.po
@@ -6,52 +6,53 @@ msgid ""
 msgstr ""
 "Project-Id-Version: el\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-03-14 07:18+0100\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2009-06-23 21:33+0300\n"
 "Last-Translator: Jimmy Angelakos <vyruss@hellug.gr>\n"
 "Language-Team: Greek <i18n@lists.hellug.gr>\n"
+"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Lokalize 0.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: git-gui.sh:41 git-gui.sh:634 git-gui.sh:648 git-gui.sh:661 git-gui.sh:744
-#: git-gui.sh:763
-msgid "git-gui: fatal error"
-msgstr "git-gui: κρίσιμο σφάλμα"
-
-#: git-gui.sh:593
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Μη έγκυρη γραμματοσειρά στο %s:"
 
-#: git-gui.sh:620
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Κύρια Γραμματοσειρά"
 
-#: git-gui.sh:621
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Γραμματοσειρά Διαφοράς/Κονσόλας"
 
-#: git-gui.sh:635
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: κρίσιμο σφάλμα"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Δε βρέθηκε το git στο PATH."
 
-#: git-gui.sh:662
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Αδύνατη η ανάγνωση στοιχειοσειράς έκδοσης Git:"
 
-#: git-gui.sh:680
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Δε μπορεί να ανιχνευτεί η έκδοση του Git. \n"
 "\n"
@@ -61,387 +62,526 @@ msgstr ""
 "\n"
 "Να υποτεθεί πως το '%s' είναι η έκδοση 1.5.0;\n"
 
-#: git-gui.sh:918
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Δε βρέθηκε φάκελος Git:"
 
-#: git-gui.sh:925
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Δεν είναι δυνατή η μετακίνηση στην κορυφή του φακέλου εργασίας:"
 
-#: git-gui.sh:932
-msgid "Cannot use funny .git directory:"
-msgstr "Δεν είναι δυνατή η χρήση περίεργου φακέλου .git:"
+#: git-gui.sh:1309
+#, fuzzy
+msgid "Cannot use bare repository:"
+msgstr "Δημιουργία Νέου Αποθετηρίου"
 
-#: git-gui.sh:937
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Δεν υπάρχει φάκελος εργασίας"
 
-#: git-gui.sh:1084 lib/checkout_op.tcl:283
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Ανανέωση κατάστασης αρχείου..."
 
-#: git-gui.sh:1149
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Ανίχνευση για τροποποιημένα αρχεία..."
 
-#: git-gui.sh:1324 lib/browser.tcl:246
+#: git-gui.sh:1627
+#, fuzzy
+msgid "Calling prepare-commit-msg hook..."
+msgstr "Γίνεται κλήση του commit-msg hook..."
+
+#: git-gui.sh:1644
+#, fuzzy
+msgid "Commit declined by prepare-commit-msg hook."
+msgstr "Η υποβολή απορρίφθηκε από το commit-msg hook."
+
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Έτοιμο."
 
-#: git-gui.sh:1590
+#: git-gui.sh:1966
+#, tcl-format
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
+
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Μη τροποποιημένο"
 
-#: git-gui.sh:1592
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Τροποποιημένο, μη σταδιοποιημένο"
 
-#: git-gui.sh:1593 git-gui.sh:1598
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Σταδιοποιημένο προς υποβολή"
 
-#: git-gui.sh:1594 git-gui.sh:1599
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Μέρη σταδιοποιημένα προς υποβολή"
 
-#: git-gui.sh:1595 git-gui.sh:1600
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Σταδιοποιημένο προς υποβολή, λείπει"
 
-#: git-gui.sh:1597
+#: git-gui.sh:2096
+#, fuzzy
+msgid "File type changed, not staged"
+msgstr "Μη παρακολουθούμενο, μη σταδιοποιημένο"
+
+#: git-gui.sh:2097 git-gui.sh:2098
+msgid "File type changed, old type staged for commit"
+msgstr ""
+
+#: git-gui.sh:2099
+msgid "File type changed, staged"
+msgstr ""
+
+#: git-gui.sh:2100
+msgid "File type change staged, modification not staged"
+msgstr ""
+
+#: git-gui.sh:2101
+msgid "File type change staged, file missing"
+msgstr ""
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Μη παρακολουθούμενο, μη σταδιοποιημένο"
 
-#: git-gui.sh:1602
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Λείπει"
 
-#: git-gui.sh:1603
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Σταδιοποιημένο προς αφαίρεση"
 
-#: git-gui.sh:1604
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Σταδιοποιημένο προς αφαίρεση, ακόμα παρόν"
 
-#: git-gui.sh:1606 git-gui.sh:1607 git-gui.sh:1608 git-gui.sh:1609
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Απαιτεί επίλυση συγχώνευσης"
 
-#: git-gui.sh:1644
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Γίνεται εκκίνηση του gitk... παρακαλώ περιμένετε..."
 
-#: git-gui.sh:1653
-#, tcl-format
-msgid ""
-"Unable to start gitk:\n"
-"\n"
-"%s does not exist"
-msgstr ""
-"Αδυναμία εκκίνησης του gitk:\n"
-"\n"
-"Το %s δεν υπάρχει"
+#: git-gui.sh:2164
+#, fuzzy
+msgid "Couldn't find gitk in PATH"
+msgstr "Δε βρέθηκε το git στο PATH."
 
-#: git-gui.sh:1860 lib/choose_repository.tcl:36
+#: git-gui.sh:2223
+#, fuzzy
+msgid "Couldn't find git gui in PATH"
+msgstr "Δε βρέθηκε το git στο PATH."
+
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Αποθετήριο"
 
-#: git-gui.sh:1861
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: git-gui.sh:1863 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Κλάδος"
 
-#: git-gui.sh:1866 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Υποβολή@@noun"
 
-#: git-gui.sh:1869 lib/merge.tcl:120 lib/merge.tcl:149 lib/merge.tcl:167
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Συγχώνευση"
 
-#: git-gui.sh:1870 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Απομακρυσμένο"
 
-#: git-gui.sh:1879
+#: git-gui.sh:2671
+msgid "Tools"
+msgstr ""
+
+#: git-gui.sh:2680
+msgid "Explore Working Copy"
+msgstr ""
+
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Περιήγηση Αρχείων Τρέχοντα Κλάδου"
 
-#: git-gui.sh:1883
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Περιήγηση Αρχείων Κλάδου..."
 
-#: git-gui.sh:1888
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Απεικόνιση Ιστορικού Τρέχοντα Κλάδου"
 
-#: git-gui.sh:1892
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Απεικόνιση Ιστορικού Όλων των Κλάδων"
 
-#: git-gui.sh:1899
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Περιήγηση Αρχείων του %s"
 
-#: git-gui.sh:1901
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Απεικόνιση Ιστορικού του %s"
 
-#: git-gui.sh:1906 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Στατιστικά Βάσης Δεδομένων"
 
-#: git-gui.sh:1909 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Συμπίεση Βάσης Δεδομένων"
 
-#: git-gui.sh:1912
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Επαλήθευση Βάσης Δεδομένων"
 
-#: git-gui.sh:1919 git-gui.sh:1923 git-gui.sh:1927 lib/shortcut.tcl:7
-#: lib/shortcut.tcl:39 lib/shortcut.tcl:71
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Δημιουργία Εικονιδίου Επιφάνειας Εργασίας"
 
-#: git-gui.sh:1932 lib/choose_repository.tcl:177 lib/choose_repository.tcl:185
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Έξοδος"
 
-#: git-gui.sh:1939
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Αναίρεση"
 
-#: git-gui.sh:1942
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Ξανά"
 
-#: git-gui.sh:1946 git-gui.sh:2443
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Αποκοπή"
 
-#: git-gui.sh:1949 git-gui.sh:2446 git-gui.sh:2520 git-gui.sh:2614
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: git-gui.sh:1952 git-gui.sh:2449
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Επικόλληση"
 
-#: git-gui.sh:1955 git-gui.sh:2452 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: git-gui.sh:1959 git-gui.sh:2456 git-gui.sh:2618 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Επιλογή Όλων"
 
-#: git-gui.sh:1968
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Δημιουργία..."
 
-#: git-gui.sh:1974
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Εξαγωγή..."
 
-#: git-gui.sh:1980
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Μετονομασία..."
 
-#: git-gui.sh:1985 git-gui.sh:2085
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Διαγραφή..."
 
-#: git-gui.sh:1990
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Επαναφορά..."
 
-#: git-gui.sh:2002 git-gui.sh:2389
-msgid "New Commit"
-msgstr "Νέα Υποβολή"
+#: git-gui.sh:2821
+msgid "Done"
+msgstr ""
 
-#: git-gui.sh:2010 git-gui.sh:2396
-msgid "Amend Last Commit"
-msgstr "Διόρθωση Τελευταίας Υποβολής"
-
-#: git-gui.sh:2019 git-gui.sh:2356 lib/remote_branch_delete.tcl:99
-msgid "Rescan"
-msgstr "Επανανίχνευση"
-
-#: git-gui.sh:2025
-msgid "Stage To Commit"
-msgstr "Σταδιοποίηση Προς Υποβολή"
-
-#: git-gui.sh:2031
-msgid "Stage Changed Files To Commit"
-msgstr "Σταδιοποίηση Αλλαγμένων Αρχείων Προς Υποβολή"
-
-#: git-gui.sh:2037
-msgid "Unstage From Commit"
-msgstr "Αποσταδιοποίηση Από Υποβολή"
-
-#: git-gui.sh:2042 lib/index.tcl:395
-msgid "Revert Changes"
-msgstr "Αναίρεση Αλλαγών"
-
-#: git-gui.sh:2049 git-gui.sh:2368 git-gui.sh:2467
-msgid "Sign Off"
-msgstr "Αποσύνδεση"
-
-#: git-gui.sh:2053 git-gui.sh:2372
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Υποβολή@@verb"
 
-#: git-gui.sh:2064
+#: git-gui.sh:2832 git-gui.sh:3317
+msgid "New Commit"
+msgstr "Νέα Υποβολή"
+
+#: git-gui.sh:2840 git-gui.sh:3324
+msgid "Amend Last Commit"
+msgstr "Διόρθωση Τελευταίας Υποβολής"
+
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
+msgid "Rescan"
+msgstr "Επανανίχνευση"
+
+#: git-gui.sh:2856
+msgid "Stage To Commit"
+msgstr "Σταδιοποίηση Προς Υποβολή"
+
+#: git-gui.sh:2862
+msgid "Stage Changed Files To Commit"
+msgstr "Σταδιοποίηση Αλλαγμένων Αρχείων Προς Υποβολή"
+
+#: git-gui.sh:2868
+msgid "Unstage From Commit"
+msgstr "Αποσταδιοποίηση Από Υποβολή"
+
+#: git-gui.sh:2874 lib/index.tcl:454
+msgid "Revert Changes"
+msgstr "Αναίρεση Αλλαγών"
+
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
+msgid "Show Less Context"
+msgstr "Προβολή Στενότερου Πλαισίου"
+
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
+msgid "Show More Context"
+msgstr "Προβολή Ευρύτερου Πλαισίου"
+
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
+msgid "Sign Off"
+msgstr "Αποσύνδεση"
+
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Τοπική Συγχώνευση..."
 
-#: git-gui.sh:2069
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Ακύρωση Συγχώνευσης..."
 
-#: git-gui.sh:2081
+#: git-gui.sh:2926 git-gui.sh:2954
+msgid "Add..."
+msgstr ""
+
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Ώθηση..."
 
-#: git-gui.sh:2092 lib/choose_repository.tcl:41
+#: git-gui.sh:2934
 #, fuzzy
-msgid "Apple"
-msgstr ""
+msgid "Delete Branch..."
+msgstr "Διαγραφή Κλάδου"
 
-#: git-gui.sh:2095 git-gui.sh:2117 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:50
+#: git-gui.sh:2944 git-gui.sh:3577
+msgid "Options..."
+msgstr "Επιλογές..."
+
+#: git-gui.sh:2955
+#, fuzzy
+msgid "Remove..."
+msgstr "Μετονομασία..."
+
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
+msgid "Help"
+msgstr "Βοήθεια"
+
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Περί %s"
 
-#: git-gui.sh:2099
-msgid "Preferences..."
-msgstr "Προτιμήσεις..."
-
-#: git-gui.sh:2107 git-gui.sh:2639
-msgid "Options..."
-msgstr "Επιλογές..."
-
-#: git-gui.sh:2113 lib/choose_repository.tcl:47
-msgid "Help"
-msgstr "Βοήθεια"
-
-#: git-gui.sh:2154
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Διαδικτυακή Τεκμηρίωση"
 
-#: git-gui.sh:2238
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
+msgid "Show SSH Key"
+msgstr ""
+
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "σφάλμα"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr "κρίσιμο: δε βρέθηκε η διαδρομή: %s: Δεν υπάρχει το αρχείο ή ο φάκελος"
 
-#: git-gui.sh:2271
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Τρέχων Κλάδος:"
 
-#: git-gui.sh:2292
-msgid "Staged Changes (Will Commit)"
-msgstr "Σταδιοποιημένες Αλλαγές (Θα Υποβληθούν)"
-
-#: git-gui.sh:2312
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Μη Σταδιοποιημένες Αλλαγές"
 
-#: git-gui.sh:2362
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Σταδιοποιημένες Αλλαγές (Θα Υποβληθούν)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Σταδιοποίηση Αλλαγών"
 
-#: git-gui.sh:2378 lib/transport.tcl:93 lib/transport.tcl:182
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Ώθηση"
 
-#: git-gui.sh:2408
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Αρχικό Μήνυμα Υποβολής:"
 
-#: git-gui.sh:2409
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Διορθωμένο Μήνυμα Υποβολής:"
 
-#: git-gui.sh:2410
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Διορθωμένο Αρχικό Μήνυμα Υποβολής:"
 
-#: git-gui.sh:2411
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Διορθωμένο Μήνυμα Υποβολής Συγχώνευσης:"
 
-#: git-gui.sh:2412
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Μήνυμα Υποβολής Συγχώνευσης:"
 
-#: git-gui.sh:2413
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Μήνυμα Υποβολής:"
 
-#: git-gui.sh:2459 git-gui.sh:2622 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Αντιγραφή Όλων"
 
-#: git-gui.sh:2483 lib/blame.tcl:107
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Αρχείο:"
 
-#: git-gui.sh:2589
-msgid "Apply/Reverse Hunk"
-msgstr "Εφαρμογή/Αντιστροφή Κομματιού"
-
-#: git-gui.sh:2595
-msgid "Show Less Context"
-msgstr "Προβολή Στενότερου Πλαισίου"
-
-#: git-gui.sh:2602
-msgid "Show More Context"
-msgstr "Προβολή Ευρύτερου Πλαισίου"
-
-#: git-gui.sh:2610
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Ανανέωση"
 
-#: git-gui.sh:2631
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Μείωση Μεγέθους Γραμματοσειράς"
 
-#: git-gui.sh:2635
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Αύξηση Μεγέθους Γραμματοσειράς"
 
-#: git-gui.sh:2646
+#: git-gui.sh:3573 lib/blame.tcl:294
+msgid "Encoding"
+msgstr ""
+
+#: git-gui.sh:3584
+msgid "Apply/Reverse Hunk"
+msgstr "Εφαρμογή/Αντιστροφή Κομματιού"
+
+#: git-gui.sh:3589
+#, fuzzy
+msgid "Apply/Reverse Line"
+msgstr "Εφαρμογή/Αντιστροφή Κομματιού"
+
+#: git-gui.sh:3608
+msgid "Run Merge Tool"
+msgstr ""
+
+#: git-gui.sh:3613
+msgid "Use Remote Version"
+msgstr ""
+
+#: git-gui.sh:3617
+msgid "Use Local Version"
+msgstr ""
+
+#: git-gui.sh:3621
+#, fuzzy
+msgid "Revert To Base"
+msgstr "Αναίρεση Αλλαγών"
+
+#: git-gui.sh:3639
+msgid "Visualize These Changes In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3643
+#, fuzzy
+msgid "Visualize Current Branch History In The Submodule"
+msgstr "Απεικόνιση Ιστορικού Τρέχοντα Κλάδου"
+
+#: git-gui.sh:3647
+#, fuzzy
+msgid "Visualize All Branch History In The Submodule"
+msgstr "Απεικόνιση Ιστορικού Όλων των Κλάδων"
+
+#: git-gui.sh:3652
+msgid "Start git gui In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Αποσταδιοποίηση Κομματιού Από Υποβολή"
 
-#: git-gui.sh:2648
+#: git-gui.sh:3689
+#, fuzzy
+msgid "Unstage Lines From Commit"
+msgstr "Αποσταδιοποίηση Από Υποβολή"
+
+#: git-gui.sh:3691
+#, fuzzy
+msgid "Unstage Line From Commit"
+msgstr "Αποσταδιοποίηση Από Υποβολή"
+
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Σταδιοποίηση Κομματιού Προς Υποβολή"
 
-#: git-gui.sh:2667
+#: git-gui.sh:3696
+#, fuzzy
+msgid "Stage Lines For Commit"
+msgstr "Σταδιοποίηση Κομματιού Προς Υποβολή"
+
+#: git-gui.sh:3698
+#, fuzzy
+msgid "Stage Line For Commit"
+msgstr "Σταδιοποίηση Κομματιού Προς Υποβολή"
+
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Γίνεται αρχικοποίηση..."
 
-#: git-gui.sh:2762
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Υπάρχουν πιθανά θέματα με το περιβάλλον.\n"
 "\n"
@@ -450,25 +590,26 @@ msgstr ""
 "από το %s:\n"
 "\n"
 
-#: git-gui.sh:2792
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Αυτό οφείλεται σε ένα γνωστό θέμα με το\n"
 "εκτελέσιμο Tcl που διανέμεται με το Cygwin."
 
-#: git-gui.sh:2797
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -477,293 +618,57 @@ msgstr ""
 "user.name και user.email στο προσωπικό σας\n"
 "αρχείο ~/.gitconfig .\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - ένα γραφικό περιβάλλον για το Git."
-
-#: lib/blame.tcl:77
-msgid "File Viewer"
-msgstr "Εφαρμογή Προβολής Αρχείου"
-
-#: lib/blame.tcl:81
-msgid "Commit:"
-msgstr "Υποβολή:"
-
-#: lib/blame.tcl:264
-msgid "Copy Commit"
-msgstr "Αντιγραφή Υποβολής"
-
-#: lib/blame.tcl:384
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Ανάγνωση %s..."
-
-#: lib/blame.tcl:488
-msgid "Loading copy/move tracking annotations..."
-msgstr "Γίνεται φόρτωση σχολίων παρακολούθησης αντιγραφής/μετακίνησης..."
-
-#: lib/blame.tcl:508
-msgid "lines annotated"
-msgstr "γραμμές σχολιασμένες"
-
-#: lib/blame.tcl:689
-msgid "Loading original location annotations..."
-msgstr "Γίνεται φόρτωση σχολίων αρχικής τοποθεσίας..."
-
-#: lib/blame.tcl:692
-msgid "Annotation complete."
-msgstr "Έγινε ολοκλήρωση του σχολιασμού."
-
-#: lib/blame.tcl:746
-msgid "Loading annotation..."
-msgstr "Φόρτωση σχολίου..."
-
-#: lib/blame.tcl:802
-msgid "Author:"
-msgstr "Δημιουργός:"
-
-#: lib/blame.tcl:806
-msgid "Committer:"
-msgstr "Υποβολέας:"
-
-#: lib/blame.tcl:811
-msgid "Original File:"
-msgstr "Αρχικό Αρχείο:"
-
-#: lib/blame.tcl:925
-msgid "Originally By:"
-msgstr "Αρχικά Από:"
-
-#: lib/blame.tcl:931
-msgid "In File:"
-msgstr "Στο Αρχείο:"
-
-#: lib/blame.tcl:936
-msgid "Copied Or Moved Here By:"
-msgstr "Αντιγράφηκε ή Μετακινήθηκε Εδώ Από:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Εξαγωγή Κλάδου"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Εξαγωγή"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:522 lib/choose_font.tcl:43 lib/merge.tcl:171
-#: lib/option.tcl:103 lib/remote_branch_delete.tcl:42 lib/transport.tcl:97
-msgid "Cancel"
-msgstr "Ακύρωση"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287
-msgid "Revision"
-msgstr "Αναθεώρηση"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:242
-msgid "Options"
-msgstr "Επιλογές"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Ανάκτηση Κλάδου Παρακολούθησης"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Αποκόλληση Από Τοπικό Κλάδο"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Δημιουργία Κλάδου"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Δημιουργία Νέου Κλάδου"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:371
-msgid "Create"
-msgstr "Δημιουργία"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Όνομα Κλάδου"
-
-#: lib/branch_create.tcl:43
-msgid "Name:"
-msgstr "Όνομα:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Συμφωνία Ονόματος Κλάδου Παρακολούθησης"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Αρχική Αναθεώρηση"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Ενημέρωση Υπάρχοντα Κλάδου:"
-
-#: lib/branch_create.tcl:75
-#, fuzzy
-msgid "No"
-msgstr "Όχι"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Συγχώνευση Επιτάχυνσης Μόνο"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:514
-msgid "Reset"
-msgstr "Επαναφορά"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Εξαγωγή Μετά τη Δημιουργία"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Παρακαλώ επιλέξτε έναν κλάδο παρακολούθησης."
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
-"Ο κλάδος παρακολούθησης %s δεν είναι κλάδος που βρίσκεται στο απομακρυσμένο "
-"αποθετήριο."
 
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Παρακαλώ δώστε ένα όνομα κλάδου."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "'%s' δεν είναι αποδεκτό όνομα κλάδου."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Διαγραφή Κλάδου"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Διαγραφή Τοπικού Κλάδου"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Τοπικοί Κλάδοι"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Διαγραφή Μόνο Εάν Είναι Συγχωνευμένο Με"
-
-#: lib/branch_delete.tcl:54
-msgid "Always (Do not perform merge test.)"
-msgstr "Πάντα (Μη διενεργηθεί δοκιμή συγχώνευσης.)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Οι εξής κλάδοι δεν είναι πλήρως συγχωνευμένοι με το %s:"
-
-#: lib/branch_delete.tcl:115
-msgid ""
-"Recovering deleted branches is difficult. \n"
-"\n"
-" Delete the selected branches?"
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
-"Η ανάκτηση διεγραμμένων κλάδων είναι δύσκολη.\n"
-"\n"
-"Διαγραφή των επιλεγμένων κλάδων;"
 
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-"Αποτυχία διαγραφής κλάδων:\n"
-"%s"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Γίνεται εργασία... Παρακαλώ περιμένετε..."
 
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Μετονομασία Κλάδου"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Κλείσιμο"
 
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Μετονομασία"
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Επιτυχία"
 
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Κλάδος:"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Σφάλμα: Η Εντολή Απέτυχε"
 
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Νέο Όνομα:"
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Παρακαλώ επιλέξτε κλάδο προς μετονομασία:"
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:179
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "Ο Κλάδος '%s' υπάρχει ήδη."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Αποτυχία μετονομασίας '%s'."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Γίνεται Εκκίνηση..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "Περιηγητής Αρχείων"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Γίνεται φόρτωση %s..."
-
-#: lib/browser.tcl:187
-#, fuzzy
-msgid "[Up To Parent]"
-msgstr "[Πάνω Προς Γονέα]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "Περιήγηση Αρχείων Κλάδου"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:387
-#: lib/choose_repository.tcl:474 lib/choose_repository.tcl:484
-#: lib/choose_repository.tcl:987
-msgid "Browse"
-msgstr "Περιήγηση"
-
-#: lib/checkout_op.tcl:79
+#: lib/checkout_op.tcl:85
 #, tcl-format
 msgid "Fetching %s from %s"
 msgstr "Ανάκτηση %s από το %s"
 
-#: lib/checkout_op.tcl:127
+#: lib/checkout_op.tcl:133
 #, tcl-format
 msgid "fatal: Cannot resolve %s"
 msgstr "κρίσιμο: Δε μπόρεσε να επιλυθεί το %s"
 
-#: lib/checkout_op.tcl:140 lib/console.tcl:81 lib/database.tcl:31
-msgid "Close"
-msgstr "Κλείσιμο"
-
-#: lib/checkout_op.tcl:169
+#: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
 msgstr "Ο Κλάδος '%s' δεν υπάρχει."
 
-#: lib/checkout_op.tcl:206
+#: lib/checkout_op.tcl:194
+#, fuzzy, tcl-format
+msgid "Failed to configure simplified git-pull for '%s'."
+msgstr "Αποτυχία ρύθμισης πηγής"
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "Ο Κλάδος '%s' υπάρχει ήδη."
+
+#: lib/checkout_op.tcl:229
 #, tcl-format
 msgid ""
 "Branch '%s' already exists.\n"
@@ -776,28 +681,29 @@ msgstr ""
 "Δε γίνεται συγχώνευση επιτάχυνσής του στο %s.\n"
 "Απαιτείται συγχώνευση."
 
-#: lib/checkout_op.tcl:220
+#: lib/checkout_op.tcl:243
 #, tcl-format
 msgid "Merge strategy '%s' not supported."
 msgstr "Η στρατηγική Συγχώνευσης %s δεν υποστηρίζεται."
 
-#: lib/checkout_op.tcl:239
+#: lib/checkout_op.tcl:262
 #, tcl-format
 msgid "Failed to update '%s'."
 msgstr "Αποτυχία ενημέρωσης '%s'."
 
-#: lib/checkout_op.tcl:251
+#: lib/checkout_op.tcl:274
 msgid "Staging area (index) is already locked."
 msgstr "Η περιοχή σταδιοποίησης (το ευρετήριο) είναι ήδη κλειδωμένη."
 
-#: lib/checkout_op.tcl:266
+#: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Η τελευταία κατάσταση που ανιχνεύθηκε δε συμφωνεί με την κατάσταση του "
 "αποθετηρίου.\n"
@@ -807,34 +713,35 @@ msgstr ""
 "\n"
 "Η επανανίχνευση θα ξεκινήσει αυτόματα τώρα.\n"
 
-#: lib/checkout_op.tcl:322
+#: lib/checkout_op.tcl:345
 #, tcl-format
 msgid "Updating working directory to '%s'..."
 msgstr "Ενημέρωση φακέλου εργασίας σε '%s'..."
 
-#: lib/checkout_op.tcl:323
+#: lib/checkout_op.tcl:346
 msgid "files checked out"
 msgstr "αρχεία έχουν εξαχθεί"
 
-#: lib/checkout_op.tcl:353
+#: lib/checkout_op.tcl:376
 #, tcl-format
 msgid "Aborted checkout of '%s' (file level merging is required)."
 msgstr ""
 "Έγινε ακύρωση εξαγωγής του '%s' (απαιτείται συγχώνευση επιπέδου αρχείου)."
 
-#: lib/checkout_op.tcl:354
+#: lib/checkout_op.tcl:377
 msgid "File level merge required."
 msgstr "Απαιτείται συγχώνευση επιπέδου αρχείου."
 
-#: lib/checkout_op.tcl:358
+#: lib/checkout_op.tcl:381
 #, tcl-format
 msgid "Staying on branch '%s'."
 msgstr "Παραμονή στον κλάδο '%s'."
 
-#: lib/checkout_op.tcl:429
+#: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -843,37 +750,50 @@ msgstr ""
 "Αν θέλατε να βρίσκεστε σε κλάδο, δημιουργήστε έναν τώρα αρχίζοντας από 'This "
 "Detached Checkout'."
 
-#: lib/checkout_op.tcl:446 lib/checkout_op.tcl:450
+#: lib/checkout_op.tcl:503 lib/checkout_op.tcl:507
 #, tcl-format
 msgid "Checked out '%s'."
 msgstr "Έγινε εξαγωγή του '%s'."
 
-#: lib/checkout_op.tcl:478
+#: lib/checkout_op.tcl:535
 #, tcl-format
 msgid "Resetting '%s' to '%s' will lose the following commits:"
 msgstr "Η επαναφορά '%s' στο '%s' θα χάσει τις εξής υποβολές:"
 
-#: lib/checkout_op.tcl:500
+#: lib/checkout_op.tcl:557
 msgid "Recovering lost commits may not be easy."
 msgstr "Η ανάκτηση χαμένων υποβολών μπορεί να είναι δύσκολη."
 
-#: lib/checkout_op.tcl:505
+#: lib/checkout_op.tcl:562
 #, tcl-format
 msgid "Reset '%s'?"
 msgstr "Επαναφορά '%s';"
 
-#: lib/checkout_op.tcl:510 lib/merge.tcl:163
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Απεικόνιση"
 
-#: lib/checkout_op.tcl:578
-#, tcl-format
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Επαναφορά"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Ακύρωση"
+
+#: lib/checkout_op.tcl:635
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Αποτυχία ορισμού τρέχοντος κλάδου.\n"
@@ -884,685 +804,227 @@ msgstr ""
 "\n"
 "Αυτό δε θα έπρεπε να συμβεί. Το %s θα κλείσει και θα εγκαταλείψει τώρα."
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Επιλογή"
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "ανάκτηση %s"
 
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Οικογένεια Γραμματοσειράς"
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "Ανάκτηση νέων αλλαγών από το %s"
 
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Μέγεθος Γραμματοσειράς"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "απομακρυσμένο κλάδεμα %s"
 
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Παράδειγμα Γραμματοσειράς"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Γίνεται κλάδεμα κλάδων παρακολούθησης που διεγράφησαν από το %s"
 
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
-"Αυτό είναι ένα παράδειγμα κειμένου.\n"
-"Αν σας αρέσει αυτό το κείμενο, μπορεί να γίνει δικό σας."
 
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Γραφικό Περιβάλλον Git"
-
-#: lib/choose_repository.tcl:81 lib/choose_repository.tcl:376
-msgid "Create New Repository"
-msgstr "Δημιουργία Νέου Αποθετηρίου"
-
-#: lib/choose_repository.tcl:87
-msgid "New..."
-msgstr "Νέο..."
-
-#: lib/choose_repository.tcl:94 lib/choose_repository.tcl:460
-msgid "Clone Existing Repository"
-msgstr "Κλωνοποίηση Υπάρχοντος Αποθετηρίου"
-
-#: lib/choose_repository.tcl:100
-msgid "Clone..."
-msgstr "Κλωνοποίηση..."
-
-#: lib/choose_repository.tcl:107 lib/choose_repository.tcl:976
-msgid "Open Existing Repository"
-msgstr "Άνοιγμα Υπάρχοντος Αποθετηρίου"
-
-#: lib/choose_repository.tcl:113
-msgid "Open..."
-msgstr "Άνοιγμα..."
-
-#: lib/choose_repository.tcl:126
-msgid "Recent Repositories"
-msgstr "Πρόσφατα Αποθετήρια"
-
-#: lib/choose_repository.tcl:132
-msgid "Open Recent Repository:"
-msgstr "Άνοιγμα Πρόσφατου Αποθετηρίου:"
-
-#: lib/choose_repository.tcl:296 lib/choose_repository.tcl:303
-#: lib/choose_repository.tcl:310
-#, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Αποτυχία δημιουργίας αποθετηρίου %s:"
-
-#: lib/choose_repository.tcl:381 lib/choose_repository.tcl:478
-msgid "Directory:"
-msgstr "Φάκελος:"
-
-#: lib/choose_repository.tcl:412 lib/choose_repository.tcl:537
-#: lib/choose_repository.tcl:1011
-msgid "Git Repository"
-msgstr "Αποθετήριο Git"
-
-#: lib/choose_repository.tcl:437
-#, tcl-format
-msgid "Directory %s already exists."
-msgstr "Ο Φάκελος '%s' υπάρχει ήδη."
-
-#: lib/choose_repository.tcl:441
-#, tcl-format
-msgid "File %s already exists."
-msgstr "Το αρχείο %s υπάρχει ήδη."
-
-#: lib/choose_repository.tcl:455
-msgid "Clone"
-msgstr "Κλώνος"
-
-#: lib/choose_repository.tcl:468
+#: lib/transport.tcl:26
 #, fuzzy
-msgid "URL:"
-msgstr ""
+msgid "Fetching new changes from all remotes"
+msgstr "Ανάκτηση νέων αλλαγών από το %s"
 
-#: lib/choose_repository.tcl:489
-msgid "Clone Type:"
-msgstr "Τύπος Κλώνου:"
-
-#: lib/choose_repository.tcl:495
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Τυπικό (Ταχύ, Ημι-Πλεονάζον, Hardlinks)"
-
-#: lib/choose_repository.tcl:501
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Πλήρες Αντίγραφο (Πιο αργό, Πλεονάζον Αντίγραφο Ασφαλείας)"
-
-#: lib/choose_repository.tcl:507
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Κοινή Χρήση (Ταχύτατο, Δε Συνιστάται, Κανένα Αντίγραφο Ασφαλείας)"
-
-#: lib/choose_repository.tcl:543 lib/choose_repository.tcl:590
-#: lib/choose_repository.tcl:736 lib/choose_repository.tcl:806
-#: lib/choose_repository.tcl:1017 lib/choose_repository.tcl:1025
-#, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Δεν είναι αποθετήριο Git: %s"
-
-#: lib/choose_repository.tcl:579
-msgid "Standard only available for local repository."
-msgstr "\"Τυπικό\" διαθέσιμο μόνο για τοπικό αποθετήριο."
-
-#: lib/choose_repository.tcl:583
-msgid "Shared only available for local repository."
-msgstr "\"Κοινή Χρήση\" διαθέσιμη μόνο για τοπικό αποθετήριο."
-
-#: lib/choose_repository.tcl:604
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "Η Τοποθεσία %s υπάρχει ήδη."
-
-#: lib/choose_repository.tcl:615
-msgid "Failed to configure origin"
-msgstr "Αποτυχία ρύθμισης πηγής"
-
-#: lib/choose_repository.tcl:627
-msgid "Counting objects"
-msgstr "Γίνεται καταμέτρηση αντικειμένων"
-
-#: lib/choose_repository.tcl:628
+#: lib/transport.tcl:40
 #, fuzzy
-msgid "buckets"
-msgstr ""
+msgid "remote prune all remotes"
+msgstr "απομακρυσμένο κλάδεμα %s"
 
-#: lib/choose_repository.tcl:652
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Αδυναμία αντιγραφής αντικειμένων/πληροφοριών/ενναλακτικών: %s"
-
-#: lib/choose_repository.tcl:688
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Τίποτα προς κλωνοποίηση από το %s."
-
-#: lib/choose_repository.tcl:690 lib/choose_repository.tcl:904
-#: lib/choose_repository.tcl:916
-msgid "The 'master' branch has not been initialized."
-msgstr "Ο κλάδος 'master' δεν έχει αρχικοποιηθεί."
-
-#: lib/choose_repository.tcl:703
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Hardlinks μη διαθέσιμα. Μετάπτωση σε αντιγραφή."
-
-#: lib/choose_repository.tcl:715
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Γίνεται κλωνοποίηση από το %s"
-
-#: lib/choose_repository.tcl:746
-msgid "Copying objects"
-msgstr "Γίνεται αντιγραφή αντικειμένων"
-
-#: lib/choose_repository.tcl:747
+#: lib/transport.tcl:41
 #, fuzzy
-msgid "KiB"
-msgstr ""
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Γίνεται κλάδεμα κλάδων παρακολούθησης που διεγράφησαν από το %s"
 
-#: lib/choose_repository.tcl:771
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Αδυναμία αντιγραφής αντικειμένου: %s"
+msgid "push %s"
+msgstr "ώθηση %s"
 
-#: lib/choose_repository.tcl:781
-msgid "Linking objects"
-msgstr "Γίνεται σύνδεση αντικειμένων"
-
-#: lib/choose_repository.tcl:782
-msgid "objects"
-msgstr "αντικείμενα"
-
-#: lib/choose_repository.tcl:790
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Αδυναμία hardlink αντικειμένου: %s"
+msgid "Pushing changes to %s"
+msgstr "Γίνεται ώθηση αλλαγών στο %s"
 
-#: lib/choose_repository.tcl:845
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr ""
-"Δε μπόρεσε να γίνει ανάκτηση κλάδων και αντικειμένων. Δείτε την έξοδο "
-"κονσόλας για λεπτομέρειες."
+#: lib/transport.tcl:93
+#, fuzzy, tcl-format
+msgid "Mirroring to %s"
+msgstr "Συγχώνευση με %s"
 
-#: lib/choose_repository.tcl:856
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-"Δε μπόρεσε να γίνει ανάκτηση ετικετών. Δείτε την έξοδο κονσόλας για "
-"λεπτομέρειες."
-
-#: lib/choose_repository.tcl:880
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-"Δε μπόρεσε να γίνει καθορισμός του HEAD (παρακλαδιού). Δείτε την έξοδο "
-"κονσόλας για "
-"λεπτομέρειες."
-
-#: lib/choose_repository.tcl:889
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Αδυναμία εκκαθάρισης %s"
+msgid "Pushing %s %s to %s"
+msgstr "Γίνεται ώθηση %s %s στο %s"
 
-#: lib/choose_repository.tcl:895
-msgid "Clone failed."
-msgstr "Αποτυχία κλωνοποίησης."
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Ώθηση Κλάδων"
 
-#: lib/choose_repository.tcl:902
-msgid "No default branch obtained."
-msgstr "Δεν έγινε ανάκτηση προεπιλεγμένου κλάδου."
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Πηγαίοι Κλάδοι"
 
-#: lib/choose_repository.tcl:913
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Δε μπόρεσε να επιλυθεί το %s ως υποβολή."
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Αποθετήριο Προορισμού"
 
-#: lib/choose_repository.tcl:925
-msgid "Creating working directory"
-msgstr "Δημιουργία φακέλου εργασίας"
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Απομακρυσμένο:"
 
-#: lib/choose_repository.tcl:926 lib/index.tcl:65 lib/index.tcl:127
-#: lib/index.tcl:193
-msgid "files"
-msgstr "αρχεία"
-
-#: lib/choose_repository.tcl:955
-msgid "Initial file checkout failed."
-msgstr "Η αρχική εξαγωγή αρχείου απέτυχε."
-
-#: lib/choose_repository.tcl:971
-msgid "Open"
-msgstr "Άνοιγμα"
-
-#: lib/choose_repository.tcl:981
-msgid "Repository:"
-msgstr "Αποθετήριο:"
-
-#: lib/choose_repository.tcl:1031
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Αποτυχία ανοίγματος αποθετηρίου %s:"
-
-#: lib/choose_rev.tcl:53
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
 #, fuzzy
-msgid "This Detached Checkout"
-msgstr "Αποσυνδεδεμένη Εξαγωγή"
+msgid "Arbitrary Location:"
+msgstr "Αυθαίρετο URL:"
 
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Έκφραση Αναθεώρησης:"
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Επιλογές Μεταφοράς"
 
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Τοπικός Κλάδος"
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr ""
+"Εξαναγκασμός επεγγραφής υπάρχοντος κλάδου (μπορεί να απορρίψει αλλαγές)"
 
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Κλάδος Παρακολούθησης"
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Χρήση ισχνού πακέτου (για αργές συνδέσεις δικτύου)"
 
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Ετικέτα"
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Συμπερίληψη ετικετών"
 
-#: lib/choose_rev.tcl:317
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Μη έγκυρη αναθεώρηση: %s"
+msgid "%s (%s): Push"
+msgstr ""
 
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Δεν έχει επιλεγεί αναθεώρηση."
+#: lib/remote_add.tcl:20
+#, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr ""
 
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "Η έκφραση αναθεώρησης είναι κενή."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Ενημερωμένο"
-
-#: lib/choose_rev.tcl:559
+#: lib/remote_add.tcl:25
 #, fuzzy
-msgid "URL"
+msgid "Add New Remote"
+msgstr "Απομακρυσμένο"
+
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
 msgstr ""
 
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
+#: lib/remote_add.tcl:39
+#, fuzzy
+msgid "Remote Details"
+msgstr "Επαναφορά Προεπιλογών"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Όνομα:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
 msgstr ""
-"Δεν υπάρχει κάτι προς διόρθωση.\n"
-"\n"
-"Πρόκειται να δημιουργήσετε την αρχική υποβολή. Δεν υπάρχει υποβολή πριν από "
-"αυτή για να διορθώσετε.\n"
 
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
+#: lib/remote_add.tcl:60
+msgid "Further Action"
 msgstr ""
-"Δε γίνεται διόρθωση καθώς συγχωνεύετε.\n"
-"\n"
-"Βρίσκεστε στο μέσο μιας συγχώνευσης που δεν έχει ολοκληρωθεί. Δε μπορείτε να "
-"διορθώσετε την προηγούμενη υποβολή εκτός εάν ακυρώσετε την τρέχουσα ενέργεια "
-"συγχώνευσης.\n"
 
-#: lib/commit.tcl:49
-msgid "Error loading commit data for amend:"
-msgstr "Σφάλμα φόρτωσης δεδομένων υποβολής προς διόρθωση:"
-
-#: lib/commit.tcl:76
-msgid "Unable to obtain your identity:"
-msgstr "Αδυναμία ανάκτησης της ταυτότητάς σας:"
-
-#: lib/commit.tcl:81
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Μη έγκυρο GIT_COMMITTER_IDENT:"
-
-#: lib/commit.tcl:133
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
 msgstr ""
-"Η τελευταία κατάσταση που ανιχνεύθηκε δε συμφωνεί με την κατάσταση του "
-"αποθετηρίου.\n"
-"\n"
-"Κάποιο άλλο πρόγραμμα Git τροποποίησε το αποθετήριο από την τελευταία "
-"ανίχνευση. Πρέπει να γίνει επανανίχνευση πριν τη δημιουργία νέας υποβολής.\n"
-"\n"
-"Η επανανίχνευση θα ξεκινήσει αυτόματα τώρα.\n"
 
-#: lib/commit.tcl:154
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
 msgstr ""
-"Τα μη συγχωνευμένα αρχεία δε μπορούν να υποβληθούν.\n"
-"\n"
-"Το αρχείο %s έχει συγκρούσεις συγχώνευσης. Πρέπει να τις επιλύσετε και να "
-"σταδιοποιήσετε το αρχείο πριν την υποβολή.\n"
 
-#: lib/commit.tcl:162
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Άγνωστη κατάσταση αρχείου %s ανιχνεύθηκε.\n"
-"\n"
-"Το αρχείο %s δε μπορεί να υποβληθεί από αυτό το πρόγραμμα.\n"
-
-#: lib/commit.tcl:170
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Δεν υπάρχουν αλλαγές προς υποβολή.\n"
-"\n "
-"Πρέπει να σταδιοποιήσετε τουλάχιστον 1 αρχείο πριν να κάνετε υποβολή.\n"
-
-#: lib/commit.tcl:183
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Παρακαλώ δώστε ένα μήνυμα υποβολής.\n"
-"\n"
-"Ένα σωστό μήνυμα υποβολής έχει την εξής μορφή:\n"
-"\n"
-"- Πρώτη γραμμή: Περιγραφή σε μία πρόταση του τι κάνατε.\n"
-"- Δεύτερη γραμμή: Κενή\n"
-"- Υπόλοιπες γραμμές: Περιγραφή του γιατί αυτή η αλλαγή είναι σωστή.\n"
-
-#: lib/commit.tcl:207
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "προειδοποίηση: H Tcl δεν υποστηρίζει την κωδικοποίηση '%s'."
-
-#: lib/commit.tcl:221
-msgid "Calling pre-commit hook..."
-msgstr "Γίνεται κλήση του pre-commit hook..."
-
-#: lib/commit.tcl:236
-msgid "Commit declined by pre-commit hook."
-msgstr "Η υποβολή απορρίφθηκε από το pre-commit hook."
-
-#: lib/commit.tcl:259
-msgid "Calling commit-msg hook..."
-msgstr "Γίνεται κλήση του commit-msg hook..."
-
-#: lib/commit.tcl:274
-msgid "Commit declined by commit-msg hook."
-msgstr "Η υποβολή απορρίφθηκε από το commit-msg hook."
-
-#: lib/commit.tcl:287
-msgid "Committing changes..."
-msgstr "Γίνεται υποβολή των αλλαγών..."
-
-#: lib/commit.tcl:303
-msgid "write-tree failed:"
-msgstr "το write-tree απέτυχε:"
-
-#: lib/commit.tcl:304 lib/commit.tcl:348 lib/commit.tcl:368
-msgid "Commit failed."
-msgstr "Η υποβολή απέτυχε."
-
-#: lib/commit.tcl:321
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Η υποβολή %s δείχνει κατεστραμμένη"
-
-#: lib/commit.tcl:326
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Δεν υπάρχουν αλλαγές προς υποβολή.\n"
-"\n"
-"Δεν τροποποιήθηκαν αρχεία από αυτή την υποβολή και δεν ήταν υποβολή "
-"συγχώνευσης.\n"
-"\n"
-"Θα ξεκινήσει αυτόματα επανανίχνευση τώρα.\n"
-
-#: lib/commit.tcl:333
-msgid "No changes to commit."
-msgstr "Δεν υπάρχουν αλλαγές προς υποβολή."
-
-#: lib/commit.tcl:347
-msgid "commit-tree failed:"
-msgstr "το commit-tree απέτυχε:"
-
-#: lib/commit.tcl:367
-msgid "update-ref failed:"
-msgstr "το update-ref απέτυχε:"
-
-#: lib/commit.tcl:454
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Δημιουργήθηκε υποβολή %s: %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Γίνεται εργασία... Παρακαλώ περιμένετε..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Επιτυχία"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Σφάλμα: Η Εντολή Απέτυχε"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Αριθμός ελεύθερων αντικειμένων"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Χώρος κατειλλημένος από ελεύθερα αντικείμενα"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Αριθμός πακεταρισμένων αντικειμένων"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Αριθμός πακέτων"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "Χώρος κατειλλημένος από πακεταρισμένα αντικείμενα"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Πακεταρισμένα αντικείμενα έτοιμα για κλάδεμα"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "Άχρηστα αρχεία"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Γίνεται συμπίεση της βάσης δεδομένων αντικειμένων"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr ""
-"Γίνεται επαλήθευση της βάσης δεδομένων αντικειμένων με αντικείμενα fsck"
-
-#: lib/database.tcl:108
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database when more than %i loose objects exist.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Αυτό το αποθετήριο έχει αυτή τη στιγμή περίπου %i ελεύθερα αντικείμενα.\n"
-"\n"
-"Για τη διατήρηση βέλτιστων επιδόσεων συνιστάται να συμπιέσετε τη βάση "
-"δεδομένων όταν υπάρχουν περισσότερα από %i ελεύθερα αντικείμενα.\n"
-"\n"
-"Συμπίεση της βάσης δεδομένων τώρα;"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Μη έγκυρη ημερομηνία από το Git: %s"
-
-#: lib/diff.tcl:42
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Δεν ανιχνεύθηκαν διαφορές.\n"
-"\n"
-"Το %s δεν έχει αλλαγές."
-"\n"
-"Η ημερομηνία τροποποίησης αυτού του αρχείου ενημερώθηκε από άλλη εφαρμογή, "
-"αλλά το περιεχόμενο του αρχείου δεν άλλαξε.\n"
-"\n"
-"Θα ξεκινήσει αυτόματα επανανίχνευση για να βρεθούν άλλα αρχεία που μπορεί να "
-"βρίσκονται σε ίδια κατάσταση."
-
-#: lib/diff.tcl:81
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Γίνεται φόρτωση διαφοράς του %s..."
-
-#: lib/diff.tcl:114 lib/diff.tcl:184
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Δεν είναι δυνατή η προβολή του %s"
-
-#: lib/diff.tcl:115
-msgid "Error loading file:"
-msgstr "Σφάλμα φόρτωσης αρχείου:"
-
-#: lib/diff.tcl:122
-msgid "Git Repository (subproject)"
-msgstr "Αποθετήριο Git (θυγατρικό έργο)"
-
-#: lib/diff.tcl:134
-msgid "* Binary file (not showing content)."
-msgstr "* Δυαδικό αρχείο (μη εμφάνιση περιεχομένου)."
-
-#: lib/diff.tcl:185
-msgid "Error loading diff:"
-msgstr "Σφάλμα φόρτωσης διαφοράς:"
-
-#: lib/diff.tcl:303
-msgid "Failed to unstage selected hunk."
-msgstr "Αποτυχία αποσταδιοποίησης επιλεγμένου κομματιού."
-
-#: lib/diff.tcl:310
-msgid "Failed to stage selected hunk."
-msgstr "Αποτυχία σταδιοποίησης επιλεγμένου κομματιού."
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "σφάλμα"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "προειδοποίηση"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr "Πρέπει να διορθώσετε τα παραπάνω λάθη πριν την υποβολή."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Αδυναμία ξεκλειδώματος του ευρετηρίου."
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Σφάλμα Ευρετηρίου"
-
-#: lib/index.tcl:21
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"Η ενημέρωση του ευρετηρίου Git απέτυχε. Θα ξεκινήσει αυτόματα επανανίχνευση "
-"για επανασυγχρονισμό του git-gui."
-
-#: lib/index.tcl:27
-msgid "Continue"
-msgstr "Συνέχεια"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Ξεκλείδωμα Ευρετηρίου"
-
-#: lib/index.tcl:282
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Αποσταδιοποίηση %s από υποβολή"
-
-#: lib/index.tcl:313
-msgid "Ready to commit."
-msgstr "Έτοιμο προς υποβολή."
-
-#: lib/index.tcl:326
-#, tcl-format
-msgid "Adding %s"
-msgstr "Προσθήκη %s"
-
-#: lib/index.tcl:381
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Αναίρεση αλλαγών στο αρχείο %s;"
-
-#: lib/index.tcl:383
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Αναίρεση αλλαγών σε αυτά τα %i αρχεία;"
-
-#: lib/index.tcl:391
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Όλες οι μη σταδιοποιημένες αλλαγές θα χαθούν οριστικά από την αναίρεση."
-
-#: lib/index.tcl:394
-msgid "Do Nothing"
+#: lib/remote_add.tcl:75
+#, fuzzy
+msgid "Do Nothing Else Now"
 msgstr "Καμία Ενέργεια"
 
+#: lib/remote_add.tcl:100
+#, fuzzy
+msgid "Please supply a remote name."
+msgstr "Παρακαλώ δώστε ένα όνομα κλάδου."
+
+#: lib/remote_add.tcl:113
+#, fuzzy, tcl-format
+msgid "'%s' is not an acceptable remote name."
+msgstr "'%s' δεν είναι αποδεκτό όνομα κλάδου."
+
+#: lib/remote_add.tcl:124
+#, fuzzy, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Αποτυχία μετονομασίας '%s'."
+
+#: lib/remote_add.tcl:133
+#, fuzzy, tcl-format
+msgid "Fetching the %s"
+msgstr "Ανάκτηση %s από το %s"
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr ""
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr ""
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Γίνεται Εκκίνηση..."
+
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Περιηγητής Αρχείων"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr "Γίνεται φόρτωση %s..."
+
+#: lib/browser.tcl:193
+#, fuzzy
+msgid "[Up To Parent]"
+msgstr "[Πάνω Προς Γονέα]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Περιήγηση Αρχείων Κλάδου"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Περιήγηση Αρχείων Κλάδου"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Περιήγηση"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Αναθεώρηση"
+
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Δε γίνεται συγχώνευση καθώς διορθώνετε.\n"
 "\n"
@@ -1570,13 +1032,14 @@ msgstr ""
 "οποιασδήποτε μορφής συγχώνευση.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Η τελευταία κατάσταση που ανιχνεύθηκε δε συμφωνεί με την κατάσταση του "
 "αποθετηρίου.\n"
@@ -1586,15 +1049,15 @@ msgstr ""
 "\n"
 "Η επανανίχνευση θα ξεκινήσει αυτόματα τώρα.\n"
 
-#: lib/merge.tcl:44
-#, tcl-format
+#: lib/merge.tcl:45
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "Βρίσκεστε στο μέσο μιας συγκρουόμενης συγχώνευσης.\n"
 "\n"
@@ -1604,66 +1067,75 @@ msgstr ""
 "για να ολοκληρώσετε την τρέχουσα συγχώνευση. Μόνο τότε μπορείτε να "
 "ξεκινήσετε άλλη συγχώνευση.\n"
 
-#: lib/merge.tcl:54
-#, tcl-format
+#: lib/merge.tcl:55
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "Βρίσκεστε στο μέσο μιας αλλαγής.\n"
 "\n"
 "Το αρχείο %s έχει τροποποιηθεί.\n"
 "\n"
-"Πρέπει να ολοκληρώσετε την τρέχουσα συγχώνευση πριν να ξεκινήσετε συγχώνευση."
-" Αυτό βοηθά στην ακύρωση αποτυχημένης συγχώνευσης, εάν χρειαστεί.\n"
+"Πρέπει να ολοκληρώσετε την τρέχουσα συγχώνευση πριν να ξεκινήσετε "
+"συγχώνευση. Αυτό βοηθά στην ακύρωση αποτυχημένης συγχώνευσης, εάν "
+"χρειαστεί.\n"
 
-#: lib/merge.tcl:106
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s από %s"
 
-#: lib/merge.tcl:119
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Γίνεται συγχώνευση του %s με το %s..."
 
-#: lib/merge.tcl:130
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "Η συγχώνευση ολοκληρώθηκε επιτυχώς."
 
-#: lib/merge.tcl:132
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "Η συγχώνευση απέτυχε. Απαιτείται επίλυση συγκρούσεων."
 
-#: lib/merge.tcl:157
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Συγχώνευση με %s"
 
-#: lib/merge.tcl:176
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Αναθεώρηση Προς Συγχώνευση"
 
-#: lib/merge.tcl:211
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "Δε γίνεται ακύρωση καθώς διορθώνετε.\n"
 "\n"
 "Πρέπει να τελειώσετε τη διόρθωση αυτής της υποβολής.\n"
 
-#: lib/merge.tcl:221
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Ακύρωση συγχώνευσης;\n"
@@ -1673,12 +1145,13 @@ msgstr ""
 "\n"
 "Να προχωρήσει η ακύρωση της τρέχουσας συγχώνευσης;"
 
-#: lib/merge.tcl:227
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Επαναφορά αλλαγών;\n"
@@ -1688,213 +1161,81 @@ msgstr ""
 "\n"
 "Να συνεχίσει η επαναφορά των τρέχουσων αλλαγών;"
 
-#: lib/merge.tcl:238
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Γίνεται ακύρωση"
 
-#: lib/merge.tcl:238
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "αρχεία που επαναφέρθηκαν"
 
-#: lib/merge.tcl:265
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "Η ακύρωση απέτυχε."
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "Η ακύρωση απέτυχε. Έτοιμο."
 
-#: lib/option.tcl:95
-msgid "Restore Defaults"
-msgstr "Επαναφορά Προεπιλογών"
-
-#: lib/option.tcl:99
-msgid "Save"
-msgstr "Αποθήκευση"
-
-#: lib/option.tcl:109
+#: lib/tools.tcl:76
 #, tcl-format
-msgid "%s Repository"
-msgstr "%s Αποθετήριο"
-
-#: lib/option.tcl:110
-msgid "Global (All Repositories)"
-msgstr "Ολικό (Όλα τα Αποθετήρια)"
-
-#: lib/option.tcl:116
-msgid "User Name"
-msgstr "Όνομα Χρήστη"
-
-#: lib/option.tcl:117
-msgid "Email Address"
-msgstr "Διεύθυνση Email"
-
-#: lib/option.tcl:119
-msgid "Summarize Merge Commits"
-msgstr "Περίληψη Υποβολών Συγχώνευσης"
-
-#: lib/option.tcl:120
-msgid "Merge Verbosity"
-msgstr "Λεπτομέρεια Συγχώνευσης"
-
-#: lib/option.tcl:121
-msgid "Show Diffstat After Merge"
-msgstr "Προβολή Στατιστικών Διαφοράς Μετά από Συγχώνευση"
-
-#: lib/option.tcl:123
-msgid "Trust File Modification Timestamps"
-msgstr "Εμπιστοσύνη Ημερομηνιών Μετατροπής Αρχείων"
-
-#: lib/option.tcl:124
-msgid "Prune Tracking Branches During Fetch"
-msgstr "Κλάδεμα Κλάδων Παρακολούθησης Κατά Την Ανάκτηση"
-
-#: lib/option.tcl:125
-msgid "Match Tracking Branches"
-msgstr "Συμφωνία Κλάδων Παρακολούθησης"
-
-#: lib/option.tcl:126
-msgid "Number of Diff Context Lines"
-msgstr "Αριθμός Γραμμών Εννοιολογικού Πλαισίου Διαφοράς"
-
-#: lib/option.tcl:127
-msgid "Commit Message Text Width"
-msgstr "Πλάτος Κειμένου Μηνύματος Υποβολής"
-
-#: lib/option.tcl:128
-msgid "New Branch Name Template"
-msgstr "Νέο Πρότυπο Ονόματος Κλάδου"
-
-#: lib/option.tcl:192
-msgid "Spelling Dictionary:"
-msgstr "Λεξικό Ορθογραφίας:"
-
-#: lib/option.tcl:216
-msgid "Change Font"
-msgstr "Αλλαγή Γραμματοσειράς"
-
-#: lib/option.tcl:220
-#, tcl-format
-msgid "Choose %s"
-msgstr "Επιλογή %s"
-
-#: lib/option.tcl:226
-#, fuzzy
-msgid "pt."
+msgid "Running %s requires a selected file."
 msgstr ""
 
-#: lib/option.tcl:240
-msgid "Preferences"
-msgstr "Προτιμήσεις"
-
-#: lib/option.tcl:275
-msgid "Failed to completely save options:"
-msgstr "Αποτυχία πλήρους αποθήκευσης επιλογών:"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Remote Branch"
-msgstr "Διαγραφή Απομακρυσμένου Κλάδου"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "Από Αποθετήριο"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:123
-msgid "Remote:"
-msgstr "Απομακρυσμένο:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:138
-#, fuzzy
-msgid "Arbitrary URL:"
-msgstr "Αυθαίρετο URL:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Κλάδοι"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Διαγραφή Μόνο Εάν"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Συγχωνευμένο Με:"
-
-#: lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Πάντα (Μη διενεργηθούν έλεγχοι συγχώνευσης)"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "Απαιτείται ένας κλάδος για 'Συγχωνευμένο Με'."
-
-#: lib/remote_branch_delete.tcl:184
+#: lib/tools.tcl:92
 #, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
 msgstr ""
-"Οι εξής κλάδοι δεν είναι πλήρως συγχωνευμένοι με το %s:\n"
-"\n"
-" - %s"
 
-#: lib/remote_branch_delete.tcl:189
+#: lib/tools.tcl:96
 #, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
+msgid "Are you sure you want to run %s?"
 msgstr ""
-"Μία ή περισσότερες από τις δοκιμές συγχώνευσης απέτυχαν επειδή δεν έχετε "
-"φέρει τις αναγκαίες υποβολές. Δοκιμάστε ανάκτηση από το %s πρώτα."
 
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Παρακαλώ επιλέξτε έναν ή περισσότερους κλάδους προς διαγραφή."
-
-#: lib/remote_branch_delete.tcl:216
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
+#: lib/tools.tcl:118
+#, tcl-format
+msgid "Tool: %s"
 msgstr ""
-"Η ανάκτηση διεγραμμένων κλάδων είναι δύσκολη.\n"
-"\n"
-"Διαγραφή των επιλεγμένων κλάδων;"
 
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Γίνεται διαγραφή κλάδων από %s"
-
-#: lib/remote_branch_delete.tcl:286
-msgid "No repository selected."
-msgstr "Δεν έχει επιλεγεί αποθετήριο."
-
-#: lib/remote_branch_delete.tcl:291
-#, tcl-format
-msgid "Scanning %s..."
+#: lib/tools.tcl:119
+#, fuzzy, tcl-format
+msgid "Running: %s"
 msgstr "Ανίχνευση %s..."
 
-#: lib/remote.tcl:165
-msgid "Prune from"
-msgstr "Κλάδεμα από"
+#: lib/tools.tcl:158
+#, fuzzy, tcl-format
+msgid "Tool completed successfully: %s"
+msgstr "Η συγχώνευση ολοκληρώθηκε επιτυχώς."
 
-#: lib/remote.tcl:170
-msgid "Fetch from"
-msgstr "Ανάκτηση από"
+#: lib/tools.tcl:160
+#, tcl-format
+msgid "Tool failed: %s"
+msgstr ""
 
-#: lib/remote.tcl:213
-msgid "Push to"
-msgstr "Ώθηση σε"
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Εξαγωγή Κλάδου"
 
-#: lib/shortcut.tcl:20 lib/shortcut.tcl:61
-msgid "Cannot write shortcut:"
-msgstr "Δε μπόρεσε να αποθηκευτεί η συντόμευση:"
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Εξαγωγή Κλάδου"
 
-#: lib/shortcut.tcl:136
-msgid "Cannot write icon:"
-msgstr "Δε μπόρεσε να αποθηκευτεί το εικονίδιο:"
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Εξαγωγή"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Επιλογές"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Ανάκτηση Κλάδου Παρακολούθησης"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Αποκόλληση Από Τοπικό Κλάδο"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -1921,85 +1262,1623 @@ msgstr "Ο ελεγκτής ορθογραφίας απέτυχε σιωπηλά
 msgid "Unrecognized spell checker"
 msgstr "Μη αναγνωρίσιμος ελεγκτής ορθογραφίας"
 
-#: lib/spellcheck.tcl:180
+#: lib/spellcheck.tcl:186
 msgid "No Suggestions"
 msgstr "Καμία Πρόταση"
 
-#: lib/spellcheck.tcl:381
+#: lib/spellcheck.tcl:388
 msgid "Unexpected EOF from spell checker"
 msgstr "Μη αναμενόμενο τέλος αρχείου από τον ελεγκτή ορθογραφίας"
 
-#: lib/spellcheck.tcl:385
+#: lib/spellcheck.tcl:392
 msgid "Spell Checker Failed"
 msgstr "Αποτυχία Ελεγκτή Ορθογραφίας"
 
-#: lib/status_bar.tcl:83
+#: lib/status_bar.tcl:87
 #, tcl-format
 msgid "%s ... %*i of %*i %s (%3i%%)"
 msgstr "%s ... %*i από %*i %s (%3i%%)"
 
-#: lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "ανάκτηση %s"
-
-#: lib/transport.tcl:7
-#, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Ανάκτηση νέων αλλαγών από το %s"
-
-#: lib/transport.tcl:18
-#, tcl-format
-msgid "remote prune %s"
-msgstr "απομακρυσμένο κλάδεμα %s"
-
-#: lib/transport.tcl:19
-#, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Γίνεται κλάδεμα κλάδων παρακολούθησης που διεγράφησαν από το %s"
-
-#: lib/transport.tcl:25 lib/transport.tcl:71
-#, tcl-format
-msgid "push %s"
-msgstr "ώθηση %s"
-
-#: lib/transport.tcl:26
-#, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Γίνεται ώθηση αλλαγών στο %s"
-
-#: lib/transport.tcl:72
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Γίνεται ώθηση %s %s στο %s"
-
-#: lib/transport.tcl:89
-msgid "Push Branches"
-msgstr "Ώθηση Κλάδων"
-
-#: lib/transport.tcl:103
-msgid "Source Branches"
-msgstr "Πηγαίοι Κλάδοι"
-
-#: lib/transport.tcl:120
-msgid "Destination Repository"
-msgstr "Αποθετήριο Προορισμού"
-
-#: lib/transport.tcl:158
-msgid "Transfer Options"
-msgstr "Επιλογές Μεταφοράς"
-
-#: lib/transport.tcl:160
-msgid "Force overwrite existing branch (may discard changes)"
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
 msgstr ""
-"Εξαναγκασμός επεγγραφής υπάρχοντος κλάδου (μπορεί να απορρίψει αλλαγές)"
+"Δεν ανιχνεύθηκαν διαφορές.\n"
+"\n"
+"Το %s δεν έχει αλλαγές.\n"
+"Η ημερομηνία τροποποίησης αυτού του αρχείου ενημερώθηκε από άλλη εφαρμογή, "
+"αλλά το περιεχόμενο του αρχείου δεν άλλαξε.\n"
+"\n"
+"Θα ξεκινήσει αυτόματα επανανίχνευση για να βρεθούν άλλα αρχεία που μπορεί να "
+"βρίσκονται σε ίδια κατάσταση."
 
-#: lib/transport.tcl:164
-msgid "Use thin pack (for slow network connections)"
-msgstr "Χρήση ισχνού πακέτου (για αργές συνδέσεις δικτύου)"
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Γίνεται φόρτωση διαφοράς του %s..."
 
-#: lib/transport.tcl:168
-msgid "Include tags"
-msgstr "Συμπερίληψη ετικετών"
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
 
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
 
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr ""
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr ""
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Δεν είναι δυνατή η προβολή του %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Σφάλμα φόρτωσης αρχείου:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Αποθετήριο Git (θυγατρικό έργο)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Δυαδικό αρχείο (μη εμφάνιση περιεχομένου)."
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Σφάλμα φόρτωσης διαφοράς:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Αποτυχία αποσταδιοποίησης επιλεγμένου κομματιού."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Αποτυχία σταδιοποίησης επιλεγμένου κομματιού."
+
+#: lib/diff.tcl:666
+#, fuzzy
+msgid "Failed to unstage selected line."
+msgstr "Αποτυχία αποσταδιοποίησης επιλεγμένου κομματιού."
+
+#: lib/diff.tcl:674
+#, fuzzy
+msgid "Failed to stage selected line."
+msgstr "Αποτυχία σταδιοποίησης επιλεγμένου κομματιού."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Ώθηση σε"
+
+#: lib/remote.tcl:218
+#, fuzzy
+msgid "Remove Remote"
+msgstr "Απομακρυσμένο"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Κλάδεμα από"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Ανάκτηση από"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Επιλογή"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Οικογένεια Γραμματοσειράς"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Μέγεθος Γραμματοσειράς"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Παράδειγμα Γραμματοσειράς"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Αυτό είναι ένα παράδειγμα κειμένου.\n"
+"Αν σας αρέσει αυτό το κείμενο, μπορεί να γίνει δικό σας."
+
+#: lib/option.tcl:11
+#, fuzzy, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr "Μη έγκυρη γραμματοσειρά στο %s:"
+
+#: lib/option.tcl:19
+#, fuzzy, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr "Μη έγκυρη γραμματοσειρά στο %s:"
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Επαναφορά Προεπιλογών"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Αποθήκευση"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "%s Αποθετήριο"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Ολικό (Όλα τα Αποθετήρια)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Όνομα Χρήστη"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Διεύθυνση Email"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "Περίληψη Υποβολών Συγχώνευσης"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Λεπτομέρεια Συγχώνευσης"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Προβολή Στατιστικών Διαφοράς Μετά από Συγχώνευση"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr ""
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "Εμπιστοσύνη Ημερομηνιών Μετατροπής Αρχείων"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr "Κλάδεμα Κλάδων Παρακολούθησης Κατά Την Ανάκτηση"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "Συμφωνία Κλάδων Παρακολούθησης"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr ""
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Πρόσφατα Αποθετήρια"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr ""
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr ""
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Αριθμός Γραμμών Εννοιολογικού Πλαισίου Διαφοράς"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Πλάτος Κειμένου Μηνύματος Υποβολής"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Νέο Πρότυπο Ονόματος Κλάδου"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr ""
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+#, fuzzy
+msgid "Change"
+msgstr "Αλλαγή Γραμματοσειράς"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Λεξικό Ορθογραφίας:"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Αλλαγή Γραμματοσειράς"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "Επιλογή %s"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr ""
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Προτιμήσεις"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "Αποτυχία πλήρους αποθήκευσης επιλογών:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr ""
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:14
+#, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr ""
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+
+#: lib/mergetool.tcl:146
+#, fuzzy
+msgid "Conflict file does not exist"
+msgstr "Ο Κλάδος '%s' δεν υπάρχει."
+
+#: lib/mergetool.tcl:246
+#, fuzzy, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "Δεν είναι αποθετήριο Git: %s"
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr ""
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr ""
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr ""
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+#, fuzzy
+msgid "Merge tool failed."
+msgstr "Η ακύρωση απέτυχε."
+
+#: lib/tools_dlg.tcl:22
+#, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr ""
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr ""
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr ""
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr ""
+
+#: lib/tools_dlg.tcl:60
+#, fuzzy
+msgid "Command:"
+msgstr "Υποβολή:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr ""
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr ""
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:118
+#, fuzzy
+msgid "Please supply a name for the tool."
+msgstr "Παρακαλώ δώστε ένα όνομα κλάδου."
+
+#: lib/tools_dlg.tcl:126
+#, fuzzy, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "Το αρχείο %s υπάρχει ήδη."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:187
+#, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr ""
+
+#: lib/tools_dlg.tcl:198
+#, fuzzy
+msgid "Remove"
+msgstr "Απομακρυσμένο"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:283
+#, tcl-format
+msgid "%s (%s):"
+msgstr ""
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr ""
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr ""
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr ""
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr ""
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr ""
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Δημιουργία Εικονιδίου Επιφάνειας Εργασίας"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Δε μπόρεσε να αποθηκευτεί η συντόμευση:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Δε μπόρεσε να αποθηκευτεί το εικονίδιο:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Μετονομασία Κλάδου"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Μετονομασία Κλάδου"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Μετονομασία"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Κλάδος:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Νέο Όνομα:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Παρακαλώ επιλέξτε κλάδο προς μετονομασία:"
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Παρακαλώ δώστε ένα όνομα κλάδου."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "'%s' δεν είναι αποδεκτό όνομα κλάδου."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Αποτυχία μετονομασίας '%s'."
+
+#: lib/remote_branch_delete.tcl:29
+#, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:34
+#, fuzzy
+msgid "Delete Branch Remotely"
+msgstr "Διαγραφή Κλάδου"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Από Αποθετήριο"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Κλάδοι"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Διαγραφή Μόνο Εάν"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Συγχωνευμένο Με:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Πάντα (Μη διενεργηθούν έλεγχοι συγχώνευσης)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "Απαιτείται ένας κλάδος για 'Συγχωνευμένο Με'."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"Οι εξής κλάδοι δεν είναι πλήρως συγχωνευμένοι με το %s:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Μία ή περισσότερες από τις δοκιμές συγχώνευσης απέτυχαν επειδή δεν έχετε "
+"φέρει τις αναγκαίες υποβολές. Δοκιμάστε ανάκτηση από το %s πρώτα."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Παρακαλώ επιλέξτε έναν ή περισσότερους κλάδους προς διαγραφή."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Η ανάκτηση διεγραμμένων κλάδων είναι δύσκολη.\n"
+"\n"
+"Διαγραφή των επιλεγμένων κλάδων;"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Γίνεται διαγραφή κλάδων από %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Δεν έχει επιλεγεί αποθετήριο."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Ανίχνευση %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Γραφικό Περιβάλλον Git"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Δημιουργία Νέου Αποθετηρίου"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Νέο..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Κλωνοποίηση Υπάρχοντος Αποθετηρίου"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Κλωνοποίηση..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Άνοιγμα Υπάρχοντος Αποθετηρίου"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Άνοιγμα..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Πρόσφατα Αποθετήρια"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Άνοιγμα Πρόσφατου Αποθετηρίου:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Αποτυχία δημιουργίας αποθετηρίου %s:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Δημιουργία"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Φάκελος:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Αποθετήριο Git"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "Ο Φάκελος '%s' υπάρχει ήδη."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Το αρχείο %s υπάρχει ήδη."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Κλώνος"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr ""
+
+#: lib/choose_repository.tcl:516
+#, fuzzy
+msgid "Target Directory:"
+msgstr "Φάκελος:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Τύπος Κλώνου:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Τυπικό (Ταχύ, Ημι-Πλεονάζον, Hardlinks)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Πλήρες Αντίγραφο (Πιο αργό, Πλεονάζον Αντίγραφο Ασφαλείας)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Κοινή Χρήση (Ταχύτατο, Δε Συνιστάται, Κανένα Αντίγραφο Ασφαλείας)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Δεν είναι αποθετήριο Git: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "\"Τυπικό\" διαθέσιμο μόνο για τοπικό αποθετήριο."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "\"Κοινή Χρήση\" διαθέσιμη μόνο για τοπικό αποθετήριο."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "Η Τοποθεσία %s υπάρχει ήδη."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Αποτυχία ρύθμισης πηγής"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Γίνεται καταμέτρηση αντικειμένων"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr ""
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Αδυναμία αντιγραφής αντικειμένων/πληροφοριών/ενναλακτικών: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Τίποτα προς κλωνοποίηση από το %s."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "Ο κλάδος 'master' δεν έχει αρχικοποιηθεί."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Hardlinks μη διαθέσιμα. Μετάπτωση σε αντιγραφή."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Γίνεται κλωνοποίηση από το %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Γίνεται αντιγραφή αντικειμένων"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr ""
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Αδυναμία αντιγραφής αντικειμένου: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Γίνεται σύνδεση αντικειμένων"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "αντικείμενα"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Αδυναμία hardlink αντικειμένου: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Δε μπόρεσε να γίνει ανάκτηση κλάδων και αντικειμένων. Δείτε την έξοδο "
+"κονσόλας για λεπτομέρειες."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+"Δε μπόρεσε να γίνει ανάκτηση ετικετών. Δείτε την έξοδο κονσόλας για "
+"λεπτομέρειες."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+"Δε μπόρεσε να γίνει καθορισμός του HEAD (παρακλαδιού). Δείτε την έξοδο "
+"κονσόλας για λεπτομέρειες."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Αδυναμία εκκαθάρισης %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Αποτυχία κλωνοποίησης."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Δεν έγινε ανάκτηση προεπιλεγμένου κλάδου."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Δε μπόρεσε να επιλυθεί το %s ως υποβολή."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Δημιουργία φακέλου εργασίας"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "αρχεία"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Γίνεται κλωνοποίηση από το %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Η αρχική εξαγωγή αρχείου απέτυχε."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Άνοιγμα"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Αποθετήριο:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Αποτυχία ανοίγματος αποθετηρίου %s:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - ένα γραφικό περιβάλλον για το Git."
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Εφαρμογή Προβολής Αρχείου"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Υποβολή:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Αντιγραφή Υποβολής"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr ""
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Κλωνοποίηση..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr ""
+
+#: lib/blame.tcl:301
+#, fuzzy
+msgid "Show History Context"
+msgstr "Προβολή Ευρύτερου Πλαισίου"
+
+#: lib/blame.tcl:304
+#, fuzzy
+msgid "Blame Parent Commit"
+msgstr "Διόρθωση Τελευταίας Υποβολής"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Ανάγνωση %s..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Γίνεται φόρτωση σχολίων παρακολούθησης αντιγραφής/μετακίνησης..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "γραμμές σχολιασμένες"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Γίνεται φόρτωση σχολίων αρχικής τοποθεσίας..."
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Έγινε ολοκλήρωση του σχολιασμού."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr ""
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr ""
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr ""
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Φόρτωση σχολίου..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Δημιουργός:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Υποβολέας:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Αρχικό Αρχείο:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr ""
+
+#: lib/blame.tcl:1112
+#, fuzzy
+msgid "Cannot find parent commit:"
+msgstr "Δε βρέθηκε το git στο PATH."
+
+#: lib/blame.tcl:1127
+#, fuzzy
+msgid "Unable to display parent"
+msgstr "Δεν είναι δυνατή η προβολή του %s"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Αρχικά Από:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "Στο Αρχείο:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Αντιγράφηκε ή Μετακινήθηκε Εδώ Από:"
+
+#: lib/sshkey.tcl:31
+msgid "No keys found."
+msgstr ""
+
+#: lib/sshkey.tcl:34
+#, tcl-format
+msgid "Found a public key in: %s"
+msgstr ""
+
+#: lib/sshkey.tcl:40
+msgid "Generate Key"
+msgstr ""
+
+#: lib/sshkey.tcl:58
+msgid "Copy To Clipboard"
+msgstr ""
+
+#: lib/sshkey.tcl:72
+msgid "Your OpenSSH Public Key"
+msgstr ""
+
+#: lib/sshkey.tcl:80
+#, fuzzy
+msgid "Generating..."
+msgstr "Γίνεται Εκκίνηση..."
+
+#: lib/sshkey.tcl:86
+#, tcl-format
+msgid ""
+"Could not start ssh-keygen:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/sshkey.tcl:113
+#, fuzzy
+msgid "Generation failed."
+msgstr "Αποτυχία κλωνοποίησης."
+
+#: lib/sshkey.tcl:120
+msgid "Generation succeeded, but no keys found."
+msgstr ""
+
+#: lib/sshkey.tcl:123
+#, tcl-format
+msgid "Your key is in: %s"
+msgstr ""
+
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Δημιουργία Κλάδου"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Δημιουργία Νέου Κλάδου"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Όνομα Κλάδου"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Συμφωνία Ονόματος Κλάδου Παρακολούθησης"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Αρχική Αναθεώρηση"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Ενημέρωση Υπάρχοντα Κλάδου:"
+
+#: lib/branch_create.tcl:75
+#, fuzzy
+msgid "No"
+msgstr "Όχι"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Συγχώνευση Επιτάχυνσης Μόνο"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Εξαγωγή Μετά τη Δημιουργία"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Παρακαλώ επιλέξτε έναν κλάδο παρακολούθησης."
+
+#: lib/branch_create.tcl:141
+#, tcl-format
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr ""
+"Ο κλάδος παρακολούθησης %s δεν είναι κλάδος που βρίσκεται στο απομακρυσμένο "
+"αποθετήριο."
+
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Δεν υπάρχει κάτι προς διόρθωση.\n"
+"\n"
+"Πρόκειται να δημιουργήσετε την αρχική υποβολή. Δεν υπάρχει υποβολή πριν από "
+"αυτή για να διορθώσετε.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Δε γίνεται διόρθωση καθώς συγχωνεύετε.\n"
+"\n"
+"Βρίσκεστε στο μέσο μιας συγχώνευσης που δεν έχει ολοκληρωθεί. Δε μπορείτε να "
+"διορθώσετε την προηγούμενη υποβολή εκτός εάν ακυρώσετε την τρέχουσα ενέργεια "
+"συγχώνευσης.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Σφάλμα φόρτωσης δεδομένων υποβολής προς διόρθωση:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Αδυναμία ανάκτησης της ταυτότητάς σας:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Μη έγκυρο GIT_COMMITTER_IDENT:"
+
+#: lib/commit.tcl:132
+#, tcl-format
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "προειδοποίηση: H Tcl δεν υποστηρίζει την κωδικοποίηση '%s'."
+
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Η τελευταία κατάσταση που ανιχνεύθηκε δε συμφωνεί με την κατάσταση του "
+"αποθετηρίου.\n"
+"\n"
+"Κάποιο άλλο πρόγραμμα Git τροποποίησε το αποθετήριο από την τελευταία "
+"ανίχνευση. Πρέπει να γίνει επανανίχνευση πριν τη δημιουργία νέας υποβολής.\n"
+"\n"
+"Η επανανίχνευση θα ξεκινήσει αυτόματα τώρα.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Τα μη συγχωνευμένα αρχεία δε μπορούν να υποβληθούν.\n"
+"\n"
+"Το αρχείο %s έχει συγκρούσεις συγχώνευσης. Πρέπει να τις επιλύσετε και να "
+"σταδιοποιήσετε το αρχείο πριν την υποβολή.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Άγνωστη κατάσταση αρχείου %s ανιχνεύθηκε.\n"
+"\n"
+"Το αρχείο %s δε μπορεί να υποβληθεί από αυτό το πρόγραμμα.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Δεν υπάρχουν αλλαγές προς υποβολή.\n"
+"\n"
+" Πρέπει να σταδιοποιήσετε τουλάχιστον 1 αρχείο πριν να κάνετε υποβολή.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Παρακαλώ δώστε ένα μήνυμα υποβολής.\n"
+"\n"
+"Ένα σωστό μήνυμα υποβολής έχει την εξής μορφή:\n"
+"\n"
+"- Πρώτη γραμμή: Περιγραφή σε μία πρόταση του τι κάνατε.\n"
+"- Δεύτερη γραμμή: Κενή\n"
+"- Υπόλοιπες γραμμές: Περιγραφή του γιατί αυτή η αλλαγή είναι σωστή.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Γίνεται κλήση του pre-commit hook..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Η υποβολή απορρίφθηκε από το pre-commit hook."
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Γίνεται κλήση του commit-msg hook..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Η υποβολή απορρίφθηκε από το commit-msg hook."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Γίνεται υποβολή των αλλαγών..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "το write-tree απέτυχε:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Η υποβολή απέτυχε."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "Η υποβολή %s δείχνει κατεστραμμένη"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Δεν υπάρχουν αλλαγές προς υποβολή.\n"
+"\n"
+"Δεν τροποποιήθηκαν αρχεία από αυτή την υποβολή και δεν ήταν υποβολή "
+"συγχώνευσης.\n"
+"\n"
+"Θα ξεκινήσει αυτόματα επανανίχνευση τώρα.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Δεν υπάρχουν αλλαγές προς υποβολή."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "το commit-tree απέτυχε:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "το update-ref απέτυχε:"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "Δημιουργήθηκε υποβολή %s: %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Διαγραφή Κλάδου"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Διαγραφή Τοπικού Κλάδου"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Τοπικοί Κλάδοι"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Διαγραφή Μόνο Εάν Είναι Συγχωνευμένο Με"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "Οι εξής κλάδοι δεν είναι πλήρως συγχωνευμένοι με το %s:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+"Αποτυχία διαγραφής κλάδων:\n"
+"%s"
+
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Αδυναμία ξεκλειδώματος του ευρετηρίου."
+
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Σφάλμα Ευρετηρίου"
+
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Η ενημέρωση του ευρετηρίου Git απέτυχε. Θα ξεκινήσει αυτόματα επανανίχνευση "
+"για επανασυγχρονισμό του git-gui."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Συνέχεια"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Ξεκλείδωμα Ευρετηρίου"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Αποσταδιοποίηση %s από υποβολή"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "Αποσταδιοποίηση %s από υποβολή"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Έτοιμο προς υποβολή."
+
+#: lib/index.tcl:346
+msgid "Adding selected files"
+msgstr ""
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "Προσθήκη %s"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr ""
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Αναίρεση αλλαγών στο αρχείο %s;"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Αναίρεση αλλαγών σε αυτά τα %i αρχεία;"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Όλες οι μη σταδιοποιημένες αλλαγές θα χαθούν οριστικά από την αναίρεση."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Καμία Ενέργεια"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Γίνεται διαγραφή κλάδων από %s"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Αναίρεση αλλαγών σε αυτά τα %i αρχεία;"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Διαγραφή"
+
+#: lib/index.tcl:528
+#, fuzzy
+msgid "Reverting selected files"
+msgstr "Αναίρεση αλλαγών στο αρχείο %s;"
+
+#: lib/index.tcl:532
+#, fuzzy, tcl-format
+msgid "Reverting %s"
+msgstr "Αναίρεση Αλλαγών"
+
+#: lib/encoding.tcl:443
+#, fuzzy
+msgid "Default"
+msgstr "Επαναφορά Προεπιλογών"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr ""
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr ""
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Μη έγκυρη ημερομηνία από το Git: %s"
+
+#: lib/choose_rev.tcl:52
+#, fuzzy
+msgid "This Detached Checkout"
+msgstr "Αποσυνδεδεμένη Εξαγωγή"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Έκφραση Αναθεώρησης:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Τοπικός Κλάδος"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Κλάδος Παρακολούθησης"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Ετικέτα"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Μη έγκυρη αναθεώρηση: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Δεν έχει επιλεγεί αναθεώρηση."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "Η έκφραση αναθεώρησης είναι κενή."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Ενημερωμένο"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr ""
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Αριθμός ελεύθερων αντικειμένων"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Χώρος κατειλλημένος από ελεύθερα αντικείμενα"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Αριθμός πακεταρισμένων αντικειμένων"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Αριθμός πακέτων"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Χώρος κατειλλημένος από πακεταρισμένα αντικείμενα"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Πακεταρισμένα αντικείμενα έτοιμα για κλάδεμα"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Άχρηστα αρχεία"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Στατιστικά Βάσης Δεδομένων"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Γίνεται συμπίεση της βάσης δεδομένων αντικειμένων"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr ""
+"Γίνεται επαλήθευση της βάσης δεδομένων αντικειμένων με αντικείμενα fsck"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Αυτό το αποθετήριο έχει αυτή τη στιγμή περίπου %i ελεύθερα αντικείμενα.\n"
+"\n"
+"Για τη διατήρηση βέλτιστων επιδόσεων συνιστάται να συμπιέσετε τη βάση "
+"δεδομένων όταν υπάρχουν περισσότερα από %i ελεύθερα αντικείμενα.\n"
+"\n"
+"Συμπίεση της βάσης δεδομένων τώρα;"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "σφάλμα"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "προειδοποίηση"
+
+#: lib/error.tcl:80
+#, tcl-format
+msgid "%s hook failed:"
+msgstr ""
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Πρέπει να διορθώσετε τα παραπάνω λάθη πριν την υποβολή."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Cannot use funny .git directory:"
+#~ msgstr "Δεν είναι δυνατή η χρήση περίεργου φακέλου .git:"
+
+#~ msgid ""
+#~ "Unable to start gitk:\n"
+#~ "\n"
+#~ "%s does not exist"
+#~ msgstr ""
+#~ "Αδυναμία εκκίνησης του gitk:\n"
+#~ "\n"
+#~ "Το %s δεν υπάρχει"
+
+#~ msgid "Preferences..."
+#~ msgstr "Προτιμήσεις..."
+
+#~ msgid "Always (Do not perform merge test.)"
+#~ msgstr "Πάντα (Μη διενεργηθεί δοκιμή συγχώνευσης.)"
+
+#~ msgid ""
+#~ "Recovering deleted branches is difficult. \n"
+#~ "\n"
+#~ " Delete the selected branches?"
+#~ msgstr ""
+#~ "Η ανάκτηση διεγραμμένων κλάδων είναι δύσκολη.\n"
+#~ "\n"
+#~ "Διαγραφή των επιλεγμένων κλάδων;"
+
+#~ msgid "Delete Remote Branch"
+#~ msgstr "Διαγραφή Απομακρυσμένου Κλάδου"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,59 +2,60 @@
 # Translation of git-gui to French.
 # Copyright (C) 2008 Shawn Pearce, et al.
 # This file is distributed under the same license as the git package.
-#
+# 
 # Christian Couder <chriscool@tuxfamily.org>, 2008.
 # Alexandre Bourget <alexandre.bourget@savoirfairelinux.com>, 2008.
 msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-01-26 15:47-0800\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2010-02-02 12:59+0100\n"
 "Last-Translator: Christian Couder <chriscool@tuxfamily.org>\n"
 "Language-Team: French\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.11.4\n"
 "Plural-Forms:  nplurals=2; plural=(n > 1);\n"
 
-#: git-gui.sh:41 git-gui.sh:793 git-gui.sh:807 git-gui.sh:820 git-gui.sh:903
-#: git-gui.sh:922
-msgid "git-gui: fatal error"
-msgstr "git-gui: erreur fatale"
-
-#: git-gui.sh:743
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Police invalide spécifiée dans %s :"
 
-#: git-gui.sh:779
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Police principale"
 
-#: git-gui.sh:780
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Police diff/console"
 
-#: git-gui.sh:794
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: erreur fatale"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Impossible de trouver git dans PATH."
 
-#: git-gui.sh:821
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Impossible de parser la version de Git :"
 
-#: git-gui.sh:839
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Impossible de déterminer la version de Git.\n"
 "\n"
@@ -64,483 +65,515 @@ msgstr ""
 "\n"
 "Peut-on considérer que '%s' est en version 1.5.0 ?\n"
 
-#: git-gui.sh:1128
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Impossible de trouver le répertoire git :"
 
-#: git-gui.sh:1146
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Impossible d'aller à la racine du répertoire de travail :"
 
-#: git-gui.sh:1154
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Impossible d'utiliser un dépôt nu (bare) :"
 
-#: git-gui.sh:1162
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Aucun répertoire de travail"
 
-#: git-gui.sh:1334 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Rafraîchissement du statut des fichiers..."
 
-#: git-gui.sh:1390
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Recherche de fichiers modifiés..."
 
-#: git-gui.sh:1454
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "Lancement de l'action de préparation du message de commit..."
 
-#: git-gui.sh:1471
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "Commit refusé par l'action de préparation du message de commit."
 
-#: git-gui.sh:1629 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Prêt."
 
-#: git-gui.sh:1787
+#: git-gui.sh:1966
 #, tcl-format
-msgid "Displaying only %s of %s files."
-msgstr "Affiche seulement %s fichiers sur %s."
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
 
-#: git-gui.sh:1913
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Non modifié"
 
-#: git-gui.sh:1915
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Modifié, pas indexé"
 
-#: git-gui.sh:1916 git-gui.sh:1924
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Indexé"
 
-#: git-gui.sh:1917 git-gui.sh:1925
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Portions indexées"
 
-#: git-gui.sh:1918 git-gui.sh:1926
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Indexés, manquant"
 
-#: git-gui.sh:1920
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Le type de fichier a changé, non indexé"
 
-#: git-gui.sh:1921
+#: git-gui.sh:2097 git-gui.sh:2098
+#, fuzzy
+msgid "File type changed, old type staged for commit"
+msgstr "Le type de fichier a changé, non indexé"
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Le type de fichier a changé, indexé"
 
-#: git-gui.sh:1923
+#: git-gui.sh:2100
+#, fuzzy
+msgid "File type change staged, modification not staged"
+msgstr "Le type de fichier a changé, non indexé"
+
+#: git-gui.sh:2101
+#, fuzzy
+msgid "File type change staged, file missing"
+msgstr "Le type de fichier a changé, indexé"
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Non versionné, non indexé"
 
-#: git-gui.sh:1928
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Manquant"
 
-#: git-gui.sh:1929
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Indexé pour suppression"
 
-#: git-gui.sh:1930
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Indexé pour suppression, toujours présent"
 
-#: git-gui.sh:1932 git-gui.sh:1933 git-gui.sh:1934 git-gui.sh:1935
-#: git-gui.sh:1936 git-gui.sh:1937
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Nécessite la résolution d'une fusion"
 
-#: git-gui.sh:1972
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Lancement de gitk... un instant..."
 
-#: git-gui.sh:1984
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Impossible de trouver gitk dans PATH."
 
-#: git-gui.sh:2043
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "Impossible de trouver git gui dans PATH"
 
-#: git-gui.sh:2455 lib/choose_repository.tcl:36
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Dépôt"
 
-#: git-gui.sh:2456
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Édition"
 
-#: git-gui.sh:2458 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Branche"
 
-#: git-gui.sh:2461 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Commit"
 
-#: git-gui.sh:2464 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Fusionner"
 
-#: git-gui.sh:2465 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Dépôt distant"
 
-#: git-gui.sh:2468
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Outils"
 
-#: git-gui.sh:2477
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Explorer la copie de travail"
 
-#: git-gui.sh:2483
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Naviguer dans la branche courante"
 
-#: git-gui.sh:2487
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Naviguer dans la branche..."
 
-#: git-gui.sh:2492
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Visualiser l'historique de la branche courante"
 
-#: git-gui.sh:2496
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Voir l'historique de toutes les branches"
 
-#: git-gui.sh:2503
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Parcourir l'arborescence de %s"
 
-#: git-gui.sh:2505
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Voir l'historique de la branche : %s"
 
-#: git-gui.sh:2510 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Statistiques du dépôt"
 
-#: git-gui.sh:2513 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Comprimer le dépôt"
 
-#: git-gui.sh:2516
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Vérifier le dépôt"
 
-#: git-gui.sh:2523 git-gui.sh:2527 git-gui.sh:2531 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Créer une icône sur le bureau"
 
-#: git-gui.sh:2539 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Quitter"
 
-#: git-gui.sh:2547
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Défaire"
 
-#: git-gui.sh:2550
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Refaire"
 
-#: git-gui.sh:2554 git-gui.sh:3109
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Couper"
 
-#: git-gui.sh:2557 git-gui.sh:3112 git-gui.sh:3186 git-gui.sh:3259
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Copier"
 
-#: git-gui.sh:2560 git-gui.sh:3115
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Coller"
 
-#: git-gui.sh:2563 git-gui.sh:3118 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Supprimer"
 
-#: git-gui.sh:2567 git-gui.sh:3122 git-gui.sh:3263 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: git-gui.sh:2576
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Créer..."
 
-#: git-gui.sh:2582
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Charger (checkout)..."
 
-#: git-gui.sh:2588
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Renommer..."
 
-#: git-gui.sh:2593
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Supprimer..."
 
-#: git-gui.sh:2598
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Réinitialiser..."
 
-#: git-gui.sh:2608
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Effectué"
 
-#: git-gui.sh:2610
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Commiter@@verb"
 
-#: git-gui.sh:2619 git-gui.sh:3050
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Nouveau commit"
 
-#: git-gui.sh:2627 git-gui.sh:3057
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Corriger dernier commit"
 
-#: git-gui.sh:2637 git-gui.sh:3011 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Recharger modifs."
 
-#: git-gui.sh:2643
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Indexer"
 
-#: git-gui.sh:2649
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Indexer toutes modifications"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Désindexer"
 
-#: git-gui.sh:2661 lib/index.tcl:412
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Annuler les modifications"
 
-#: git-gui.sh:2669 git-gui.sh:3310 git-gui.sh:3341
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Montrer moins de contexte"
 
-#: git-gui.sh:2673 git-gui.sh:3314 git-gui.sh:3345
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Montrer plus de contexte"
 
-#: git-gui.sh:2680 git-gui.sh:3024 git-gui.sh:3133
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Signer"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Fusion locale..."
 
-#: git-gui.sh:2701
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Abandonner fusion..."
 
-#: git-gui.sh:2713 git-gui.sh:2741
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Ajouter..."
 
-#: git-gui.sh:2717
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Pousser..."
 
-#: git-gui.sh:2721
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Supprimer branche..."
 
-#: git-gui.sh:2731 git-gui.sh:3292
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Options..."
 
-#: git-gui.sh:2742
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Supprimer..."
 
-#: git-gui.sh:2751 lib/choose_repository.tcl:50
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Aide"
 
-#: git-gui.sh:2755 git-gui.sh:2759 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "À propos de %s"
 
-#: git-gui.sh:2783
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Documentation en ligne"
 
-#: git-gui.sh:2786 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Montrer la clé SSH"
 
-#: git-gui.sh:2893
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "erreur"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "erreur fatale : pas d'infos sur le chemin %s : Fichier ou répertoire "
 "inexistant"
 
-#: git-gui.sh:2926
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Branche courante :"
 
-#: git-gui.sh:2947
-msgid "Staged Changes (Will Commit)"
-msgstr "Modifs. indexées (pour commit)"
-
-#: git-gui.sh:2967
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Modifs. non indexées"
 
-#: git-gui.sh:3017
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Modifs. indexées (pour commit)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Indexer modifs."
 
-#: git-gui.sh:3036 lib/transport.tcl:104 lib/transport.tcl:193
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Pousser"
 
-#: git-gui.sh:3071
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Message de commit initial :"
 
-#: git-gui.sh:3072
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Message de commit corrigé :"
 
-#: git-gui.sh:3073
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Message de commit initial corrigé :"
 
-#: git-gui.sh:3074
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Message de commit de fusion corrigé :"
 
-#: git-gui.sh:3075
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Message de commit de fusion :"
 
-#: git-gui.sh:3076
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Message de commit :"
 
-#: git-gui.sh:3125 git-gui.sh:3267 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Copier tout"
 
-#: git-gui.sh:3149 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Fichier :"
 
-#: git-gui.sh:3255
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Diminuer la police"
 
-#: git-gui.sh:3280
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Agrandir la police"
 
-#: git-gui.sh:3288 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Codage des caractères"
 
-#: git-gui.sh:3299
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Appliquer/Inverser section"
 
-#: git-gui.sh:3304
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Appliquer/Inverser la ligne"
 
-#: git-gui.sh:3323
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Lancer l'outil de fusion"
 
-#: git-gui.sh:3328
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Utiliser la version distante"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Utiliser la version locale"
 
-#: git-gui.sh:3336
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Revenir à la version de base"
 
-#: git-gui.sh:3354
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Voir les changments dans le sous-module"
 
-#: git-gui.sh:3358
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Voir l'historique de la branche courante du sous-module"
 
-#: git-gui.sh:3362
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Voir l'historique de toutes les branches du sous-module"
 
-#: git-gui.sh:3367
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Démarrer git gui dans le sous-module"
 
-#: git-gui.sh:3389
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Désindexer la section"
 
-#: git-gui.sh:3391
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Désindexer la ligne du commit"
 
-#: git-gui.sh:3393
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Désindexer la ligne"
 
-#: git-gui.sh:3396
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Indexer la section"
 
-#: git-gui.sh:3398
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Indexer les lignes"
 
-#: git-gui.sh:3400
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Indexer la ligne"
 
-#: git-gui.sh:3424
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Initialisation..."
 
-#: git-gui.sh:3541
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Des problèmes d'environnement sont possibles.\n"
 "\n"
@@ -549,25 +582,26 @@ msgstr ""
 "sous-processus de Git lancés par %s\n"
 "\n"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Ceci est dû à un problème connu avec\n"
 "le binaire Tcl distribué par Cygwin."
 
-#: git-gui.sh:3575
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -576,314 +610,30 @@ msgstr ""
 "de l'utilisateur) et 'user.email' (addresse email\n"
 "de l'utilisateur) dans votre fichier '~/.gitconfig'.\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - une interface graphique utilisateur pour Git"
-
-#: lib/blame.tcl:72
-msgid "File Viewer"
-msgstr "Visionneur de fichier"
-
-#: lib/blame.tcl:78
-msgid "Commit:"
-msgstr "Commit :"
-
-#: lib/blame.tcl:271
-msgid "Copy Commit"
-msgstr "Copier commit"
-
-#: lib/blame.tcl:275
-msgid "Find Text..."
-msgstr "Chercher texte..."
-
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr "Lancer la détection approfondie des copies"
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr "Montrer l'historique"
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
-msgstr "Blâmer le commit parent"
-
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Lecture de %s..."
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
-msgstr "Chargement des annotations de suivi des copies/déplacements..."
-
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr "lignes annotées"
-
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr "Chargement des annotations d'emplacement original"
-
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr "Annotation terminée."
-
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr "Occupé"
-
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr "Annotation en cours d'exécution."
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr "Recherche de copie approfondie en cours..."
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr "Chargement des annotations..."
-
-#: lib/blame.tcl:963
-msgid "Author:"
-msgstr "Auteur :"
-
-#: lib/blame.tcl:967
-msgid "Committer:"
-msgstr "Commiteur :"
-
-#: lib/blame.tcl:972
-msgid "Original File:"
-msgstr "Fichier original :"
-
-#: lib/blame.tcl:1020
-msgid "Cannot find HEAD commit:"
-msgstr "Impossible de trouver le commit HEAD :"
-
-#: lib/blame.tcl:1075
-msgid "Cannot find parent commit:"
-msgstr "Impossible de trouver le commit parent :"
-
-#: lib/blame.tcl:1090
-msgid "Unable to display parent"
-msgstr "Impossible d'afficher le parent"
-
-#: lib/blame.tcl:1091 lib/diff.tcl:320
-msgid "Error loading diff:"
-msgstr "Erreur lors du chargement des différences :"
-
-#: lib/blame.tcl:1231
-msgid "Originally By:"
-msgstr "À l'origine par :"
-
-#: lib/blame.tcl:1237
-msgid "In File:"
-msgstr "Dans le fichier :"
-
-#: lib/blame.tcl:1242
-msgid "Copied Or Moved Here By:"
-msgstr "Copié ou déplacé ici par :"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Charger la branche (checkout)"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Charger (checkout)"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:579 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:108
-msgid "Cancel"
-msgstr "Annuler"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr "Révision"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr "Options"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Récupérer la branche de suivi"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Détacher de la branche locale"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Créer une branche"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Créer une nouvelle branche"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:381
-msgid "Create"
-msgstr "Créer"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Nom de branche"
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr "Nom :"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Trouver nom de branche de suivi"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Révision initiale"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Mettre à jour une branche existante :"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Non"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Mise à jour rectiligne seulement (fast-forward)"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr "Réinitialiser"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Charger (checkout) après création"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Choisissez une branche de suivi"
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "La branche de suivi %s n'est pas une branche dans le dépôt distant."
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Fournissez un nom de branche."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "'%s' n'est pas un nom de branche acceptable."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Supprimer branche"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Supprimer branche locale"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Branches locales"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Supprimer seulement si fusionnée dans :"
-
-#: lib/branch_delete.tcl:54 lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Toujours (ne pas vérifier les fusions)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Les branches suivantes ne sont pas complètement fusionnées dans %s :"
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:217
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
-"Il est difficile de récupérer des branches supprimées.\n"
-"\n"
-"Supprimer les branches sélectionnées ?"
 
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
-"La suppression des branches suivantes a échoué :\n"
-"%s"
 
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Renommer branche"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Travail en cours... merci de patienter..."
 
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Renommer"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Fermer"
 
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Branche :"
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Succès"
 
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Nouveau nom :"
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Merci de sélectionner une branche à renommer."
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "La branche '%s' existe déjà."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Échec pour renommer '%s'."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Lancement..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "Visionneur de fichier"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Chargement de %s..."
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[Jusqu'au parent]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "Naviguer dans les fichiers de le branche"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:398
-#: lib/choose_repository.tcl:486 lib/choose_repository.tcl:497
-#: lib/choose_repository.tcl:1028
-msgid "Browse"
-msgstr "Naviguer"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Erreur : échec de la commande"
 
 #: lib/checkout_op.tcl:85
 #, tcl-format
@@ -895,11 +645,6 @@ msgstr "Récupération de %s à partir de %s"
 msgid "fatal: Cannot resolve %s"
 msgstr "erreur fatale : Impossible de résoudre %s"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr "Fermer"
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -909,6 +654,11 @@ msgstr "La branche '%s' n'existe pas."
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Échec de la configuration simplifiée de git-pull pour '%s'."
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "La branche '%s' existe déjà."
 
 #: lib/checkout_op.tcl:229
 #, tcl-format
@@ -938,13 +688,14 @@ msgid "Staging area (index) is already locked."
 msgstr "L'index (staging area) est déjà verrouillé."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "L'état lors de la dernière synchronisation ne correspond plus à l'état du "
 "dépôt.\n"
@@ -980,9 +731,10 @@ msgid "Staying on branch '%s'."
 msgstr "Le répertoire de travail reste sur la branche '%s'."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -1010,18 +762,31 @@ msgstr "Récupérer les commits perdus ne sera peut être pas facile."
 msgid "Reset '%s'?"
 msgstr "Réinitialiser '%s' ?"
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Visualiser"
 
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Annuler"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Le changement de la branche courante a échoué.\n"
@@ -1032,755 +797,222 @@ msgstr ""
 "\n"
 "Cela n'aurait pas dû se produire. %s va abandonner et se terminer."
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Sélectionner"
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "récupérer %s"
 
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Familles de polices"
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "Récupération des dernières modifications de %s"
 
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Taille de police"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "purger à distance %s"
 
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Exemple de police"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Nettoyer les branches de suivi supprimées de %s"
 
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
-"Ceci est un texte d'exemple.\n"
-"Si vous aimez ce texte, vous pouvez choisir cette police."
 
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
+#: lib/transport.tcl:26
+#, fuzzy
+msgid "Fetching new changes from all remotes"
+msgstr "Récupération des dernières modifications de %s"
 
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:386
-msgid "Create New Repository"
-msgstr "Créer nouveau dépôt"
+#: lib/transport.tcl:40
+#, fuzzy
+msgid "remote prune all remotes"
+msgstr "purger à distance %s"
 
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr "Nouveau..."
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Nettoyer les branches de suivi supprimées de %s"
 
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:471
-msgid "Clone Existing Repository"
-msgstr "Cloner un dépôt existant"
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr "Cloner..."
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:1016
-msgid "Open Existing Repository"
-msgstr "Ouvrir un dépôt existant"
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr "Ouvrir..."
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr "Dépôts récemment utilisés"
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr "Ouvrir un dépôt récent :"
-
-#: lib/choose_repository.tcl:306 lib/choose_repository.tcl:313
-#: lib/choose_repository.tcl:320
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "La création du dépôt %s a échoué :"
+msgid "push %s"
+msgstr "pousser %s"
 
-#: lib/choose_repository.tcl:391
-msgid "Directory:"
-msgstr "Répertoire :"
-
-#: lib/choose_repository.tcl:423 lib/choose_repository.tcl:550
-#: lib/choose_repository.tcl:1052
-msgid "Git Repository"
-msgstr "Dépôt Git"
-
-#: lib/choose_repository.tcl:448
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Directory %s already exists."
-msgstr "Le répertoire %s existe déjà."
+msgid "Pushing changes to %s"
+msgstr "Les modifications sont poussées vers %s"
 
-#: lib/choose_repository.tcl:452
+#: lib/transport.tcl:93
 #, tcl-format
-msgid "File %s already exists."
-msgstr "Le fichier %s existe déjà."
+msgid "Mirroring to %s"
+msgstr "Dupliquer dans %s"
 
-#: lib/choose_repository.tcl:466
-msgid "Clone"
-msgstr "Cloner"
-
-#: lib/choose_repository.tcl:479
-msgid "Source Location:"
-msgstr "Emplacement source :"
-
-#: lib/choose_repository.tcl:490
-msgid "Target Directory:"
-msgstr "Répertoire cible :"
-
-#: lib/choose_repository.tcl:502
-msgid "Clone Type:"
-msgstr "Type de clonage :"
-
-#: lib/choose_repository.tcl:508
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Standard (rapide, semi-redondant, liens durs)"
-
-#: lib/choose_repository.tcl:514
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Copie complète (plus lent, sauvegarde redondante)"
-
-#: lib/choose_repository.tcl:520
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Partagé (le plus rapide, non recommandé, pas de sauvegarde)"
-
-#: lib/choose_repository.tcl:556 lib/choose_repository.tcl:603
-#: lib/choose_repository.tcl:749 lib/choose_repository.tcl:819
-#: lib/choose_repository.tcl:1058 lib/choose_repository.tcl:1066
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "'%s' n'est pas un dépôt Git."
+msgid "Pushing %s %s to %s"
+msgstr "Pousse %s %s vers %s"
 
-#: lib/choose_repository.tcl:592
-msgid "Standard only available for local repository."
-msgstr "Standard n'est disponible que pour un dépôt local."
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Pousser branches"
 
-#: lib/choose_repository.tcl:596
-msgid "Shared only available for local repository."
-msgstr "Partagé n'est disponible que pour un dépôt local."
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Branches source"
 
-#: lib/choose_repository.tcl:617
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "L'emplacement %s existe déjà."
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Dépôt de destination"
 
-#: lib/choose_repository.tcl:628
-msgid "Failed to configure origin"
-msgstr "La configuration de l'origine a échoué."
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Branche distante :"
 
-#: lib/choose_repository.tcl:640
-msgid "Counting objects"
-msgstr "Décompte des objets"
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Emplacement arbitraire :"
 
-#: lib/choose_repository.tcl:641
-msgid "buckets"
-msgstr "paniers"
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Options de transfert"
 
-#: lib/choose_repository.tcl:665
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Impossible de copier 'objects/info/alternates' : %s"
-
-#: lib/choose_repository.tcl:701
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Il n'y a rien à cloner depuis %s."
-
-#: lib/choose_repository.tcl:703 lib/choose_repository.tcl:917
-#: lib/choose_repository.tcl:929
-msgid "The 'master' branch has not been initialized."
-msgstr "La branche 'master' n'a pas été initialisée."
-
-#: lib/choose_repository.tcl:716
-msgid "Hardlinks are unavailable.  Falling back to copying."
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
 msgstr ""
-"Les liens durs ne sont pas supportés. Une copie sera effectuée à la place."
+"Forcer l'écrasement d'une branche existante (peut supprimer des "
+"modifications)"
 
-#: lib/choose_repository.tcl:728
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Utiliser des petits paquets (pour les connexions lentes)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Inclure les marques (tags)"
+
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Cloning from %s"
-msgstr "Clonage depuis %s"
-
-#: lib/choose_repository.tcl:759
-msgid "Copying objects"
-msgstr "Copie des objets"
-
-#: lib/choose_repository.tcl:760
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:784
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Impossible de copier l'objet : %s"
-
-#: lib/choose_repository.tcl:794
-msgid "Linking objects"
-msgstr "Liaison des objets"
-
-#: lib/choose_repository.tcl:795
-msgid "objects"
-msgstr "objets"
-
-#: lib/choose_repository.tcl:803
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Impossible créer un lien dur pour l'objet : %s"
-
-#: lib/choose_repository.tcl:858
-msgid "Cannot fetch branches and objects.  See console output for details."
+msgid "%s (%s): Push"
 msgstr ""
-"Impossible de récupérer les branches et objets. Voir la sortie console pour "
-"plus de détails."
 
-#: lib/choose_repository.tcl:869
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-"Impossible de récupérer les marques (tags). Voir la sortie console pour plus "
-"de détails."
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "Ajouter un dépôt distant"
 
-#: lib/choose_repository.tcl:893
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-"Impossible de déterminer HEAD. Voir la sortie console pour plus de détails."
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Ajouter un nouveau dépôt distant"
 
-#: lib/choose_repository.tcl:902
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Ajouter"
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Détails des dépôts distants"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Nom :"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Emplacement :"
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Action supplémentaire"
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Récupérer immédiatement"
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Initialiser un dépôt distant et pousser"
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr "Ne rien faire d'autre maintenant"
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Merci de fournir un nom de dépôt distant."
+
+#: lib/remote_add.tcl:113
 #, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Impossible de nettoyer %s"
+msgid "'%s' is not an acceptable remote name."
+msgstr "'%s' n'est pas un nom de dépôt distant acceptable."
 
-#: lib/choose_repository.tcl:908
-msgid "Clone failed."
-msgstr "Le clonage a échoué."
-
-#: lib/choose_repository.tcl:915
-msgid "No default branch obtained."
-msgstr "Aucune branche par défaut n'a été obtenue."
-
-#: lib/choose_repository.tcl:926
+#: lib/remote_add.tcl:124
 #, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Impossible de résoudre %s comme commit."
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Échec de l'ajout du dépôt distant '%s' à l'emplacement '%s'."
 
-#: lib/choose_repository.tcl:938
-msgid "Creating working directory"
-msgstr "Création du répertoire de travail"
-
-#: lib/choose_repository.tcl:939 lib/index.tcl:67 lib/index.tcl:130
-#: lib/index.tcl:198
-msgid "files"
-msgstr "fichiers"
-
-#: lib/choose_repository.tcl:968
-msgid "Initial file checkout failed."
-msgstr "Le chargement initial du fichier a échoué."
-
-#: lib/choose_repository.tcl:1011
-msgid "Open"
-msgstr "Ouvrir"
-
-#: lib/choose_repository.tcl:1021
-msgid "Repository:"
-msgstr "Dépôt :"
-
-#: lib/choose_repository.tcl:1072
+#: lib/remote_add.tcl:133
 #, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Impossible d'ouvrir le dépôt %s :"
+msgid "Fetching the %s"
+msgstr "Récupération de %s"
 
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "Cet emprunt détaché"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Expression de révision :"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Branche locale"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Branche de suivi"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Marque (tag)"
-
-#: lib/choose_rev.tcl:317
+#: lib/remote_add.tcl:156
 #, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Révision invalide : %s"
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "Pas de méthode connue pour initialiser le dépôt à l'emplacement '%s'."
 
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Pas de révision sélectionnée."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "L'expression de révision est vide."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Mise à jour:"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"Il n'y a rien à corriger.\n"
-"\n"
-"Vous allez créer le commit initial. Il n'y a pas de commit avant celui-ci à "
-"corriger.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Impossible de corriger pendant une fusion.\n"
-"\n"
-"Vous êtes actuellement au milieu d'une fusion qui n'a pas été complètement "
-"terminée. Vous ne pouvez pas corriger le commit précédent sauf si vous "
-"abandonnez la fusion courante.\n"
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Erreur lors du chargement des données de commit pour correction :"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Impossible d'obtenir votre identité :"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "GIT_COMMITTER_IDENT invalide :"
-
-#: lib/commit.tcl:129
+#: lib/remote_add.tcl:163
 #, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "attention : Tcl ne supporte pas le codage '%s'."
+msgid "Setting up the %s (at %s)"
+msgstr "Mise en place de %s (à %s)"
 
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"L'état lors de la dernière synchronisation ne correspond plus à l'état du "
-"dépôt.\n"
-"\n"
-"Un autre programme Git a modifié ce dépôt depuis la dernière "
-"synchronisation. Une resynshronisation doit être effectuée avant de pouvoir "
-"créer un nouveau commit.\n"
-"\n"
-"Cela va être fait tout de suite automatiquement.\n"
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Lancement..."
 
-#: lib/commit.tcl:172
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Visionneur de fichier"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
 #, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"Des fichiers non fusionnés ne peuvent être commités.\n"
-"\n"
-"Le fichier %s a des conflicts de fusion. Vous devez les résoudre et pré-"
-"commiter le fichier avant de pouvoir commiter.\n"
-
-#: lib/commit.tcl:180
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Un état de fichier inconnu %s a été détecté.\n"
-"\n"
-"Le fichier %s ne peut pas être commité par ce programme.\n"
-
-#: lib/commit.tcl:188
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Pas de modification à commiter.\n"
-"\n"
-"Vous devez indexer au moins 1 fichier avant de pouvoir commiter.\n"
-
-#: lib/commit.tcl:203
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Merci de fournir un message de commit.\n"
-"\n"
-"Un bon message de commit a le format suivant :\n"
-"\n"
-"- Première ligne : décrire en une phrase ce que vous avez fait.\n"
-"- Deuxième ligne : rien.\n"
-"- Lignes suivantes : Décrire pourquoi ces modifications sont bonnes.\n"
-
-#: lib/commit.tcl:234
-msgid "Calling pre-commit hook..."
-msgstr "Lancement de l'action d'avant-commit..."
-
-#: lib/commit.tcl:249
-msgid "Commit declined by pre-commit hook."
-msgstr "Commit refusé par l'action d'avant-commit."
-
-#: lib/commit.tcl:272
-msgid "Calling commit-msg hook..."
-msgstr "Lancement de l'action \"message de commit\"..."
-
-#: lib/commit.tcl:287
-msgid "Commit declined by commit-msg hook."
-msgstr "Commit refusé par l'action \"message de commit\"."
-
-#: lib/commit.tcl:300
-msgid "Committing changes..."
-msgstr "Commit des modifications..."
-
-#: lib/commit.tcl:316
-msgid "write-tree failed:"
-msgstr "write-tree a échoué :"
-
-#: lib/commit.tcl:317 lib/commit.tcl:361 lib/commit.tcl:382
-msgid "Commit failed."
-msgstr "Le commit a échoué."
-
-#: lib/commit.tcl:334
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Le commit %s semble être corrompu"
-
-#: lib/commit.tcl:339
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Pas de modification à commiter.\n"
-"\n"
-"Aucun fichier n'a été modifié par ce commit et il ne s'agit pas d'un commit "
-"de fusion.\n"
-"\n"
-"Une resynchronisation va être lancée tout de suite automatiquement.\n"
-
-#: lib/commit.tcl:346
-msgid "No changes to commit."
-msgstr "Pas de modifications à commiter."
-
-#: lib/commit.tcl:360
-msgid "commit-tree failed:"
-msgstr "commit-tree a échoué :"
-
-#: lib/commit.tcl:381
-msgid "update-ref failed:"
-msgstr "update-ref a échoué :"
-
-#: lib/commit.tcl:469
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Commit %s créé : %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Travail en cours... merci de patienter..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Succès"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Erreur : échec de la commande"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Nombre d'objets en fichier particulier"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Espace disque utilisé par les fichiers particuliers"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Nombre d'objets empaquetés"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Nombre de paquets d'objets"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "Espace disque utilisé par les objets empaquetés"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Objets empaquetés attendant d'être supprimés"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "Fichiers poubelle"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Compression de la base des objets"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Vérification de la base des objets avec fsck-objects"
-
-#: lib/database.tcl:107
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Ce dépôt comprend actuellement environ %i objets ayant leur fichier "
-"particulier.\n"
-"\n"
-"Pour conserver une performance optimale, il est fortement recommandé de "
-"comprimer la base de donnée.\n"
-"\n"
-"Comprimer la base maintenant ?"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Date invalide de Git : %s"
-
-#: lib/diff.tcl:64
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Aucune différence détectée.\n"
-"\n"
-"%s ne comporte aucune modification.\n"
-"\n"
-"La date de modification de ce fichier a été mise à jour par une autre "
-"application, mais le contenu du fichier n'a pas changé.\n"
-"\n"
-"Une resynchronisation va être lancée automatiquement pour trouver d'autres "
-"fichiers qui pourraient se trouver dans le même état."
-
-#: lib/diff.tcl:104
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Chargement des différences de %s..."
-
-#: lib/diff.tcl:125
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-"LOCAL : supprimé\n"
-"DISTANT :\n"
-
-#: lib/diff.tcl:130
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-"DISTANT : supprimé\n"
-"LOCAL :\n"
-
-#: lib/diff.tcl:137
-msgid "LOCAL:\n"
-msgstr "LOCAL :\n"
-
-#: lib/diff.tcl:140
-msgid "REMOTE:\n"
-msgstr "DISTANT :\n"
-
-#: lib/diff.tcl:202 lib/diff.tcl:319
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Impossible d'afficher %s"
-
-#: lib/diff.tcl:203
-msgid "Error loading file:"
-msgstr "Erreur lors du chargement du fichier :"
-
-#: lib/diff.tcl:210
-msgid "Git Repository (subproject)"
-msgstr "Dépôt Git (sous projet)"
-
-#: lib/diff.tcl:222
-msgid "* Binary file (not showing content)."
-msgstr "* Fichier binaire (pas d'apperçu du contenu)."
-
-#: lib/diff.tcl:227
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* Le fichier non suivi fait %d octets.\n"
-"* Seuls les %d premiers octets sont montrés.\n"
-
-#: lib/diff.tcl:233
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-"\n"
-"* Fichier suivi raccourcis ici de %s.\n"
-"* Pour voir le fichier entier, utilisez un éditeur externe.\n"
-
-#: lib/diff.tcl:482
-msgid "Failed to unstage selected hunk."
-msgstr "Échec lors de la désindexation de la section sélectionnée."
-
-#: lib/diff.tcl:489
-msgid "Failed to stage selected hunk."
-msgstr "Échec lors de l'indexation de la section."
-
-#: lib/diff.tcl:568
-msgid "Failed to unstage selected line."
-msgstr "Échec lors de la désindexation de la ligne sélectionnée."
-
-#: lib/diff.tcl:576
-msgid "Failed to stage selected line."
-msgstr "Échec lors de l'indexation de la ligne."
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Défaut"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Système (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Autre"
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "erreur"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "attention"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr "Vous devez corriger les erreurs suivantes avant de pouvoir commiter."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Impossible de déverrouiller l'index."
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Erreur de l'index"
-
-#: lib/index.tcl:17
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"Échec de la mise à jour de l'index. Une resynchronisation va être lancée "
-"automatiquement."
-
-#: lib/index.tcl:28
-msgid "Continue"
-msgstr "Continuer"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Déverrouiller l'index"
-
-#: lib/index.tcl:289
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Désindexation de : %s"
-
-#: lib/index.tcl:328
-msgid "Ready to commit."
-msgstr "Prêt à être commité."
-
-#: lib/index.tcl:341
-#, tcl-format
-msgid "Adding %s"
-msgstr "Ajout de %s"
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Annuler les modifications dans le fichier %s ? "
-
-#: lib/index.tcl:400
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Annuler les modifications dans ces %i fichiers ?"
-
-#: lib/index.tcl:408
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Toutes les modifications non-indexées seront définitivement perdues par "
-"l'annulation."
-
-#: lib/index.tcl:411
-msgid "Do Nothing"
-msgstr "Ne rien faire"
-
-#: lib/index.tcl:429
-msgid "Reverting selected files"
-msgstr "Annuler modifications dans fichiers selectionnés"
-
-#: lib/index.tcl:433
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Annulation des modifications dans %s"
+msgid "Loading %s..."
+msgstr "Chargement de %s..."
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Jusqu'au parent]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Naviguer dans les fichiers de le branche"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Naviguer dans les fichiers de le branche"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Naviguer"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Révision"
 
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Impossible de fusionner pendant une correction.\n"
 "\n"
@@ -1788,13 +1020,14 @@ msgstr ""
 "fusion.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "L'état lors de la dernière synchronisation ne correspond plus à l'état du "
 "dépôt.\n"
@@ -1806,14 +1039,14 @@ msgstr ""
 "Cela va être fait tout de suite automatiquement\n"
 
 #: lib/merge.tcl:45
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "Vous êtes au milieu d'une fusion conflictuelle.\n"
 "\n"
@@ -1824,14 +1057,14 @@ msgstr ""
 "d'effectuer une nouvelle fusion.\n"
 
 #: lib/merge.tcl:55
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "Vous êtes au milieu d'une modification.\n"
 "\n"
@@ -1841,49 +1074,57 @@ msgstr ""
 "faisait comme cela, vous éviterez de devoir éventuellement abandonner une "
 "fusion ayant échoué.\n"
 
-#: lib/merge.tcl:107
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s de %s"
 
-#: lib/merge.tcl:120
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Fusion de %s et %s..."
 
-#: lib/merge.tcl:131
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "La fusion s'est faite avec succès."
 
-#: lib/merge.tcl:133
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "La fusion a echoué. Il est nécessaire de résoudre les conflits."
 
-#: lib/merge.tcl:158
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Fusion dans %s"
 
-#: lib/merge.tcl:177
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Révision à fusionner"
 
-#: lib/merge.tcl:212
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "Impossible d'abandonner en cours de correction.\n"
 "\n"
 "Vous devez finir de corriger ce commit.\n"
 
-#: lib/merge.tcl:222
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Abandonner la fusion ?\n"
@@ -1893,12 +1134,13 @@ msgstr ""
 "\n"
 "Abandonner quand même la fusion courante ?"
 
-#: lib/merge.tcl:228
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Réinitialiser les modifications ?\n"
@@ -1908,418 +1150,81 @@ msgstr ""
 "\n"
 "Réinitialiser quand même les modifications courantes ?"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Abandon"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "fichiers réinitialisés"
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "L'abandon a échoué."
 
-#: lib/merge.tcl:269
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "Abandon teminé. Prêt."
 
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Forcer la résolution à la version de base ?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Forcer la résolution à cette branche ?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Forcer la résolution à l'autre branche ?"
-
-#: lib/mergetool.tcl:14
+#: lib/tools.tcl:76
 #, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Noter que le diff ne montre que les modifications en conflit.\n"
-"\n"
-"%s sera écrasé.\n"
-"\n"
-"Cette opération ne peut être inversée qu'en relançant la fusion."
+msgid "Running %s requires a selected file."
+msgstr "Lancer %s nécessite qu'un fichier soit sélectionné."
 
-#: lib/mergetool.tcl:45
+#: lib/tools.tcl:92
+#, fuzzy, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Êtes-vous sûr de vouloir lancer %s ?"
+
+#: lib/tools.tcl:96
 #, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-"Le fichier %s semble avoir des conflits non résolus, indexer quand même ?"
+msgid "Are you sure you want to run %s?"
+msgstr "Êtes-vous sûr de vouloir lancer %s ?"
 
-#: lib/mergetool.tcl:60
+#: lib/tools.tcl:118
 #, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Ajouter une résolution pour %s"
+msgid "Tool: %s"
+msgstr "Outil : %s"
 
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-"Impossible de résoudre la suppression ou de relier des conflits en utilisant "
-"un outil"
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "Le fichier en conflit n'existe pas."
-
-#: lib/mergetool.tcl:264
+#: lib/tools.tcl:119
 #, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "'%s' n'est pas un outil graphique pour fusionner des fichiers."
+msgid "Running: %s"
+msgstr "Lancement de : %s"
 
-#: lib/mergetool.tcl:268
+#: lib/tools.tcl:158
 #, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "Outil de fusion '%s' non supporté"
+msgid "Tool completed successfully: %s"
+msgstr "L'outil a terminé avec succès : %s"
 
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr "L'outil de fusion tourne déjà, faut-il le terminer ?"
-
-#: lib/mergetool.tcl:323
+#: lib/tools.tcl:160
 #, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Erreur lors de la récupération des versions :\n"
-"%s"
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-"Impossible de lancer l'outil de fusion :\n"
-"\n"
-"%s"
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr "Lancement de l'outil de fusion..."
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr "L'outil de fusion a échoué."
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr "Codage global '%s' invalide"
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr "Codage de dépôt '%s' invalide"
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr "Remettre les valeurs par défaut"
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr "Sauvegarder"
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr "Dépôt : %s"
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr "Globales (tous les dépôts)"
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr "Nom d'utilisateur"
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr "Adresse email"
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr "Résumer les commits de fusion"
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr "Fusion bavarde"
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr "Montrer statistiques de diff après fusion"
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr "Utiliser outil de fusion"
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr "Faire confiance aux dates de modification de fichiers "
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr "Purger les branches de suivi pendant la récupération"
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr "Faire correspondre les branches de suivi"
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr "Annoter les copies seulement sur fichiers modifiés"
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr "Minimum de caratères pour annoter une copie"
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr "Distance de blâme dans l'historique (jours)"
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr "Nombre de lignes de contexte dans les diffs"
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr "Largeur du texte de message de commit"
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr "Nouveau modèle de nom de branche"
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr "Codage du contenu des fichiers par défaut"
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr "Modifier"
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr "Dictionnaire d'orthographe :"
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr "Modifier les polices"
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr "Choisir %s"
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr "pt."
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr "Préférences"
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr "La sauvegarde complète des options a échoué :"
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr "Supprimer un dépôt distant"
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr "Purger de"
-
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr "Récupérer de"
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr "Pousser vers"
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
-msgstr "Ajouter un dépôt distant"
-
-#: lib/remote_add.tcl:24
-msgid "Add New Remote"
-msgstr "Ajouter un nouveau dépôt distant"
-
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
-msgid "Add"
-msgstr "Ajouter"
-
-#: lib/remote_add.tcl:37
-msgid "Remote Details"
-msgstr "Détails des dépôts distants"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Emplacement :"
-
-#: lib/remote_add.tcl:62
-msgid "Further Action"
-msgstr "Action supplémentaire"
-
-#: lib/remote_add.tcl:65
-msgid "Fetch Immediately"
-msgstr "Récupérer immédiatement"
-
-#: lib/remote_add.tcl:71
-msgid "Initialize Remote Repository and Push"
-msgstr "Initialiser un dépôt distant et pousser"
-
-#: lib/remote_add.tcl:77
-msgid "Do Nothing Else Now"
-msgstr "Ne rien faire d'autre maintenant"
-
-#: lib/remote_add.tcl:101
-msgid "Please supply a remote name."
-msgstr "Merci de fournir un nom de dépôt distant."
-
-#: lib/remote_add.tcl:114
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "'%s' n'est pas un nom de dépôt distant acceptable."
-
-#: lib/remote_add.tcl:125
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Échec de l'ajout du dépôt distant '%s' à l'emplacement '%s'."
-
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "récupérer %s"
-
-#: lib/remote_add.tcl:134
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "Récupération de %s"
-
-#: lib/remote_add.tcl:157
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Pas de méthode connue pour initialiser le dépôt à l'emplacement '%s'."
-
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:63
-#: lib/transport.tcl:81
-#, tcl-format
-msgid "push %s"
-msgstr "pousser %s"
-
-#: lib/remote_add.tcl:164
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "Mise en place de %s (à %s)"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Supprimer une branche à distance"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "Dépôt source"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:134
-msgid "Remote:"
-msgstr "Branche distante :"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:149
-msgid "Arbitrary Location:"
-msgstr "Emplacement arbitraire :"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Branches"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Supprimer seulement si"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Fusionné dans :"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "Une branche est nécessaire pour 'Fusionné dans'."
-
-#: lib/remote_branch_delete.tcl:184
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-"Les branches suivantes ne sont pas complètement fusionnées dans %s :\n"
-"\n"
-" - %s"
-
-#: lib/remote_branch_delete.tcl:189
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-"Un ou plusieurs des tests de fusion ont échoué parce que vous n'avez pas "
-"récupéré les commits nécessaires. Essayez de récupérer à partir de %s "
-"d'abord."
-
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Merci de sélectionner une ou plusieurs branches à supprimer."
-
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Suppression des branches de %s"
-
-#: lib/remote_branch_delete.tcl:292
-msgid "No repository selected."
-msgstr "Aucun dépôt n'est sélectionné."
-
-#: lib/remote_branch_delete.tcl:297
-#, tcl-format
-msgid "Scanning %s..."
-msgstr "Synchronisation de %s..."
-
-#: lib/search.tcl:21
-msgid "Find:"
-msgstr "Chercher :"
-
-#: lib/search.tcl:23
-msgid "Next"
-msgstr "Suivant"
-
-#: lib/search.tcl:24
-msgid "Prev"
-msgstr "Précédent"
-
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
-msgstr "Sensible à la casse"
-
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "Impossible d'écrire le raccourci :"
-
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "Impossible d'écrire l'icône :"
+msgid "Tool failed: %s"
+msgstr "L'outil a échoué : %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Charger la branche (checkout)"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Charger la branche (checkout)"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Charger (checkout)"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Options"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Récupérer la branche de suivi"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Détacher de la branche locale"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -2358,6 +1263,1018 @@ msgstr "EOF inattendue envoyée par le vérificateur d'orthographe"
 msgid "Spell Checker Failed"
 msgstr "Le vérificateur d'orthographe a échoué"
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s ... %*i de %*i %s (%3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Aucune différence détectée.\n"
+"\n"
+"%s ne comporte aucune modification.\n"
+"\n"
+"La date de modification de ce fichier a été mise à jour par une autre "
+"application, mais le contenu du fichier n'a pas changé.\n"
+"\n"
+"Une resynchronisation va être lancée automatiquement pour trouver d'autres "
+"fichiers qui pourraient se trouver dans le même état."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Chargement des différences de %s..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"LOCAL : supprimé\n"
+"DISTANT :\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"DISTANT : supprimé\n"
+"LOCAL :\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "LOCAL :\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "DISTANT :\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Impossible d'afficher %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Erreur lors du chargement du fichier :"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Dépôt Git (sous projet)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Fichier binaire (pas d'apperçu du contenu)."
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* Fichier suivi raccourcis ici de %s.\n"
+"* Pour voir le fichier entier, utilisez un éditeur externe.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Erreur lors du chargement des différences :"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Échec lors de la désindexation de la section sélectionnée."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Échec lors de l'indexation de la section."
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Échec lors de la désindexation de la ligne sélectionnée."
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Échec lors de l'indexation de la ligne."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Pousser vers"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Supprimer un dépôt distant"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Purger de"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Récupérer de"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Sélectionner"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Familles de polices"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Taille de police"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Exemple de police"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Ceci est un texte d'exemple.\n"
+"Si vous aimez ce texte, vous pouvez choisir cette police."
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr "Codage global '%s' invalide"
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr "Codage de dépôt '%s' invalide"
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Remettre les valeurs par défaut"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Sauvegarder"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "Dépôt : %s"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Globales (tous les dépôts)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Nom d'utilisateur"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Adresse email"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "Résumer les commits de fusion"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Fusion bavarde"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Montrer statistiques de diff après fusion"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr "Utiliser outil de fusion"
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "Faire confiance aux dates de modification de fichiers "
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr "Purger les branches de suivi pendant la récupération"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "Faire correspondre les branches de suivi"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr "Annoter les copies seulement sur fichiers modifiés"
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Dépôts récemment utilisés"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr "Minimum de caratères pour annoter une copie"
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr "Distance de blâme dans l'historique (jours)"
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Nombre de lignes de contexte dans les diffs"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Largeur du texte de message de commit"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Nouveau modèle de nom de branche"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr "Codage du contenu des fichiers par défaut"
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr "Modifier"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Dictionnaire d'orthographe :"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Modifier les polices"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "Choisir %s"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "pt."
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Préférences"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "La sauvegarde complète des options a échoué :"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Forcer la résolution à la version de base ?"
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Forcer la résolution à cette branche ?"
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Forcer la résolution à l'autre branche ?"
+
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"Noter que le diff ne montre que les modifications en conflit.\n"
+"\n"
+"%s sera écrasé.\n"
+"\n"
+"Cette opération ne peut être inversée qu'en relançant la fusion."
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+"Le fichier %s semble avoir des conflits non résolus, indexer quand même ?"
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr "Ajouter une résolution pour %s"
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+"Impossible de résoudre la suppression ou de relier des conflits en utilisant "
+"un outil"
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "Le fichier en conflit n'existe pas."
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "'%s' n'est pas un outil graphique pour fusionner des fichiers."
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr "Outil de fusion '%s' non supporté"
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "L'outil de fusion tourne déjà, faut-il le terminer ?"
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Erreur lors de la récupération des versions :\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+"Impossible de lancer l'outil de fusion :\n"
+"\n"
+"%s"
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "Lancement de l'outil de fusion..."
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "L'outil de fusion a échoué."
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "Ajouter un outil"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "Ajouter une nouvelle commande d'outil"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "Ajouter globalement"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "Détails sur l'outil"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "Utiliser les séparateurs '/' pour créer un arbre de sous-menus :"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "Commande :"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "Montrer une boîte de dialogue avant le lancement"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr ""
+"Demander à l'utilisateur de sélectionner une révision (change $REVISION)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "Demander à l'utilisateur des arguments supplémentaires (change $ARGS)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "Ne pas montrer la fenêtre de sortie des commandes"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "Lancer seulement si un diff est sélectionné ($FILENAME non vide)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "Merci de fournir un nom pour l'outil."
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "L'outil '%s' existe déjà."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+"Impossible d'ajouter l'outil :\n"
+"%s"
+
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "Supprimer l'outil"
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "Supprimer des commandes d'outil"
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "Supprimer"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(Le bleu indique des outils locaux au dépôt)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Système (%s)"
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "Lancer commande : %s"
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "Arguments"
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "OK"
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Chercher :"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Suivant"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Précédent"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Créer une icône sur le bureau"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Impossible d'écrire le raccourci :"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Impossible d'écrire l'icône :"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Renommer branche"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Renommer branche"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Renommer"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Branche :"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Nouveau nom :"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Merci de sélectionner une branche à renommer."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Fournissez un nom de branche."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "'%s' n'est pas un nom de branche acceptable."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Échec pour renommer '%s'."
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Supprimer une branche à distance"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Supprimer une branche à distance"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Dépôt source"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Branches"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Supprimer seulement si"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Fusionné dans :"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Toujours (ne pas vérifier les fusions)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "Une branche est nécessaire pour 'Fusionné dans'."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"Les branches suivantes ne sont pas complètement fusionnées dans %s :\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Un ou plusieurs des tests de fusion ont échoué parce que vous n'avez pas "
+"récupéré les commits nécessaires. Essayez de récupérer à partir de %s "
+"d'abord."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Merci de sélectionner une ou plusieurs branches à supprimer."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Il est difficile de récupérer des branches supprimées.\n"
+"\n"
+"Supprimer les branches sélectionnées ?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Suppression des branches de %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Aucun dépôt n'est sélectionné."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Synchronisation de %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Créer nouveau dépôt"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Nouveau..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Cloner un dépôt existant"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Cloner..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Ouvrir un dépôt existant"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Ouvrir..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Dépôts récemment utilisés"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Ouvrir un dépôt récent :"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "La création du dépôt %s a échoué :"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Créer"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Répertoire :"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Dépôt Git"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "Le répertoire %s existe déjà."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Le fichier %s existe déjà."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Cloner"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Emplacement source :"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Répertoire cible :"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Type de clonage :"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Standard (rapide, semi-redondant, liens durs)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Copie complète (plus lent, sauvegarde redondante)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Partagé (le plus rapide, non recommandé, pas de sauvegarde)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "'%s' n'est pas un dépôt Git."
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Standard n'est disponible que pour un dépôt local."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "Partagé n'est disponible que pour un dépôt local."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "L'emplacement %s existe déjà."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "La configuration de l'origine a échoué."
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Décompte des objets"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "paniers"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Impossible de copier 'objects/info/alternates' : %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Il n'y a rien à cloner depuis %s."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "La branche 'master' n'a pas été initialisée."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr ""
+"Les liens durs ne sont pas supportés. Une copie sera effectuée à la place."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Clonage depuis %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Copie des objets"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Impossible de copier l'objet : %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Liaison des objets"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "objets"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Impossible créer un lien dur pour l'objet : %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Impossible de récupérer les branches et objets. Voir la sortie console pour "
+"plus de détails."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+"Impossible de récupérer les marques (tags). Voir la sortie console pour plus "
+"de détails."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+"Impossible de déterminer HEAD. Voir la sortie console pour plus de détails."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Impossible de nettoyer %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Le clonage a échoué."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Aucune branche par défaut n'a été obtenue."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Impossible de résoudre %s comme commit."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Création du répertoire de travail"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "fichiers"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Clonage depuis %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Le chargement initial du fichier a échoué."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Ouvrir"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Dépôt :"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Impossible d'ouvrir le dépôt %s :"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - une interface graphique utilisateur pour Git"
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Visionneur de fichier"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Commit :"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Copier commit"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Chercher texte..."
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Cloner..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Lancer la détection approfondie des copies"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Montrer l'historique"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Blâmer le commit parent"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Lecture de %s..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Chargement des annotations de suivi des copies/déplacements..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "lignes annotées"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Chargement des annotations d'emplacement original"
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Annotation terminée."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Occupé"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "Annotation en cours d'exécution."
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Recherche de copie approfondie en cours..."
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Chargement des annotations..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Auteur :"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Commiteur :"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Fichier original :"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Impossible de trouver le commit HEAD :"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Impossible de trouver le commit parent :"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Impossible d'afficher le parent"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "À l'origine par :"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "Dans le fichier :"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Copié ou déplacé ici par :"
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr "Aucune clé trouvée."
@@ -2371,19 +2288,19 @@ msgstr "Clé publique trouvée dans : %s"
 msgid "Generate Key"
 msgstr "Générer une clé"
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "Copier dans le presse-papier"
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "Votre clé publique OpenSSH"
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Génération..."
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2394,205 +2311,557 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr "La génération a échoué."
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr "La génération a réussi, mais aucune clé n'a été trouvée."
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "Votre clé est dans : %s"
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Créer une branche"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Créer une nouvelle branche"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Nom de branche"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Trouver nom de branche de suivi"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Révision initiale"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Mettre à jour une branche existante :"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Non"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Mise à jour rectiligne seulement (fast-forward)"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Charger (checkout) après création"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Choisissez une branche de suivi"
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s ... %*i de %*i %s (%3i%%)"
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "La branche de suivi %s n'est pas une branche dans le dépôt distant."
 
-#: lib/tools.tcl:75
-#, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "Lancer %s nécessite qu'un fichier soit sélectionné."
-
-#: lib/tools.tcl:90
-#, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Êtes-vous sûr de vouloir lancer %s ?"
-
-#: lib/tools.tcl:110
-#, tcl-format
-msgid "Tool: %s"
-msgstr "Outil : %s"
-
-#: lib/tools.tcl:111
-#, tcl-format
-msgid "Running: %s"
-msgstr "Lancement de : %s"
-
-#: lib/tools.tcl:149
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "L'outil a terminé avec succès : %s"
-
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "L'outil a échoué : %s"
-
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "Ajouter un outil"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "Ajouter une nouvelle commande d'outil"
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr "Ajouter globalement"
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr "Détails sur l'outil"
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "Utiliser les séparateurs '/' pour créer un arbre de sous-menus :"
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr "Commande :"
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr "Montrer une boîte de dialogue avant le lancement"
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
 msgstr ""
-"Demander à l'utilisateur de sélectionner une révision (change $REVISION)"
+"Il n'y a rien à corriger.\n"
+"\n"
+"Vous allez créer le commit initial. Il n'y a pas de commit avant celui-ci à "
+"corriger.\n"
 
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "Demander à l'utilisateur des arguments supplémentaires (change $ARGS)"
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Impossible de corriger pendant une fusion.\n"
+"\n"
+"Vous êtes actuellement au milieu d'une fusion qui n'a pas été complètement "
+"terminée. Vous ne pouvez pas corriger le commit précédent sauf si vous "
+"abandonnez la fusion courante.\n"
 
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr "Ne pas montrer la fenêtre de sortie des commandes"
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Erreur lors du chargement des données de commit pour correction :"
 
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "Lancer seulement si un diff est sélectionné ($FILENAME non vide)"
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Impossible d'obtenir votre identité :"
 
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr "Merci de fournir un nom pour l'outil."
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "GIT_COMMITTER_IDENT invalide :"
 
-#: lib/tools_dlg.tcl:129
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "L'outil '%s' existe déjà."
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "attention : Tcl ne supporte pas le codage '%s'."
 
-#: lib/tools_dlg.tcl:151
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"L'état lors de la dernière synchronisation ne correspond plus à l'état du "
+"dépôt.\n"
+"\n"
+"Un autre programme Git a modifié ce dépôt depuis la dernière "
+"synchronisation. Une resynshronisation doit être effectuée avant de pouvoir "
+"créer un nouveau commit.\n"
+"\n"
+"Cela va être fait tout de suite automatiquement.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Des fichiers non fusionnés ne peuvent être commités.\n"
+"\n"
+"Le fichier %s a des conflicts de fusion. Vous devez les résoudre et pré-"
+"commiter le fichier avant de pouvoir commiter.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Un état de fichier inconnu %s a été détecté.\n"
+"\n"
+"Le fichier %s ne peut pas être commité par ce programme.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Pas de modification à commiter.\n"
+"\n"
+"Vous devez indexer au moins 1 fichier avant de pouvoir commiter.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Merci de fournir un message de commit.\n"
+"\n"
+"Un bon message de commit a le format suivant :\n"
+"\n"
+"- Première ligne : décrire en une phrase ce que vous avez fait.\n"
+"- Deuxième ligne : rien.\n"
+"- Lignes suivantes : Décrire pourquoi ces modifications sont bonnes.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Lancement de l'action d'avant-commit..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Commit refusé par l'action d'avant-commit."
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Lancement de l'action \"message de commit\"..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Commit refusé par l'action \"message de commit\"."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Commit des modifications..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "write-tree a échoué :"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Le commit a échoué."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "Le commit %s semble être corrompu"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Pas de modification à commiter.\n"
+"\n"
+"Aucun fichier n'a été modifié par ce commit et il ne s'agit pas d'un commit "
+"de fusion.\n"
+"\n"
+"Une resynchronisation va être lancée tout de suite automatiquement.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Pas de modifications à commiter."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree a échoué :"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref a échoué :"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "Commit %s créé : %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Supprimer branche"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Supprimer branche locale"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Branches locales"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Supprimer seulement si fusionnée dans :"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "Les branches suivantes ne sont pas complètement fusionnées dans %s :"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
 #, tcl-format
 msgid ""
-"Could not add tool:\n"
+"Failed to delete branches:\n"
 "%s"
 msgstr ""
-"Impossible d'ajouter l'outil :\n"
+"La suppression des branches suivantes a échoué :\n"
 "%s"
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
-msgstr "Supprimer l'outil"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Impossible de déverrouiller l'index."
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
-msgstr "Supprimer des commandes d'outil"
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Erreur de l'index"
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Échec de la mise à jour de l'index. Une resynchronisation va être lancée "
+"automatiquement."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Continuer"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Déverrouiller l'index"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Désindexation de : %s"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "Désindexation de : %s"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Prêt à être commité."
+
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Annuler modifications dans fichiers selectionnés"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "Ajout de %s"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr ""
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Annuler les modifications dans le fichier %s ? "
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Annuler les modifications dans ces %i fichiers ?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Toutes les modifications non-indexées seront définitivement perdues par "
+"l'annulation."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Ne rien faire"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Suppression des branches de %s"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Annuler les modifications dans ces %i fichiers ?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
 msgstr "Supprimer"
 
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
-msgstr "(Le bleu indique des outils locaux au dépôt)"
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Annuler modifications dans fichiers selectionnés"
 
-#: lib/tools_dlg.tcl:297
+#: lib/index.tcl:532
 #, tcl-format
-msgid "Run Command: %s"
-msgstr "Lancer commande : %s"
+msgid "Reverting %s"
+msgstr "Annulation des modifications dans %s"
 
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
-msgstr "Arguments"
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Défaut"
 
-#: lib/tools_dlg.tcl:348
-msgid "OK"
-msgstr "OK"
-
-#: lib/transport.tcl:7
+#: lib/encoding.tcl:448
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Récupération des dernières modifications de %s"
+msgid "System (%s)"
+msgstr "Système (%s)"
 
-#: lib/transport.tcl:18
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Autre"
+
+#: lib/date.tcl:25
 #, tcl-format
-msgid "remote prune %s"
-msgstr "purger à distance %s"
+msgid "Invalid date from Git: %s"
+msgstr "Date invalide de Git : %s"
 
-#: lib/transport.tcl:19
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Cet emprunt détaché"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Expression de révision :"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Branche locale"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Branche de suivi"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Marque (tag)"
+
+#: lib/choose_rev.tcl:321
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Nettoyer les branches de suivi supprimées de %s"
+msgid "Invalid revision: %s"
+msgstr "Révision invalide : %s"
 
-#: lib/transport.tcl:26
-#, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Les modifications sont poussées vers %s"
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Pas de révision sélectionnée."
 
-#: lib/transport.tcl:64
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr "Dupliquer dans %s"
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "L'expression de révision est vide."
 
-#: lib/transport.tcl:82
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Pousse %s %s vers %s"
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Mise à jour:"
 
-#: lib/transport.tcl:100
-msgid "Push Branches"
-msgstr "Pousser branches"
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
 
-#: lib/transport.tcl:114
-msgid "Source Branches"
-msgstr "Branches source"
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Nombre d'objets en fichier particulier"
 
-#: lib/transport.tcl:131
-msgid "Destination Repository"
-msgstr "Dépôt de destination"
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Espace disque utilisé par les fichiers particuliers"
 
-#: lib/transport.tcl:169
-msgid "Transfer Options"
-msgstr "Options de transfert"
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Nombre d'objets empaquetés"
 
-#: lib/transport.tcl:171
-msgid "Force overwrite existing branch (may discard changes)"
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Nombre de paquets d'objets"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Espace disque utilisé par les objets empaquetés"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Objets empaquetés attendant d'être supprimés"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Fichiers poubelle"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Statistiques du dépôt"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Compression de la base des objets"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Vérification de la base des objets avec fsck-objects"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
 msgstr ""
-"Forcer l'écrasement d'une branche existante (peut supprimer des "
-"modifications)"
+"Ce dépôt comprend actuellement environ %i objets ayant leur fichier "
+"particulier.\n"
+"\n"
+"Pour conserver une performance optimale, il est fortement recommandé de "
+"comprimer la base de donnée.\n"
+"\n"
+"Comprimer la base maintenant ?"
 
-#: lib/transport.tcl:175
-msgid "Use thin pack (for slow network connections)"
-msgstr "Utiliser des petits paquets (pour les connexions lentes)"
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "erreur"
 
-#: lib/transport.tcl:179
-msgid "Include tags"
-msgstr "Inclure les marques (tags)"
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "attention"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "L'outil a échoué : %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Vous devez corriger les erreurs suivantes avant de pouvoir commiter."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Displaying only %s of %s files."
+#~ msgstr "Affiche seulement %s fichiers sur %s."
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Le fichier non suivi fait %d octets.\n"
+#~ "* Seuls les %d premiers octets sont montrés.\n"
+
+#~ msgid "Case-Sensitive"
+#~ msgstr "Sensible à la casse"
 
 #~ msgid "Cannot use funny .git directory:"
 #~ msgstr "Impossible d'utiliser le répertoire .git:"

--- a/po/git-gui.pot
+++ b/po/git-gui.pot
@@ -12,845 +12,595 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:41 git-gui.sh:793 git-gui.sh:807 git-gui.sh:820 git-gui.sh:903
-#: git-gui.sh:922
-msgid "git-gui: fatal error"
-msgstr ""
-
-#: git-gui.sh:743
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr ""
 
-#: git-gui.sh:779
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr ""
 
-#: git-gui.sh:780
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr ""
 
-#: git-gui.sh:794
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr ""
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr ""
 
-#: git-gui.sh:821
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr ""
 
-#: git-gui.sh:839
+#: git-gui.sh:970
 #, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 
-#: git-gui.sh:1128
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr ""
 
-#: git-gui.sh:1146
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr ""
 
-#: git-gui.sh:1154
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr ""
 
-#: git-gui.sh:1162
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr ""
 
-#: git-gui.sh:1334 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr ""
 
-#: git-gui.sh:1390
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr ""
 
-#: git-gui.sh:1454
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr ""
 
-#: git-gui.sh:1471
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr ""
 
-#: git-gui.sh:1629 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr ""
 
-#: git-gui.sh:1787
+#: git-gui.sh:1966
 #, tcl-format
-msgid "Displaying only %s of %s files."
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
 msgstr ""
 
-#: git-gui.sh:1913
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr ""
 
-#: git-gui.sh:1915
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr ""
 
-#: git-gui.sh:1916 git-gui.sh:1924
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr ""
 
-#: git-gui.sh:1917 git-gui.sh:1925
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr ""
 
-#: git-gui.sh:1918 git-gui.sh:1926
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr ""
 
-#: git-gui.sh:1920
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr ""
 
-#: git-gui.sh:1921
+#: git-gui.sh:2097 git-gui.sh:2098
+msgid "File type changed, old type staged for commit"
+msgstr ""
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr ""
 
-#: git-gui.sh:1923
+#: git-gui.sh:2100
+msgid "File type change staged, modification not staged"
+msgstr ""
+
+#: git-gui.sh:2101
+msgid "File type change staged, file missing"
+msgstr ""
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr ""
 
-#: git-gui.sh:1928
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr ""
 
-#: git-gui.sh:1929
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr ""
 
-#: git-gui.sh:1930
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr ""
 
-#: git-gui.sh:1932 git-gui.sh:1933 git-gui.sh:1934 git-gui.sh:1935
-#: git-gui.sh:1936 git-gui.sh:1937
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr ""
 
-#: git-gui.sh:1972
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr ""
 
-#: git-gui.sh:1984
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr ""
 
-#: git-gui.sh:2043
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr ""
 
-#: git-gui.sh:2455 lib/choose_repository.tcl:36
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr ""
 
-#: git-gui.sh:2456
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr ""
 
-#: git-gui.sh:2458 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr ""
 
-#: git-gui.sh:2461 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr ""
 
-#: git-gui.sh:2464 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr ""
 
-#: git-gui.sh:2465 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr ""
 
-#: git-gui.sh:2468
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr ""
 
-#: git-gui.sh:2477
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr ""
 
-#: git-gui.sh:2483
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr ""
 
-#: git-gui.sh:2487
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr ""
 
-#: git-gui.sh:2492
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr ""
 
-#: git-gui.sh:2496
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr ""
 
-#: git-gui.sh:2503
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr ""
 
-#: git-gui.sh:2505
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr ""
 
-#: git-gui.sh:2510 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr ""
 
-#: git-gui.sh:2513 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr ""
 
-#: git-gui.sh:2516
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr ""
 
-#: git-gui.sh:2523 git-gui.sh:2527 git-gui.sh:2531 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr ""
 
-#: git-gui.sh:2539 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr ""
 
-#: git-gui.sh:2547
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr ""
 
-#: git-gui.sh:2550
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr ""
 
-#: git-gui.sh:2554 git-gui.sh:3109
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr ""
 
-#: git-gui.sh:2557 git-gui.sh:3112 git-gui.sh:3186 git-gui.sh:3259
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr ""
 
-#: git-gui.sh:2560 git-gui.sh:3115
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr ""
 
-#: git-gui.sh:2563 git-gui.sh:3118 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr ""
 
-#: git-gui.sh:2567 git-gui.sh:3122 git-gui.sh:3263 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr ""
 
-#: git-gui.sh:2576
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr ""
 
-#: git-gui.sh:2582
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr ""
 
-#: git-gui.sh:2588
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr ""
 
-#: git-gui.sh:2593
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr ""
 
-#: git-gui.sh:2598
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr ""
 
-#: git-gui.sh:2608
+#: git-gui.sh:2821
 msgid "Done"
 msgstr ""
 
-#: git-gui.sh:2610
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr ""
 
-#: git-gui.sh:2619 git-gui.sh:3050
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr ""
 
-#: git-gui.sh:2627 git-gui.sh:3057
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr ""
 
-#: git-gui.sh:2637 git-gui.sh:3011 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr ""
 
-#: git-gui.sh:2643
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr ""
 
-#: git-gui.sh:2649
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr ""
 
-#: git-gui.sh:2655
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr ""
 
-#: git-gui.sh:2661 lib/index.tcl:412
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr ""
 
-#: git-gui.sh:2669 git-gui.sh:3310 git-gui.sh:3341
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr ""
 
-#: git-gui.sh:2673 git-gui.sh:3314 git-gui.sh:3345
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr ""
 
-#: git-gui.sh:2680 git-gui.sh:3024 git-gui.sh:3133
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr ""
 
-#: git-gui.sh:2696
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr ""
 
-#: git-gui.sh:2701
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr ""
 
-#: git-gui.sh:2713 git-gui.sh:2741
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr ""
 
-#: git-gui.sh:2717
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr ""
 
-#: git-gui.sh:2721
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr ""
 
-#: git-gui.sh:2731 git-gui.sh:3292
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr ""
 
-#: git-gui.sh:2742
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr ""
 
-#: git-gui.sh:2751 lib/choose_repository.tcl:50
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr ""
 
-#: git-gui.sh:2755 git-gui.sh:2759 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr ""
 
-#: git-gui.sh:2783
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr ""
 
-#: git-gui.sh:2786 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr ""
 
-#: git-gui.sh:2893
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+msgid "Error"
+msgstr ""
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 
-#: git-gui.sh:2926
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr ""
 
-#: git-gui.sh:2947
-msgid "Staged Changes (Will Commit)"
-msgstr ""
-
-#: git-gui.sh:2967
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr ""
 
-#: git-gui.sh:3017
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr ""
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr ""
 
-#: git-gui.sh:3036 lib/transport.tcl:104 lib/transport.tcl:193
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr ""
 
-#: git-gui.sh:3071
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3072
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3073
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3074
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3075
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3076
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3125 git-gui.sh:3267 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr ""
 
-#: git-gui.sh:3149 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr ""
 
-#: git-gui.sh:3255
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr ""
 
-#: git-gui.sh:3276
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr ""
 
-#: git-gui.sh:3280
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr ""
 
-#: git-gui.sh:3288 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr ""
 
-#: git-gui.sh:3299
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr ""
 
-#: git-gui.sh:3304
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr ""
 
-#: git-gui.sh:3323
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr ""
 
-#: git-gui.sh:3328
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr ""
 
-#: git-gui.sh:3332
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr ""
 
-#: git-gui.sh:3336
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr ""
 
-#: git-gui.sh:3354
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3358
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3362
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3367
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3389
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr ""
 
-#: git-gui.sh:3391
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr ""
 
-#: git-gui.sh:3393
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr ""
 
-#: git-gui.sh:3396
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr ""
 
-#: git-gui.sh:3398
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr ""
 
-#: git-gui.sh:3400
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr ""
 
-#: git-gui.sh:3424
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr ""
 
-#: git-gui.sh:3541
+#: git-gui.sh:3868
 #, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 
-#: git-gui.sh:3570
+#: git-gui.sh:3897
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 
-#: git-gui.sh:3575
+#: git-gui.sh:3902
 #, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
 
-#: lib/blame.tcl:72
-msgid "File Viewer"
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
 
-#: lib/blame.tcl:78
-msgid "Commit:"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
 msgstr ""
 
-#: lib/blame.tcl:271
-msgid "Copy Commit"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
 msgstr ""
 
-#: lib/blame.tcl:275
-msgid "Find Text..."
+#: lib/console.tcl:186
+msgid "Success"
 msgstr ""
 
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr ""
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr ""
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
-msgstr ""
-
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr ""
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
-msgstr ""
-
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr ""
-
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr ""
-
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr ""
-
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr ""
-
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr ""
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr ""
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr ""
-
-#: lib/blame.tcl:963
-msgid "Author:"
-msgstr ""
-
-#: lib/blame.tcl:967
-msgid "Committer:"
-msgstr ""
-
-#: lib/blame.tcl:972
-msgid "Original File:"
-msgstr ""
-
-#: lib/blame.tcl:1020
-msgid "Cannot find HEAD commit:"
-msgstr ""
-
-#: lib/blame.tcl:1075
-msgid "Cannot find parent commit:"
-msgstr ""
-
-#: lib/blame.tcl:1090
-msgid "Unable to display parent"
-msgstr ""
-
-#: lib/blame.tcl:1091 lib/diff.tcl:320
-msgid "Error loading diff:"
-msgstr ""
-
-#: lib/blame.tcl:1231
-msgid "Originally By:"
-msgstr ""
-
-#: lib/blame.tcl:1237
-msgid "In File:"
-msgstr ""
-
-#: lib/blame.tcl:1242
-msgid "Copied Or Moved Here By:"
-msgstr ""
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr ""
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr ""
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:579 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:108
-msgid "Cancel"
-msgstr ""
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr ""
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr ""
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr ""
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr ""
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr ""
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr ""
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:381
-msgid "Create"
-msgstr ""
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr ""
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr ""
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr ""
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr ""
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr ""
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr ""
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr ""
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr ""
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr ""
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr ""
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr ""
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr ""
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr ""
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr ""
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr ""
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr ""
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr ""
-
-#: lib/branch_delete.tcl:54 lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr ""
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr ""
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:217
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr ""
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr ""
-
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr ""
-
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr ""
-
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr ""
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr ""
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr ""
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr ""
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr ""
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr ""
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr ""
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr ""
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr ""
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:398
-#: lib/choose_repository.tcl:486 lib/choose_repository.tcl:497
-#: lib/choose_repository.tcl:1028
-msgid "Browse"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
 msgstr ""
 
 #: lib/checkout_op.tcl:85
@@ -863,11 +613,6 @@ msgstr ""
 msgid "fatal: Cannot resolve %s"
 msgstr ""
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr ""
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -876,6 +621,11 @@ msgstr ""
 #: lib/checkout_op.tcl:194
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
+msgstr ""
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
 msgstr ""
 
 #: lib/checkout_op.tcl:229
@@ -903,12 +653,12 @@ msgstr ""
 
 #: lib/checkout_op.tcl:289
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 
 #: lib/checkout_op.tcl:345
@@ -936,8 +686,8 @@ msgstr ""
 
 #: lib/checkout_op.tcl:452
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -961,1171 +711,410 @@ msgstr ""
 msgid "Reset '%s'?"
 msgstr ""
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
+msgstr ""
+
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr ""
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
 msgstr ""
 
 #: lib/checkout_op.tcl:635
 #, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr ""
-
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr ""
-
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr ""
-
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr ""
-
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
-msgstr ""
-
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr ""
-
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:386
-msgid "Create New Repository"
-msgstr ""
-
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr ""
-
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:471
-msgid "Clone Existing Repository"
-msgstr ""
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr ""
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:1016
-msgid "Open Existing Repository"
-msgstr ""
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr ""
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr ""
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr ""
-
-#: lib/choose_repository.tcl:306 lib/choose_repository.tcl:313
-#: lib/choose_repository.tcl:320
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
 #, tcl-format
-msgid "Failed to create repository %s:"
+msgid "fetch %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:391
-msgid "Directory:"
-msgstr ""
-
-#: lib/choose_repository.tcl:423 lib/choose_repository.tcl:550
-#: lib/choose_repository.tcl:1052
-msgid "Git Repository"
-msgstr ""
-
-#: lib/choose_repository.tcl:448
+#: lib/transport.tcl:7
 #, tcl-format
-msgid "Directory %s already exists."
+msgid "Fetching new changes from %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:452
+#: lib/transport.tcl:18
 #, tcl-format
-msgid "File %s already exists."
+msgid "remote prune %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:466
-msgid "Clone"
-msgstr ""
-
-#: lib/choose_repository.tcl:479
-msgid "Source Location:"
-msgstr ""
-
-#: lib/choose_repository.tcl:490
-msgid "Target Directory:"
-msgstr ""
-
-#: lib/choose_repository.tcl:502
-msgid "Clone Type:"
-msgstr ""
-
-#: lib/choose_repository.tcl:508
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr ""
-
-#: lib/choose_repository.tcl:514
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr ""
-
-#: lib/choose_repository.tcl:520
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr ""
-
-#: lib/choose_repository.tcl:556 lib/choose_repository.tcl:603
-#: lib/choose_repository.tcl:749 lib/choose_repository.tcl:819
-#: lib/choose_repository.tcl:1058 lib/choose_repository.tcl:1066
+#: lib/transport.tcl:19
 #, tcl-format
-msgid "Not a Git repository: %s"
+msgid "Pruning tracking branches deleted from %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:592
-msgid "Standard only available for local repository."
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
 
-#: lib/choose_repository.tcl:596
-msgid "Shared only available for local repository."
+#: lib/transport.tcl:26
+msgid "Fetching new changes from all remotes"
 msgstr ""
 
-#: lib/choose_repository.tcl:617
+#: lib/transport.tcl:40
+msgid "remote prune all remotes"
+msgstr ""
+
+#: lib/transport.tcl:41
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr ""
+
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Location %s already exists."
+msgid "push %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:628
-msgid "Failed to configure origin"
-msgstr ""
-
-#: lib/choose_repository.tcl:640
-msgid "Counting objects"
-msgstr ""
-
-#: lib/choose_repository.tcl:641
-msgid "buckets"
-msgstr ""
-
-#: lib/choose_repository.tcl:665
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
+msgid "Pushing changes to %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:701
+#: lib/transport.tcl:93
 #, tcl-format
-msgid "Nothing to clone from %s."
+msgid "Mirroring to %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:703 lib/choose_repository.tcl:917
-#: lib/choose_repository.tcl:929
-msgid "The 'master' branch has not been initialized."
-msgstr ""
-
-#: lib/choose_repository.tcl:716
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr ""
-
-#: lib/choose_repository.tcl:728
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Cloning from %s"
+msgid "Pushing %s %s to %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:759
-msgid "Copying objects"
+#: lib/transport.tcl:132
+msgid "Push Branches"
 msgstr ""
 
-#: lib/choose_repository.tcl:760
-msgid "KiB"
+#: lib/transport.tcl:147
+msgid "Source Branches"
 msgstr ""
 
-#: lib/choose_repository.tcl:784
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr ""
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr ""
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr ""
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr ""
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr ""
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr ""
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr ""
+
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Unable to copy object: %s"
+msgid "%s (%s): Push"
 msgstr ""
 
-#: lib/choose_repository.tcl:794
-msgid "Linking objects"
-msgstr ""
-
-#: lib/choose_repository.tcl:795
-msgid "objects"
-msgstr ""
-
-#: lib/choose_repository.tcl:803
+#: lib/remote_add.tcl:20
 #, tcl-format
-msgid "Unable to hardlink object: %s"
+msgid "%s (%s): Add Remote"
 msgstr ""
 
-#: lib/choose_repository.tcl:858
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr ""
-
-#: lib/choose_repository.tcl:869
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-
-#: lib/choose_repository.tcl:893
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-
-#: lib/choose_repository.tcl:902
-#, tcl-format
-msgid "Unable to cleanup %s"
-msgstr ""
-
-#: lib/choose_repository.tcl:908
-msgid "Clone failed."
-msgstr ""
-
-#: lib/choose_repository.tcl:915
-msgid "No default branch obtained."
-msgstr ""
-
-#: lib/choose_repository.tcl:926
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr ""
-
-#: lib/choose_repository.tcl:938
-msgid "Creating working directory"
-msgstr ""
-
-#: lib/choose_repository.tcl:939 lib/index.tcl:67 lib/index.tcl:130
-#: lib/index.tcl:198
-msgid "files"
-msgstr ""
-
-#: lib/choose_repository.tcl:968
-msgid "Initial file checkout failed."
-msgstr ""
-
-#: lib/choose_repository.tcl:1011
-msgid "Open"
-msgstr ""
-
-#: lib/choose_repository.tcl:1021
-msgid "Repository:"
-msgstr ""
-
-#: lib/choose_repository.tcl:1072
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr ""
-
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr ""
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr ""
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr ""
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr ""
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr ""
-
-#: lib/choose_rev.tcl:317
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr ""
-
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr ""
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr ""
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr ""
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr ""
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr ""
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr ""
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr ""
-
-#: lib/commit.tcl:129
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr ""
-
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-
-#: lib/commit.tcl:172
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-
-#: lib/commit.tcl:180
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-
-#: lib/commit.tcl:188
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-
-#: lib/commit.tcl:203
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-
-#: lib/commit.tcl:234
-msgid "Calling pre-commit hook..."
-msgstr ""
-
-#: lib/commit.tcl:249
-msgid "Commit declined by pre-commit hook."
-msgstr ""
-
-#: lib/commit.tcl:272
-msgid "Calling commit-msg hook..."
-msgstr ""
-
-#: lib/commit.tcl:287
-msgid "Commit declined by commit-msg hook."
-msgstr ""
-
-#: lib/commit.tcl:300
-msgid "Committing changes..."
-msgstr ""
-
-#: lib/commit.tcl:316
-msgid "write-tree failed:"
-msgstr ""
-
-#: lib/commit.tcl:317 lib/commit.tcl:361 lib/commit.tcl:382
-msgid "Commit failed."
-msgstr ""
-
-#: lib/commit.tcl:334
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr ""
-
-#: lib/commit.tcl:339
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-
-#: lib/commit.tcl:346
-msgid "No changes to commit."
-msgstr ""
-
-#: lib/commit.tcl:360
-msgid "commit-tree failed:"
-msgstr ""
-
-#: lib/commit.tcl:381
-msgid "update-ref failed:"
-msgstr ""
-
-#: lib/commit.tcl:469
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr ""
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr ""
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr ""
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr ""
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr ""
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr ""
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr ""
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr ""
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr ""
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr ""
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr ""
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr ""
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr ""
-
-#: lib/database.tcl:107
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr ""
-
-#: lib/diff.tcl:64
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-
-#: lib/diff.tcl:104
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr ""
-
-#: lib/diff.tcl:125
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-
-#: lib/diff.tcl:130
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-
-#: lib/diff.tcl:137
-msgid "LOCAL:\n"
-msgstr ""
-
-#: lib/diff.tcl:140
-msgid "REMOTE:\n"
-msgstr ""
-
-#: lib/diff.tcl:202 lib/diff.tcl:319
-#, tcl-format
-msgid "Unable to display %s"
-msgstr ""
-
-#: lib/diff.tcl:203
-msgid "Error loading file:"
-msgstr ""
-
-#: lib/diff.tcl:210
-msgid "Git Repository (subproject)"
-msgstr ""
-
-#: lib/diff.tcl:222
-msgid "* Binary file (not showing content)."
-msgstr ""
-
-#: lib/diff.tcl:227
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-
-#: lib/diff.tcl:233
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-
-#: lib/diff.tcl:482
-msgid "Failed to unstage selected hunk."
-msgstr ""
-
-#: lib/diff.tcl:489
-msgid "Failed to stage selected hunk."
-msgstr ""
-
-#: lib/diff.tcl:568
-msgid "Failed to unstage selected line."
-msgstr ""
-
-#: lib/diff.tcl:576
-msgid "Failed to stage selected line."
-msgstr ""
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr ""
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr ""
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr ""
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr ""
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr ""
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr ""
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr ""
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr ""
-
-#: lib/index.tcl:17
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-
-#: lib/index.tcl:28
-msgid "Continue"
-msgstr ""
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr ""
-
-#: lib/index.tcl:289
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr ""
-
-#: lib/index.tcl:328
-msgid "Ready to commit."
-msgstr ""
-
-#: lib/index.tcl:341
-#, tcl-format
-msgid "Adding %s"
-msgstr ""
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr ""
-
-#: lib/index.tcl:400
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr ""
-
-#: lib/index.tcl:408
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-
-#: lib/index.tcl:411
-msgid "Do Nothing"
-msgstr ""
-
-#: lib/index.tcl:429
-msgid "Reverting selected files"
-msgstr ""
-
-#: lib/index.tcl:433
-#, tcl-format
-msgid "Reverting %s"
-msgstr ""
-
-#: lib/merge.tcl:13
-msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
-msgstr ""
-
-#: lib/merge.tcl:27
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-
-#: lib/merge.tcl:45
-#, tcl-format
-msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
-"You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
-msgstr ""
-
-#: lib/merge.tcl:55
-#, tcl-format
-msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
-"You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
-msgstr ""
-
-#: lib/merge.tcl:107
-#, tcl-format
-msgid "%s of %s"
-msgstr ""
-
-#: lib/merge.tcl:120
-#, tcl-format
-msgid "Merging %s and %s..."
-msgstr ""
-
-#: lib/merge.tcl:131
-msgid "Merge completed successfully."
-msgstr ""
-
-#: lib/merge.tcl:133
-msgid "Merge failed.  Conflict resolution is required."
-msgstr ""
-
-#: lib/merge.tcl:158
-#, tcl-format
-msgid "Merge Into %s"
-msgstr ""
-
-#: lib/merge.tcl:177
-msgid "Revision To Merge"
-msgstr ""
-
-#: lib/merge.tcl:212
-msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
-msgstr ""
-
-#: lib/merge.tcl:222
-msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with aborting the current merge?"
-msgstr ""
-
-#: lib/merge.tcl:228
-msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with resetting the current changes?"
-msgstr ""
-
-#: lib/merge.tcl:239
-msgid "Aborting"
-msgstr ""
-
-#: lib/merge.tcl:239
-msgid "files reset"
-msgstr ""
-
-#: lib/merge.tcl:267
-msgid "Abort failed."
-msgstr ""
-
-#: lib/merge.tcl:269
-msgid "Abort completed.  Ready."
-msgstr ""
-
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr ""
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr ""
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr ""
-
-#: lib/mergetool.tcl:14
-#, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-
-#: lib/mergetool.tcl:45
-#, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-
-#: lib/mergetool.tcl:60
-#, tcl-format
-msgid "Adding resolution for %s"
-msgstr ""
-
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr ""
-
-#: lib/mergetool.tcl:264
-#, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr ""
-
-#: lib/mergetool.tcl:268
-#, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr ""
-
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr ""
-
-#: lib/mergetool.tcl:323
-#, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr ""
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr ""
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr ""
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr ""
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr ""
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr ""
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr ""
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr ""
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr ""
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr ""
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr ""
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr ""
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr ""
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr ""
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr ""
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr ""
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr ""
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr ""
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr ""
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr ""
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr ""
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr ""
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr ""
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr ""
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr ""
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr ""
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr ""
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr ""
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr ""
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr ""
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr ""
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr ""
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr ""
-
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr ""
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr ""
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
-msgstr ""
-
-#: lib/remote_add.tcl:24
+#: lib/remote_add.tcl:25
 msgid "Add New Remote"
 msgstr ""
 
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
 msgid "Add"
 msgstr ""
 
-#: lib/remote_add.tcl:37
+#: lib/remote_add.tcl:39
 msgid "Remote Details"
+msgstr ""
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
 msgstr ""
 
 #: lib/remote_add.tcl:50
 msgid "Location:"
 msgstr ""
 
-#: lib/remote_add.tcl:62
+#: lib/remote_add.tcl:60
 msgid "Further Action"
 msgstr ""
 
-#: lib/remote_add.tcl:65
+#: lib/remote_add.tcl:63
 msgid "Fetch Immediately"
 msgstr ""
 
-#: lib/remote_add.tcl:71
+#: lib/remote_add.tcl:69
 msgid "Initialize Remote Repository and Push"
 msgstr ""
 
-#: lib/remote_add.tcl:77
+#: lib/remote_add.tcl:75
 msgid "Do Nothing Else Now"
 msgstr ""
 
-#: lib/remote_add.tcl:101
+#: lib/remote_add.tcl:100
 msgid "Please supply a remote name."
 msgstr ""
 
-#: lib/remote_add.tcl:114
+#: lib/remote_add.tcl:113
 #, tcl-format
 msgid "'%s' is not an acceptable remote name."
 msgstr ""
 
-#: lib/remote_add.tcl:125
+#: lib/remote_add.tcl:124
 #, tcl-format
 msgid "Failed to add remote '%s' of location '%s'."
 msgstr ""
 
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr ""
-
-#: lib/remote_add.tcl:134
+#: lib/remote_add.tcl:133
 #, tcl-format
 msgid "Fetching the %s"
 msgstr ""
 
-#: lib/remote_add.tcl:157
+#: lib/remote_add.tcl:156
 #, tcl-format
 msgid "Do not know how to initialize repository at location '%s'."
 msgstr ""
 
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:63
-#: lib/transport.tcl:81
-#, tcl-format
-msgid "push %s"
-msgstr ""
-
-#: lib/remote_add.tcl:164
+#: lib/remote_add.tcl:163
 #, tcl-format
 msgid "Setting up the %s (at %s)"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
+#: lib/browser.tcl:17
+msgid "Starting..."
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
+#: lib/browser.tcl:27
+#, tcl-format
+msgid "%s (%s): File Browser"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:134
-msgid "Remote:"
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:149
-msgid "Arbitrary Location:"
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
+#: lib/browser.tcl:275
+#, tcl-format
+msgid "%s (%s): Browse Branch Files"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:184
+#: lib/merge.tcl:13
+msgid ""
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
+msgstr ""
+
+#: lib/merge.tcl:27
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+
+#: lib/merge.tcl:45
 #, tcl-format
 msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
+"You must resolve them, stage the file, and commit to complete the current "
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:189
+#: lib/merge.tcl:55
 #, tcl-format
 msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
+"You should complete the current commit before starting a merge.  Doing so "
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:226
+#: lib/merge.tcl:108
 #, tcl-format
-msgid "Deleting branches from %s"
+msgid "%s of %s"
 msgstr ""
 
-#: lib/remote_branch_delete.tcl:292
-msgid "No repository selected."
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:297
+#: lib/merge.tcl:126
 #, tcl-format
-msgid "Scanning %s..."
+msgid "Merging %s and %s..."
 msgstr ""
 
-#: lib/search.tcl:21
-msgid "Find:"
+#: lib/merge.tcl:137
+msgid "Merge completed successfully."
 msgstr ""
 
-#: lib/search.tcl:23
-msgid "Next"
+#: lib/merge.tcl:139
+msgid "Merge failed.  Conflict resolution is required."
 msgstr ""
 
-#: lib/search.tcl:24
-msgid "Prev"
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
 msgstr ""
 
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
+#: lib/merge.tcl:164
+#, tcl-format
+msgid "Merge Into %s"
 msgstr ""
 
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
+#: lib/merge.tcl:183
+msgid "Revision To Merge"
 msgstr ""
 
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
+#: lib/merge.tcl:218
+msgid ""
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
+msgstr ""
+
+#: lib/merge.tcl:228
+msgid ""
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
+"Continue with aborting the current merge?"
+msgstr ""
+
+#: lib/merge.tcl:234
+msgid ""
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
+"Continue with resetting the current changes?"
+msgstr ""
+
+#: lib/merge.tcl:245
+msgid "Aborting"
+msgstr ""
+
+#: lib/merge.tcl:245
+msgid "files reset"
+msgstr ""
+
+#: lib/merge.tcl:273
+msgid "Abort failed."
+msgstr ""
+
+#: lib/merge.tcl:275
+msgid "Abort completed.  Ready."
+msgstr ""
+
+#: lib/tools.tcl:76
+#, tcl-format
+msgid "Running %s requires a selected file."
+msgstr ""
+
+#: lib/tools.tcl:92
+#, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr ""
+
+#: lib/tools.tcl:96
+#, tcl-format
+msgid "Are you sure you want to run %s?"
+msgstr ""
+
+#: lib/tools.tcl:118
+#, tcl-format
+msgid "Tool: %s"
+msgstr ""
+
+#: lib/tools.tcl:119
+#, tcl-format
+msgid "Running: %s"
+msgstr ""
+
+#: lib/tools.tcl:158
+#, tcl-format
+msgid "Tool completed successfully: %s"
+msgstr ""
+
+#: lib/tools.tcl:160
+#, tcl-format
+msgid "Tool failed: %s"
+msgstr ""
+
+#: lib/branch_checkout.tcl:16
+#, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr ""
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr ""
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr ""
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr ""
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr ""
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
 msgstr ""
 
 #: lib/spellcheck.tcl:57
@@ -2165,6 +1154,966 @@ msgstr ""
 msgid "Spell Checker Failed"
 msgstr ""
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr ""
+
+#: lib/diff.tcl:77
+#, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr ""
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr ""
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr ""
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr ""
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr ""
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr ""
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr ""
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr ""
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr ""
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr ""
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr ""
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr ""
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr ""
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr ""
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr ""
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr ""
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr ""
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr ""
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr ""
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr ""
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr ""
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr ""
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr ""
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr ""
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr ""
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr ""
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr ""
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr ""
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr ""
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr ""
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr ""
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr ""
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr ""
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr ""
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr ""
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr ""
+
+#: lib/option.tcl:153
+msgid "Maximum Length of Recent Repositories List"
+msgstr ""
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr ""
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr ""
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr ""
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr ""
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr ""
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr ""
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr ""
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr ""
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr ""
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr ""
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr ""
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr ""
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr ""
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr ""
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:14
+#, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr ""
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr ""
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr ""
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr ""
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr ""
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr ""
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr ""
+
+#: lib/tools_dlg.tcl:22
+#, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr ""
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr ""
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr ""
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr ""
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr ""
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr ""
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr ""
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr ""
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr ""
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:187
+#, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr ""
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr ""
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:283
+#, tcl-format
+msgid "%s (%s):"
+msgstr ""
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr ""
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr ""
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr ""
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr ""
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr ""
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr ""
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr ""
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr ""
+
+#: lib/branch_rename.tcl:15
+#, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr ""
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr ""
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr ""
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr ""
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr ""
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr ""
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr ""
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr ""
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:29
+#, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:185
+#, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr ""
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr ""
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr ""
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr ""
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr ""
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr ""
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr ""
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr ""
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr ""
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr ""
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr ""
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr ""
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr ""
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr ""
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr ""
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr ""
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr ""
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr ""
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr ""
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr ""
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr ""
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr ""
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr ""
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr ""
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr ""
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr ""
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr ""
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr ""
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr ""
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr ""
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr ""
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr ""
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr ""
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr ""
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr ""
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr ""
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr ""
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr ""
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr ""
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr ""
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr ""
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr ""
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr ""
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr ""
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr ""
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr ""
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr ""
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+msgid "Cloning submodules"
+msgstr ""
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr ""
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr ""
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr ""
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr ""
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr ""
+
+#: lib/blame.tcl:73
+#, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr ""
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr ""
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr ""
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr ""
+
+#: lib/blame.tcl:288
+msgid "Goto Line..."
+msgstr ""
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr ""
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr ""
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr ""
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr ""
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr ""
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr ""
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr ""
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr ""
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr ""
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr ""
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr ""
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr ""
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr ""
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr ""
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr ""
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr ""
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr ""
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr ""
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr ""
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr ""
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr ""
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr ""
@@ -2178,19 +2127,19 @@ msgstr ""
 msgid "Generate Key"
 msgstr ""
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr ""
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr ""
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr ""
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2198,197 +2147,479 @@ msgid ""
 "%s"
 msgstr ""
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr ""
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr ""
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr ""
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
+msgid "%s (%s): Create Branch"
 msgstr ""
 
-#: lib/tools.tcl:75
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr ""
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr ""
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr ""
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr ""
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr ""
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr ""
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr ""
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr ""
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr ""
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "Running %s requires a selected file."
+msgid "Tracking branch %s is not a branch in the remote repository."
 msgstr ""
 
-#: lib/tools.tcl:90
+#: lib/commit.tcl:9
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:18
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr ""
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr ""
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr ""
+
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Are you sure you want to run %s?"
+msgid "warning: Tcl does not support encoding '%s'."
 msgstr ""
 
-#: lib/tools.tcl:110
-#, tcl-format
-msgid "Tool: %s"
+#: lib/commit.tcl:152
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 
-#: lib/tools.tcl:111
-#, tcl-format
-msgid "Running: %s"
-msgstr ""
-
-#: lib/tools.tcl:149
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr ""
-
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr ""
-
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr ""
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr ""
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr ""
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr ""
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr ""
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr ""
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr ""
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr ""
-
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr ""
-
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr ""
-
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr ""
-
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr ""
-
-#: lib/tools_dlg.tcl:129
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr ""
-
-#: lib/tools_dlg.tcl:151
+#: lib/commit.tcl:176
 #, tcl-format
 msgid ""
-"Could not add tool:\n"
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:184
+#, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:192
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:207
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr ""
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr ""
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr ""
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr ""
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr ""
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr ""
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr ""
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr ""
+
+#: lib/commit.tcl:361
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr ""
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr ""
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr ""
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr ""
+
+#: lib/branch_delete.tcl:16
+#, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr ""
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr ""
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr ""
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr ""
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
 "%s"
 msgstr ""
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
 msgstr ""
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
+#: lib/index.tcl:17
+msgid "Index Error"
 msgstr ""
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
 msgstr ""
 
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
+#: lib/index.tcl:30
+msgid "Continue"
 msgstr ""
 
-#: lib/tools_dlg.tcl:297
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr ""
+
+#: lib/index.tcl:294
+msgid "Unstaging selected files from commit"
+msgstr ""
+
+#: lib/index.tcl:298
 #, tcl-format
-msgid "Run Command: %s"
+msgid "Unstaging %s from commit"
 msgstr ""
 
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
+#: lib/index.tcl:337
+msgid "Ready to commit."
 msgstr ""
 
-#: lib/tools_dlg.tcl:348
-msgid "OK"
+#: lib/index.tcl:346
+msgid "Adding selected files"
 msgstr ""
 
-#: lib/transport.tcl:7
+#: lib/index.tcl:350
 #, tcl-format
-msgid "Fetching new changes from %s"
+msgid "Adding %s"
 msgstr ""
 
-#: lib/transport.tcl:18
+#: lib/index.tcl:380
 #, tcl-format
-msgid "remote prune %s"
+msgid "Stage %d untracked files?"
 msgstr ""
 
-#: lib/transport.tcl:19
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
+msgid "Revert changes in file %s?"
 msgstr ""
 
-#: lib/transport.tcl:26
+#: lib/index.tcl:442
 #, tcl-format
-msgid "Pushing changes to %s"
+msgid "Revert changes in these %i files?"
 msgstr ""
 
-#: lib/transport.tcl:64
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr ""
+
+#: lib/index.tcl:475
 #, tcl-format
-msgid "Mirroring to %s"
+msgid "Delete untracked file %s?"
 msgstr ""
 
-#: lib/transport.tcl:82
+#: lib/index.tcl:477
 #, tcl-format
-msgid "Pushing %s %s to %s"
+msgid "Delete these %i untracked files?"
 msgstr ""
 
-#: lib/transport.tcl:100
-msgid "Push Branches"
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
 msgstr ""
 
-#: lib/transport.tcl:114
-msgid "Source Branches"
+#: lib/index.tcl:489
+msgid "Delete Files"
 msgstr ""
 
-#: lib/transport.tcl:131
-msgid "Destination Repository"
+#: lib/index.tcl:528
+msgid "Reverting selected files"
 msgstr ""
 
-#: lib/transport.tcl:169
-msgid "Transfer Options"
+#: lib/index.tcl:532
+#, tcl-format
+msgid "Reverting %s"
 msgstr ""
 
-#: lib/transport.tcl:171
-msgid "Force overwrite existing branch (may discard changes)"
+#: lib/encoding.tcl:443
+msgid "Default"
 msgstr ""
 
-#: lib/transport.tcl:175
-msgid "Use thin pack (for slow network connections)"
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
 msgstr ""
 
-#: lib/transport.tcl:179
-msgid "Include tags"
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr ""
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr ""
+
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr ""
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr ""
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr ""
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr ""
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr ""
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr ""
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr ""
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr ""
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr ""
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr ""
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr ""
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr ""
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr ""
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr ""
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr ""
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr ""
+
+#: lib/database.tcl:66
+#, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr ""
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr ""
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr ""
+
+#: lib/database.tcl:107
+#, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+
+#: lib/error.tcl:20
+#, tcl-format
+msgid "%s: error"
+msgstr ""
+
+#: lib/error.tcl:36
+#, tcl-format
+msgid "%s: warning"
+msgstr ""
+
+#: lib/error.tcl:80
+#, tcl-format
+msgid "%s hook failed:"
+msgstr ""
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr ""
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -2,56 +2,57 @@
 # Copyright (C) 2007 THE git-gui-i'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the git-gui-i package.
 # Miklos Vajna <vmiklos@frugalware.org>, 2007.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui-i 18n\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-12-08 08:31-0800\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2008-12-10 15:00+0100\n"
 "Last-Translator: Miklos Vajna <vmiklos@frugalware.org>\n"
 "Language-Team: Hungarian\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: git-gui.sh:41 git-gui.sh:737 git-gui.sh:751 git-gui.sh:764 git-gui.sh:847
-#: git-gui.sh:866
-msgid "git-gui: fatal error"
-msgstr "git-gui: végzetes hiba"
-
-#: git-gui.sh:689
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Érvénytelen font lett megadva itt: %s:"
 
-#: git-gui.sh:723
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Fő betűtípus"
 
-#: git-gui.sh:724
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Diff/konzol betűtípus"
 
-#: git-gui.sh:738
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: végzetes hiba"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "A git nem található a PATH-ban."
 
-#: git-gui.sh:765
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Nem értelmezhető a Git verzió sztring:"
 
-#: git-gui.sh:783
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Nem állípítható meg a Git verziója.\n"
 "\n"
@@ -61,453 +62,520 @@ msgstr ""
 "\n"
 "Feltételezhetjük, hogy a(z) '%s' verziója legalább 1.5.0?\n"
 
-#: git-gui.sh:1062
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "A Git könyvtár nem található:"
 
-#: git-gui.sh:1069
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Nem lehet a munkakönyvtár tetejére lépni:"
 
-#: git-gui.sh:1076
-msgid "Cannot use funny .git directory:"
-msgstr "Nem használható vicces .git könyvtár:"
+#: git-gui.sh:1309
+#, fuzzy
+msgid "Cannot use bare repository:"
+msgstr "Új repó létrehozása"
 
-#: git-gui.sh:1081
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Nincs munkakönyvtár"
 
-#: git-gui.sh:1247 lib/checkout_op.tcl:305
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "A fájlok státuszának frissítése..."
 
-#: git-gui.sh:1303
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Módosított fájlok keresése ..."
 
-#: git-gui.sh:1367
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "A prepare-commit-msg hurok meghívása..."
 
-#: git-gui.sh:1384
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "A commitot megakadályozta a prepare-commit-msg hurok."
 
-#: git-gui.sh:1542 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Kész."
 
-#: git-gui.sh:1819
+#: git-gui.sh:1966
+#, tcl-format
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
+
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Nem módosított"
 
-#: git-gui.sh:1821
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Módosított, de nem kiválasztott"
 
-#: git-gui.sh:1822 git-gui.sh:1830
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Kiválasztva commitolásra"
 
-#: git-gui.sh:1823 git-gui.sh:1831
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Részek kiválasztva commitolásra"
 
-#: git-gui.sh:1824 git-gui.sh:1832
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Kiválasztva commitolásra, hiányzó"
 
-#: git-gui.sh:1826
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Fájl típus megváltozott, nem kiválasztott"
 
-#: git-gui.sh:1827
+#: git-gui.sh:2097 git-gui.sh:2098
+#, fuzzy
+msgid "File type changed, old type staged for commit"
+msgstr "Fájl típus megváltozott, nem kiválasztott"
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "A fájltípus megváltozott, kiválasztott"
 
-#: git-gui.sh:1829
+#: git-gui.sh:2100
+#, fuzzy
+msgid "File type change staged, modification not staged"
+msgstr "Fájl típus megváltozott, nem kiválasztott"
+
+#: git-gui.sh:2101
+#, fuzzy
+msgid "File type change staged, file missing"
+msgstr "A fájltípus megváltozott, kiválasztott"
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Nem követett, nem kiválasztott"
 
-#: git-gui.sh:1834
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Hiányzó"
 
-#: git-gui.sh:1835
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Kiválasztva eltávolításra"
 
-#: git-gui.sh:1836
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Kiválasztva eltávolításra, jelenleg is elérhető"
 
-#: git-gui.sh:1838 git-gui.sh:1839 git-gui.sh:1840 git-gui.sh:1841
-#: git-gui.sh:1842 git-gui.sh:1843
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Merge feloldás szükséges"
 
-#: git-gui.sh:1878
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "A gitk indítása... várjunk..."
 
-#: git-gui.sh:1887
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "A gitk nem található a PATH-ban."
 
-#: git-gui.sh:2280 lib/choose_repository.tcl:36
+#: git-gui.sh:2223
+#, fuzzy
+msgid "Couldn't find git gui in PATH"
+msgstr "A gitk nem található a PATH-ban."
+
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Repó"
 
-#: git-gui.sh:2281
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: git-gui.sh:2283 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Branch"
 
-#: git-gui.sh:2286 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Commit@@főnév"
 
-#: git-gui.sh:2289 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Merge"
 
-#: git-gui.sh:2290 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Távoli"
 
-#: git-gui.sh:2293
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Eszközök"
 
-#: git-gui.sh:2302
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Munkamásolat felfedezése"
 
-#: git-gui.sh:2307
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "A jelenlegi branch fájljainak böngészése"
 
-#: git-gui.sh:2311
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "A branch fájljainak böngészése..."
 
-#: git-gui.sh:2316
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "A jelenlegi branch történetének vizualizálása"
 
-#: git-gui.sh:2320
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Az összes branch történetének vizualizálása"
 
-#: git-gui.sh:2327
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "A(z) %s branch fájljainak böngészése"
 
-#: git-gui.sh:2329
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "A(z) %s branch történetének vizualizálása"
 
-#: git-gui.sh:2334 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Adatbázis statisztikák"
 
-#: git-gui.sh:2337 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Adatbázis tömörítése"
 
-#: git-gui.sh:2340
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Adatbázis ellenőrzése"
 
-#: git-gui.sh:2347 git-gui.sh:2351 git-gui.sh:2355 lib/shortcut.tcl:7
-#: lib/shortcut.tcl:39 lib/shortcut.tcl:71
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Asztal ikon létrehozása"
 
-#: git-gui.sh:2363 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Kilépés"
 
-#: git-gui.sh:2371
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Visszavonás"
 
-#: git-gui.sh:2374
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Mégis"
 
-#: git-gui.sh:2378 git-gui.sh:2937
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Kivágás"
 
-#: git-gui.sh:2381 git-gui.sh:2940 git-gui.sh:3014 git-gui.sh:3096
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Másolás"
 
-#: git-gui.sh:2384 git-gui.sh:2943
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: git-gui.sh:2387 git-gui.sh:2946 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Törlés"
 
-#: git-gui.sh:2391 git-gui.sh:2950 git-gui.sh:3100 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Mindent kiválaszt"
 
-#: git-gui.sh:2400
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Létrehozás..."
 
-#: git-gui.sh:2406
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Checkout..."
 
-#: git-gui.sh:2412
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Átnevezés..."
 
-#: git-gui.sh:2417
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Törlés..."
 
-#: git-gui.sh:2422
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Visszaállítás..."
 
-#: git-gui.sh:2432
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Kész"
 
-#: git-gui.sh:2434
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Commit@@ige"
 
-#: git-gui.sh:2443 git-gui.sh:2878
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Új commit"
 
-#: git-gui.sh:2451 git-gui.sh:2885
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Utolsó commit javítása"
 
-#: git-gui.sh:2461 git-gui.sh:2839 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Keresés újra"
 
-#: git-gui.sh:2467
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Kiválasztás commitolásra"
 
-#: git-gui.sh:2473
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Módosított fájlok kiválasztása commitolásra"
 
-#: git-gui.sh:2479
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Commitba való kiválasztás visszavonása"
 
-#: git-gui.sh:2484 lib/index.tcl:410
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Változtatások visszaállítása"
 
-#: git-gui.sh:2491 git-gui.sh:3083
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Kevesebb környezet mutatása"
 
-#: git-gui.sh:2495 git-gui.sh:3087
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Több környezet mutatása"
 
-#: git-gui.sh:2502 git-gui.sh:2852 git-gui.sh:2961
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Aláír"
 
-#: git-gui.sh:2518
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Helyi merge..."
 
-#: git-gui.sh:2523
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Merge megszakítása..."
 
-#: git-gui.sh:2535 git-gui.sh:2575
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Hozzáadás..."
 
-#: git-gui.sh:2539
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Push..."
 
-#: git-gui.sh:2543
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Branch törlése..."
 
-#: git-gui.sh:2553 git-gui.sh:2589 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2944 git-gui.sh:3577
+msgid "Options..."
+msgstr "Opciók..."
+
+#: git-gui.sh:2955
+msgid "Remove..."
+msgstr "Eltávolítás..."
+
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
+msgid "Help"
+msgstr "Segítség"
+
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Névjegy: %s"
 
-#: git-gui.sh:2557
-msgid "Preferences..."
-msgstr "Beállítások..."
-
-#: git-gui.sh:2565 git-gui.sh:3129
-msgid "Options..."
-msgstr "Opciók..."
-
-#: git-gui.sh:2576
-msgid "Remove..."
-msgstr "Eltávolítás..."
-
-#: git-gui.sh:2585 lib/choose_repository.tcl:50
-msgid "Help"
-msgstr "Segítség"
-
-#: git-gui.sh:2611
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Online dokumentáció"
 
-#: git-gui.sh:2614 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "SSH kulcs mutatása"
 
-#: git-gui.sh:2721
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "hiba"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "végzetes hiba: nem érhető el a(z) %s útvonal: Nincs ilyen fájl vagy könyvtár"
 
-#: git-gui.sh:2754
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Jelenlegi branch:"
 
-#: git-gui.sh:2775
-msgid "Staged Changes (Will Commit)"
-msgstr "Kiválasztott változtatások (commitolva lesz)"
-
-#: git-gui.sh:2795
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Kiválasztatlan változtatások"
 
-#: git-gui.sh:2845
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Kiválasztott változtatások (commitolva lesz)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Változtatások kiválasztása"
 
-#: git-gui.sh:2864 lib/transport.tcl:104 lib/transport.tcl:193
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Push"
 
-#: git-gui.sh:2899
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Kezdeti commit üzenet:"
 
-#: git-gui.sh:2900
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Javító commit üzenet:"
 
-#: git-gui.sh:2901
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Kezdeti javító commit üzenet:"
 
-#: git-gui.sh:2902
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Javító merge commit üzenet:"
 
-#: git-gui.sh:2903
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Merge commit üzenet:"
 
-#: git-gui.sh:2904
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Commit üzenet:"
 
-#: git-gui.sh:2953 git-gui.sh:3104 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Összes másolása"
 
-#: git-gui.sh:2977 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Fájl:"
 
-#: git-gui.sh:3092
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: git-gui.sh:3113
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Font méret csökkentése"
 
-#: git-gui.sh:3117
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Fönt méret növelése"
 
-#: git-gui.sh:3125 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Kódolás"
 
-#: git-gui.sh:3136
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Hunk alkalmazása/visszaállítása"
 
-#: git-gui.sh:3141
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Sor alkalmazása/visszaállítása"
 
-#: git-gui.sh:3151
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Merge eszköz futtatása"
 
-#: git-gui.sh:3156
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Távoli verzió használata"
 
-#: git-gui.sh:3160
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Helyi verzió használata"
 
-#: git-gui.sh:3164
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Visszaállítás az alaphoz"
 
-#: git-gui.sh:3183
+#: git-gui.sh:3639
+msgid "Visualize These Changes In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3643
+#, fuzzy
+msgid "Visualize Current Branch History In The Submodule"
+msgstr "A jelenlegi branch történetének vizualizálása"
+
+#: git-gui.sh:3647
+#, fuzzy
+msgid "Visualize All Branch History In The Submodule"
+msgstr "Az összes branch történetének vizualizálása"
+
+#: git-gui.sh:3652
+msgid "Start git gui In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Hunk törlése commitból"
 
-#: git-gui.sh:3184
+#: git-gui.sh:3689
+#, fuzzy
+msgid "Unstage Lines From Commit"
+msgstr "A sor kiválasztásának törlése"
+
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "A sor kiválasztásának törlése"
 
-#: git-gui.sh:3186
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Hunk kiválasztása commitba"
 
-#: git-gui.sh:3187
+#: git-gui.sh:3696
+#, fuzzy
+msgid "Stage Lines For Commit"
+msgstr "Sor kiválasztása commitba"
+
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Sor kiválasztása commitba"
 
-#: git-gui.sh:3210
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Inicializálás..."
 
-#: git-gui.sh:3315
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Lehetséges, hogy környezeti problémák vannak.\n"
 "\n"
@@ -516,25 +584,26 @@ msgstr ""
 "indított folyamatok által:\n"
 "\n"
 
-#: git-gui.sh:3345
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Ez a Cygwin által terjesztett Tcl binárisban\n"
 "lévő ismert hiba miatt van."
 
-#: git-gui.sh:3350
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -543,332 +612,58 @@ msgstr ""
 "elhelyezése a személyes\n"
 "~/.gitconfig fájlba.\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - egy grafikus felület a Githez."
-
-#: lib/blame.tcl:72
-msgid "File Viewer"
-msgstr "Fájl néző"
-
-#: lib/blame.tcl:78
-msgid "Commit:"
-msgstr "Commit:"
-
-#: lib/blame.tcl:271
-msgid "Copy Commit"
-msgstr "Commit másolása"
-
-#: lib/blame.tcl:275
-msgid "Find Text..."
-msgstr "Szöveg keresése..."
-
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr "Teljes másolat-érzékelés bekapcsolása"
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr "Történeti környezet mutatása"
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
-msgstr "Szülő commit vizsgálata"
-
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr "A(z) %s olvasása..."
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
-msgstr "A másolást/átnevezést követő annotációk betöltése..."
-
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr "sor annotálva"
-
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr "Az eredeti hely annotációk betöltése..."
-
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr "Az annotáció kész."
-
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr "Elfoglalt"
-
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr "Az annotációs folyamat már fut."
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr "Futtatás másolás-érzékelésen keresztül..."
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr "Az annotáció betöltése..."
-
-#: lib/blame.tcl:963
-msgid "Author:"
-msgstr "Szerző:"
-
-#: lib/blame.tcl:967
-msgid "Committer:"
-msgstr "Commiter:"
-
-#: lib/blame.tcl:972
-msgid "Original File:"
-msgstr "Eredeti fájl:"
-
-#: lib/blame.tcl:1020
-msgid "Cannot find HEAD commit:"
-msgstr "Nem található a HEAD commit:"
-
-#: lib/blame.tcl:1075
-msgid "Cannot find parent commit:"
-msgstr "Nem található a szülő commit:"
-
-#: lib/blame.tcl:1090
-msgid "Unable to display parent"
-msgstr "Nem lehet megjeleníteni a szülőt"
-
-#: lib/blame.tcl:1091 lib/diff.tcl:297
-msgid "Error loading diff:"
-msgstr "Hiba a diff betöltése közben:"
-
-#: lib/blame.tcl:1231
-msgid "Originally By:"
-msgstr "Eredeti szerző:"
-
-#: lib/blame.tcl:1237
-msgid "In File:"
-msgstr "Ebben a fájlban:"
-
-#: lib/blame.tcl:1242
-msgid "Copied Or Moved Here By:"
-msgstr "Ide másolta vagy helyezte:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Branch checkoutolása"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Checkout"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:544 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:108
-msgid "Cancel"
-msgstr "Mégsem"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr "Revízió"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr "Opciók"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Követő branch letöltése"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Helyi branch leválasztása"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Branch létrehozása"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Új branch létrehozása"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:377
-msgid "Create"
-msgstr "Létrehozás"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Branch neve"
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr "Név:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Egyeztetendő követési branch név"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "A következő revíziótól"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Létező branch frissítése"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Nem"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Csak fast forward"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:536
-msgid "Reset"
-msgstr "Visszaállítás"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Checkout létrehozás után"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Válasszunk ki egy követő branchet."
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "A(z) %s követő branch nem branch a távoli repóban."
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Adjunk megy egy branch nevet."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "A(z) '%s' nem egy elfogadható branch név."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Branch törlése"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Helyi branch törlése"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Helyi branchek"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Csak már merge-ölt törlése"
-
-#: lib/branch_delete.tcl:54
-msgid "Always (Do not perform merge test.)"
-msgstr "Mindig (Ne legyen merge teszt.)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "A következő branchek nem teljesen lettek merge-ölve ebbe: %s:"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
-"Nem sikerült törölni a következő brancheket:\n"
-"%s"
 
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Branch átnevezése"
+#: lib/line.tcl:23
+msgid "Go"
+msgstr ""
 
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Átnevezés"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Munka folyamatban.. Várjunk..."
 
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Branch:"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Bezárás"
 
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Új név:"
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Siker"
 
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Válasszunk ki egy átnevezendő branchet."
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Hiba: a parancs sikertelen"
 
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:201
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "A(z) '%s' branch már létezik."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Nem sikerült átnevezni: '%s'."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Indítás..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "Fájl böngésző"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "A(z) %s betöltése..."
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[Fel a szülőhöz]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "A branch fájljainak böngészése"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:394
-#: lib/choose_repository.tcl:480 lib/choose_repository.tcl:491
-#: lib/choose_repository.tcl:995
-msgid "Browse"
-msgstr "Böngészés"
-
-#: lib/checkout_op.tcl:84
+#: lib/checkout_op.tcl:85
 #, tcl-format
 msgid "Fetching %s from %s"
 msgstr "A(z) %s letöltése innen: %s"
 
-#: lib/checkout_op.tcl:132
+#: lib/checkout_op.tcl:133
 #, tcl-format
 msgid "fatal: Cannot resolve %s"
 msgstr "végzetes: Nem lehet feloldani a következőt: %s"
 
-#: lib/checkout_op.tcl:145 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr "Bezárás"
-
-#: lib/checkout_op.tcl:174
+#: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
 msgstr "A(z) '%s' branch nem létezik."
 
-#: lib/checkout_op.tcl:193
+#: lib/checkout_op.tcl:194
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr ""
 "Nem sikerült beállítani az egyszerűsített git-pull-t a(z) '%s' számára."
 
-#: lib/checkout_op.tcl:228
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "A(z) '%s' branch már létezik."
+
+#: lib/checkout_op.tcl:229
 #, tcl-format
 msgid ""
 "Branch '%s' already exists.\n"
@@ -881,28 +676,29 @@ msgstr ""
 "Nem lehet fast-forwardolni a következőhöz: %s.\n"
 "Egy merge szükséges."
 
-#: lib/checkout_op.tcl:242
+#: lib/checkout_op.tcl:243
 #, tcl-format
 msgid "Merge strategy '%s' not supported."
 msgstr "A(z) '%s' merge strategy nem támogatott."
 
-#: lib/checkout_op.tcl:261
+#: lib/checkout_op.tcl:262
 #, tcl-format
 msgid "Failed to update '%s'."
 msgstr "Nem sikerült frissíteni a következőt: '%s'."
 
-#: lib/checkout_op.tcl:273
+#: lib/checkout_op.tcl:274
 msgid "Staging area (index) is already locked."
 msgstr "A kiválasztási terület (index) már zárolva van."
 
-#: lib/checkout_op.tcl:288
+#: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Az utolsó keresési állapot nem egyezik meg a repó állpotával.\n"
 "\n"
@@ -912,33 +708,34 @@ msgstr ""
 "\n"
 "Az újrakeresés most automatikusan el fog indulni.\n"
 
-#: lib/checkout_op.tcl:344
+#: lib/checkout_op.tcl:345
 #, tcl-format
 msgid "Updating working directory to '%s'..."
 msgstr "A munkkönyvtár frissiítése a következőre: '%s'..."
 
-#: lib/checkout_op.tcl:345
+#: lib/checkout_op.tcl:346
 msgid "files checked out"
 msgstr "fájl frissítve"
 
-#: lib/checkout_op.tcl:375
+#: lib/checkout_op.tcl:376
 #, tcl-format
 msgid "Aborted checkout of '%s' (file level merging is required)."
 msgstr "A(z) '%s' checkoutja megszakítva (fájlszintű merge-ölés szükséges)."
 
-#: lib/checkout_op.tcl:376
+#: lib/checkout_op.tcl:377
 msgid "File level merge required."
 msgstr "Fájlszintű merge-ölés szükséges."
 
-#: lib/checkout_op.tcl:380
+#: lib/checkout_op.tcl:381
 #, tcl-format
 msgid "Staying on branch '%s'."
 msgstr "Jelenleg a(z) '%s' branchen."
 
-#: lib/checkout_op.tcl:451
+#: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -947,38 +744,51 @@ msgstr ""
 "Ha egy branchen szeretnénk lenni, hozzunk létre egyet az 'Ez a leválasztott "
 "checkout'-ból."
 
-#: lib/checkout_op.tcl:468 lib/checkout_op.tcl:472
+#: lib/checkout_op.tcl:503 lib/checkout_op.tcl:507
 #, tcl-format
 msgid "Checked out '%s'."
 msgstr "'%s' kifejtve."
 
-#: lib/checkout_op.tcl:500
+#: lib/checkout_op.tcl:535
 #, tcl-format
 msgid "Resetting '%s' to '%s' will lose the following commits:"
 msgstr ""
 "A(z) '%s' -> '%s' visszaállítás a következő commitok elvesztését jelenti:"
 
-#: lib/checkout_op.tcl:522
+#: lib/checkout_op.tcl:557
 msgid "Recovering lost commits may not be easy."
 msgstr "Az elveszett commitok helyreállítása nem biztos, hogy egyszerű."
 
-#: lib/checkout_op.tcl:527
+#: lib/checkout_op.tcl:562
 #, tcl-format
 msgid "Reset '%s'?"
 msgstr "Visszaállítjuk a következőt: '%s'?"
 
-#: lib/checkout_op.tcl:532 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Vizualizálás"
 
-#: lib/checkout_op.tcl:600
-#, tcl-format
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Visszaállítás"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Mégsem"
+
+#: lib/checkout_op.tcl:635
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Nem sikerült beállítani a jelenlegi branchet.\n"
@@ -988,746 +798,222 @@ msgstr ""
 "\n"
 "Ennek nem szabad megtörténnie.  A(z) %s most kilép és feladja."
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Kiválaszt"
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "a(z) %s letöltése"
 
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Font család"
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "Új változások letöltése innen: %s"
 
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Font méret"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "a(z) %s távoli törlése"
 
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Font példa"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "A %s repóból törölt követő branchek törlése"
 
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
-"Ez egy példa szöveg.\n"
-"Ha ez megfelel, ez lehet a betűtípus."
 
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
+#: lib/transport.tcl:26
+#, fuzzy
+msgid "Fetching new changes from all remotes"
+msgstr "Új változások letöltése innen: %s"
 
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:382
-msgid "Create New Repository"
-msgstr "Új repó létrehozása"
+#: lib/transport.tcl:40
+#, fuzzy
+msgid "remote prune all remotes"
+msgstr "a(z) %s távoli törlése"
 
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr "Új..."
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "A %s repóból törölt követő branchek törlése"
 
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:465
-msgid "Clone Existing Repository"
-msgstr "Létező repó másolása"
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr "Másolás..."
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:983
-msgid "Open Existing Repository"
-msgstr "Létező könyvtár megnyitása"
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr "Meggyitás..."
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr "Legutóbbi repók"
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr "Legutóbbi repók megnyitása:"
-
-#: lib/choose_repository.tcl:302 lib/choose_repository.tcl:309
-#: lib/choose_repository.tcl:316
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Nem sikerült letrehozni a(z) %s repót:"
+msgid "push %s"
+msgstr "%s push-olása"
 
-#: lib/choose_repository.tcl:387
-msgid "Directory:"
-msgstr "Könyvtár:"
-
-#: lib/choose_repository.tcl:417 lib/choose_repository.tcl:544
-#: lib/choose_repository.tcl:1017
-msgid "Git Repository"
-msgstr "Git repó"
-
-#: lib/choose_repository.tcl:442
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Directory %s already exists."
-msgstr "A(z) '%s' könyvtár már létezik."
+msgid "Pushing changes to %s"
+msgstr "Változások pusholása ide: %s"
 
-#: lib/choose_repository.tcl:446
+#: lib/transport.tcl:93
 #, tcl-format
-msgid "File %s already exists."
-msgstr "A(z) '%s' fájl már létezik."
+msgid "Mirroring to %s"
+msgstr "Tükrözés a következő helyre: %s"
 
-#: lib/choose_repository.tcl:460
-msgid "Clone"
-msgstr "Bezárás"
-
-#: lib/choose_repository.tcl:473
-msgid "Source Location:"
-msgstr "Forrás helye:"
-
-#: lib/choose_repository.tcl:484
-msgid "Target Directory:"
-msgstr "Cél könyvtár:"
-
-#: lib/choose_repository.tcl:496
-msgid "Clone Type:"
-msgstr "Másolás típusa:"
-
-#: lib/choose_repository.tcl:502
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Általános (Gyors, félig-redundáns, hardlinkek)"
-
-#: lib/choose_repository.tcl:508
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Teljes másolás (Lassabb, redundáns biztonsági mentés)"
-
-#: lib/choose_repository.tcl:514
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Megosztott (Leggyorsabb, nem ajánlott, nincs mentés)"
-
-#: lib/choose_repository.tcl:550 lib/choose_repository.tcl:597
-#: lib/choose_repository.tcl:743 lib/choose_repository.tcl:813
-#: lib/choose_repository.tcl:1023 lib/choose_repository.tcl:1031
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Nem Git repó: %s"
+msgid "Pushing %s %s to %s"
+msgstr "Pusholás: %s %s, ide: %s"
 
-#: lib/choose_repository.tcl:586
-msgid "Standard only available for local repository."
-msgstr "A standard csak helyi repókra érhető el."
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Branchek pusholása"
 
-#: lib/choose_repository.tcl:590
-msgid "Shared only available for local repository."
-msgstr "A megosztott csak helyi repókra érhető el."
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Forrás branchek"
 
-#: lib/choose_repository.tcl:611
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "A(z) '%s' hely már létezik."
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Cél repó"
 
-#: lib/choose_repository.tcl:622
-msgid "Failed to configure origin"
-msgstr "Nem sikerült beállítani az origint"
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Távoli:"
 
-#: lib/choose_repository.tcl:634
-msgid "Counting objects"
-msgstr "Objektumok számolása"
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Önkényes hely:"
 
-#: lib/choose_repository.tcl:635
-msgid "buckets"
-msgstr "vödrök"
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Átviteli opciók"
 
-#: lib/choose_repository.tcl:659
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Nem sikerült másolni az objects/info/alternates-t: %s"
-
-#: lib/choose_repository.tcl:695
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Semmi másolni való nincs innen: %s"
-
-#: lib/choose_repository.tcl:697 lib/choose_repository.tcl:911
-#: lib/choose_repository.tcl:923
-msgid "The 'master' branch has not been initialized."
-msgstr "A 'master' branch nincs inicializálva."
-
-#: lib/choose_repository.tcl:710
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Nem érhetőek el hardlinkek.  Másolás használata."
-
-#: lib/choose_repository.tcl:722
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Másolás innen: %s"
-
-#: lib/choose_repository.tcl:753
-msgid "Copying objects"
-msgstr "Objektumok másolása"
-
-#: lib/choose_repository.tcl:754
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:778
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Nem sikerült másolni az objektumot: %s"
-
-#: lib/choose_repository.tcl:788
-msgid "Linking objects"
-msgstr "Objektumok összefűzése"
-
-#: lib/choose_repository.tcl:789
-msgid "objects"
-msgstr "objektum"
-
-#: lib/choose_repository.tcl:797
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Nem sikerült hardlinkelni az objektumot: %s"
-
-#: lib/choose_repository.tcl:852
-msgid "Cannot fetch branches and objects.  See console output for details."
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
 msgstr ""
-"Nem sikerült letölteni a branch-eket és az objektumokat.  Bővebben a "
-"konzolos kimenetben."
+"Létező branch felülírásának erőltetése (lehet, hogy el fog dobni "
+"változtatásokat)"
 
-#: lib/choose_repository.tcl:863
-msgid "Cannot fetch tags.  See console output for details."
-msgstr "Nem sikerült letölteni a tageket.  Bővebben a konzolos kimenetben."
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Vékony csomagok használata (lassú hálózati kapcsolatok számára)"
 
-#: lib/choose_repository.tcl:887
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr "Nem sikerült megállapítani a HEAD-et.  Bővebben a konzolos kimenetben."
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Tageket is"
 
-#: lib/choose_repository.tcl:896
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Nem sikerült tiszítani: %s."
-
-#: lib/choose_repository.tcl:902
-msgid "Clone failed."
-msgstr "A másolás nem sikerült."
-
-#: lib/choose_repository.tcl:909
-msgid "No default branch obtained."
-msgstr "Nincs alapértelmezett branch."
-
-#: lib/choose_repository.tcl:920
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Nem sikerült felöldani a(z) %s objektumot commitként."
-
-#: lib/choose_repository.tcl:932
-msgid "Creating working directory"
-msgstr "Munkakönyvtár létrehozása"
-
-#: lib/choose_repository.tcl:933 lib/index.tcl:65 lib/index.tcl:128
-#: lib/index.tcl:196
-msgid "files"
-msgstr "fájl"
-
-#: lib/choose_repository.tcl:962
-msgid "Initial file checkout failed."
-msgstr "A kezdeti fájl-kibontás sikertelen."
-
-#: lib/choose_repository.tcl:978
-msgid "Open"
-msgstr "Megnyitás"
-
-#: lib/choose_repository.tcl:988
-msgid "Repository:"
-msgstr "Repó:"
-
-#: lib/choose_repository.tcl:1037
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Nem sikerült megnyitni a(z) %s repót:"
-
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "Ez a leválasztott checkout"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Revízió kifejezés:"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Helyi branch"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Követő branch"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Tag"
-
-#: lib/choose_rev.tcl:317
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Érvénytelen revízió: %s"
-
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Nincs kiválasztva revízió."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "A revízió kifejezés üres."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Frissítve"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
+msgid "%s (%s): Push"
 msgstr ""
-"Nincs semmi javítanivaló.\n"
-"\n"
-"Az első commit létrehozása előtt nincs semmilyen commit amit javitani "
-"lehetne.\n"
 
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Nem lehet javítani merge alatt.\n"
-"\n"
-"A jelenlegi merge még nem teljesen fejeződött be. Csak akkor javíthat egy "
-"előbbi commitot, hogyha megszakítja a jelenlegi merge folyamatot.\n"
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "Remote hozzáadása"
 
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Hiba a javítandó commit adat betöltése közben:"
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Új remote hozzáadása"
 
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Nem sikerült megállapítani az azonosítót:"
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Hozzáadás"
 
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Érvénytelen GIT_COMMITTER_IDENT:"
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Remote részletei"
 
-#: lib/commit.tcl:132
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"Az utolsó keresési állapot nem egyezik meg a repó állapotával.\n"
-"\n"
-"Egy másik Git program módosította ezt a repót az utolsó keresés óta. Egy "
-"újrakeresés mindenképpen szükséges mielőtt a jelenlegi branchet módosítani "
-"lehetne.\n"
-"\n"
-"Az újrakeresés most automatikusan el fog indulni.\n"
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Név:"
 
-#: lib/commit.tcl:155
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"Nem commitolhatunk fájlokat merge előtt.\n"
-"\n"
-"A(z) %s fájlban ütközések vannak. Egyszer azokat ki kell javítani, majd "
-"hozzá ki kell választani a fájlt mielőtt commitolni lehetne.\n"
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Hely:"
 
-#: lib/commit.tcl:163
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Ismeretlen fájl típus %s érzékelve.\n"
-"\n"
-"A(z) %s fájlt nem tudja ez a program commitolni.\n"
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Következő művelet"
 
-#: lib/commit.tcl:171
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Nincs commitolandó változtatás.\n"
-"\n"
-"Legalább egy fájl ki kell választani, hogy commitolni lehessen.\n"
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Letöltés most"
 
-#: lib/commit.tcl:186
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Adjunk megy egy commit üzenetet.\n"
-"\n"
-"Egy jó commit üzenetnek a következő a formátuma:\n"
-"\n"
-"- Első sor: Egy mondatban leírja, hogy mit csináltunk.\n"
-"- Második sor: Üres\n"
-"- A többi sor: Leírja, hogy miért jó ez a változtatás.\n"
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Távoli repó inicializálása és push"
 
-#: lib/commit.tcl:210
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "figyelmeztetés: a Tcl nem támogatja a(z) '%s' kódolást."
-
-#: lib/commit.tcl:226
-msgid "Calling pre-commit hook..."
-msgstr "A pre-commit hurok meghívása..."
-
-#: lib/commit.tcl:241
-msgid "Commit declined by pre-commit hook."
-msgstr "A commitot megakadályozta a pre-commit hurok. "
-
-#: lib/commit.tcl:264
-msgid "Calling commit-msg hook..."
-msgstr "A commit-msg hurok meghívása..."
-
-#: lib/commit.tcl:279
-msgid "Commit declined by commit-msg hook."
-msgstr "A commiot megakadályozta a commit-msg hurok."
-
-#: lib/commit.tcl:292
-msgid "Committing changes..."
-msgstr "A változtatások commitolása..."
-
-#: lib/commit.tcl:308
-msgid "write-tree failed:"
-msgstr "a write-tree sikertelen:"
-
-#: lib/commit.tcl:309 lib/commit.tcl:353 lib/commit.tcl:373
-msgid "Commit failed."
-msgstr "A commit nem sikerült."
-
-#: lib/commit.tcl:326
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "A(z) %s commit sérültnek tűnik"
-
-#: lib/commit.tcl:331
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Nincs commitolandó változtatás.\n"
-"\n"
-"Egyetlen fájlt se módosított ez a commit és merge commit se volt.\n"
-"\n"
-"Az újrakeresés most automatikusan el fog indulni.\n"
-
-#: lib/commit.tcl:338
-msgid "No changes to commit."
-msgstr "Nincs commitolandó változtatás."
-
-#: lib/commit.tcl:352
-msgid "commit-tree failed:"
-msgstr "a commit-tree sikertelen:"
-
-#: lib/commit.tcl:372
-msgid "update-ref failed:"
-msgstr "az update-ref sikertelen:"
-
-#: lib/commit.tcl:460
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Létrejött a %s commit: %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Munka folyamatban.. Várjunk..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Siker"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Hiba: a parancs sikertelen"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Elvesztett objektumok száma"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Elveszett objektumok által elfoglalt lemezterület"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Csomagolt objektumok számra"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Csomagok száma"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "A csomagolt objektumok által használt lemezterület"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Eltávolításra váró csomagolt objektumok számra"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "Hulladék fájlok"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Az objektum adatbázis tömörítése"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Az objektum adatbázis ellenőrzése az fsck-objects használatával"
-
-#: lib/database.tcl:108
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database when more than %i loose objects exist.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Ennek a repónak jelenleg %i különálló objektuma van.\n"
-"\n"
-"Az optimális teljesítményhez erősen ajánlott az adatbázis tömörítése, ha "
-"több mint %i objektum létezik.\n"
-"\n"
-"Lehet most tömöríteni az adatbázist?"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Érvénytelen dátum a Git-től: %s"
-
-#: lib/diff.tcl:59
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Nincsenek változások.\n"
-"\n"
-"A(z) %s módosítatlan.\n"
-"\n"
-"A fájl módosítási dátumát frissítette egy másik alkalmazás, de a fájl "
-"tartalma változatlan.\n"
-"\n"
-"Egy újrakeresés fog indulni a hasonló állapotú fájlok megtalálása érdekében."
-
-#: lib/diff.tcl:99
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "A(z) %s diff-jének betöltése..."
-
-#: lib/diff.tcl:120
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-"HELYI: törölve\n"
-"TÁVOLI:\n"
-
-#: lib/diff.tcl:125
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-"TÁVOLI: törölve\n"
-"HELYI:\n"
-
-#: lib/diff.tcl:132
-msgid "LOCAL:\n"
-msgstr "HELYI:\n"
-
-#: lib/diff.tcl:135
-msgid "REMOTE:\n"
-msgstr "TÁVOLI:\n"
-
-#: lib/diff.tcl:197 lib/diff.tcl:296
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Nem lehet megjeleníteni a következőt: %s"
-
-#: lib/diff.tcl:198
-msgid "Error loading file:"
-msgstr "Hiba a fájl betöltése közben:"
-
-#: lib/diff.tcl:205
-msgid "Git Repository (subproject)"
-msgstr "Git repó (alprojekt)"
-
-#: lib/diff.tcl:217
-msgid "* Binary file (not showing content)."
-msgstr "* Bináris fájl (tartalom elrejtése)."
-
-#: lib/diff.tcl:222
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* Nem követett fájl %d bájttal.\n"
-"* Csak az első %d bájt mutatása.\n"
-
-#: lib/diff.tcl:228
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-"\n"
-"* Nem követett fájlt levágta a(z) %s.\n"
-"* A teljes tartalom megjelenítéséhez használjunk külső szövegszerkesztőt.\n"
-
-#: lib/diff.tcl:436
-msgid "Failed to unstage selected hunk."
-msgstr "Nem visszavonni a hunk kiválasztását."
-
-#: lib/diff.tcl:443
-msgid "Failed to stage selected hunk."
-msgstr "Nem sikerült kiválasztani a hunkot."
-
-#: lib/diff.tcl:509
-msgid "Failed to unstage selected line."
-msgstr "Nem sikerült visszavonni a sor kiválasztását."
-
-#: lib/diff.tcl:517
-msgid "Failed to stage selected line."
-msgstr "Nem sikerült kiválasztani a sort."
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Alapértelmezés"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Rendszer (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Más"
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "hiba"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "figyelmeztetés"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr "Ki kell javítanunk a fenti hibákat commit előtt."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Nem sikerült az index zárolásának feloldása."
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Index hiba"
-
-#: lib/index.tcl:21
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"A Git index frissítése sikertelen volt.  Egy újraolvasás automatikusan "
-"elindult, hogy a git-gui újra szinkonban legyen."
-
-#: lib/index.tcl:27
-msgid "Continue"
-msgstr "Folytatás"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Index zárolásának feloldása"
-
-#: lib/index.tcl:287
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "A(z) %s commitba való kiválasztásának visszavonása"
-
-#: lib/index.tcl:326
-msgid "Ready to commit."
-msgstr "Commitolásra kész."
-
-#: lib/index.tcl:339
-#, tcl-format
-msgid "Adding %s"
-msgstr "A(z) %s hozzáadása..."
-
-#: lib/index.tcl:396
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Visszaállítja a változtatásokat a(z) %s fájlban?"
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Visszaállítja a változtatásokat ebben e %i fájlban?"
-
-#: lib/index.tcl:406
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Minden nem kiválasztott változtatás el fog veszni ezáltal a visszaállítás "
-"által."
-
-#: lib/index.tcl:409
-msgid "Do Nothing"
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
 msgstr "Ne csináljunk semmit"
 
-#: lib/index.tcl:427
-msgid "Reverting selected files"
-msgstr "A kiválasztott fájlok visszaállítása"
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Adjunk megy egy remote nevet."
 
-#: lib/index.tcl:431
+#: lib/remote_add.tcl:113
 #, tcl-format
-msgid "Reverting %s"
-msgstr "%s visszaállítása"
+msgid "'%s' is not an acceptable remote name."
+msgstr "A(z) '%s' nem egy elfogadható remote név."
+
+#: lib/remote_add.tcl:124
+#, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Nem sikerült a(t) '%s' remote hozzáadása innen: '%s'."
+
+#: lib/remote_add.tcl:133
+#, tcl-format
+msgid "Fetching the %s"
+msgstr "A(z) %s letöltése"
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "Nem tudni, hogy hogy kell a(z) '%s' helyen repót inicializálni."
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr "A(z) %s beállítása itt: %s"
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Indítás..."
+
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Fájl böngésző"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr "A(z) %s betöltése..."
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Fel a szülőhöz]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "A branch fájljainak böngészése"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "A branch fájljainak böngészése"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Böngészés"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Revízió"
 
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Javítás közben nem lehetséges a merge.\n"
 "\n"
@@ -1735,13 +1021,14 @@ msgstr ""
 "merge.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Az utolsó keresési állapot nem egyezik meg a repó állapotával.\n"
 "\n"
@@ -1752,14 +1039,14 @@ msgstr ""
 "Az újrakeresés most automatikusan el fog indulni.\n"
 
 #: lib/merge.tcl:45
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "Jelenleg egy ütközés feloldása közben vagyunk.\n"
 "\n"
@@ -1769,14 +1056,14 @@ msgstr ""
 "a jelenlegi merge-t. Csak ezután kezdhetünk el egy újabbat.\n"
 
 #: lib/merge.tcl:55
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "Jelenleg egy változtatás közben vagyunk.\n"
 "\n"
@@ -1785,49 +1072,57 @@ msgstr ""
 "Először be kell fejeznünk a jelenlegi commitot, hogy elkezdhessünk egy merge-"
 "t. Ez segíteni fog, hogy félbeszakíthassunk egy merge-t.\n"
 
-#: lib/merge.tcl:107
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s / %s"
 
-#: lib/merge.tcl:120
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "A(z) %s és a(z) %s merge-ölése..."
 
-#: lib/merge.tcl:131
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "A merge sikeresen befejeződött."
 
-#: lib/merge.tcl:133
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "A merge sikertelen. Fel kell oldanunk az ütközéseket."
 
-#: lib/merge.tcl:158
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Merge-ölés a következőbe: %s"
 
-#: lib/merge.tcl:177
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Merge-ölni szándékozott revízió"
 
-#: lib/merge.tcl:212
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "A commit javítás közben megszakítva.\n"
 "\n"
 "Be kell fejeznünk ennek a commitnak a javítását.\n"
 
-#: lib/merge.tcl:222
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Megszakítjuk a merge-t?\n"
@@ -1837,12 +1132,13 @@ msgstr ""
 "\n"
 "Folytatjuk a jelenlegi merge megszakítását?"
 
-#: lib/merge.tcl:228
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Visszavonjuk a módosításokat?\n"
@@ -1852,429 +1148,81 @@ msgstr ""
 "\n"
 "Folytatjuk a jelenlegi módosítások visszavonását?"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Félbeszakítás"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "fájl visszaállítva"
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "A félbeszakítás nem sikerült."
 
-#: lib/merge.tcl:269
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "A megkeszakítás befejeződött. Kész."
 
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Feloldás erőltetése az alap verzióhoz?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Feloldás erőltetése ehhez a branch-hez?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Feloldás erőltetése a másik branch-hez?"
-
-#: lib/mergetool.tcl:14
+#: lib/tools.tcl:76
 #, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Megjegyzés: csak az ütköző különbségek látszanak.\n"
-"\n"
-"A(z) %s felül lesz írva.\n"
-"\n"
-"Ez a művelet csak a merge újraindításával lesz visszavonható."
+msgid "Running %s requires a selected file."
+msgstr "A(z) %s futtatása egy kiválasztott fájlt igényel."
 
-#: lib/mergetool.tcl:45
+#: lib/tools.tcl:92
+#, fuzzy, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Biztos benne, hogy futtatni kívánja: %s?"
+
+#: lib/tools.tcl:96
 #, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-"A(z) %s fájl nem feloldott ütközéseket tartalmaz, mégis legyen kiválasztva?"
+msgid "Are you sure you want to run %s?"
+msgstr "Biztos benne, hogy futtatni kívánja: %s?"
 
-#: lib/mergetool.tcl:60
+#: lib/tools.tcl:118
 #, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Feloldás hozzáadása a(z) %s számára"
+msgid "Tool: %s"
+msgstr "Eszköz: %s"
 
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr "Nem lehet feloldani törlési vagy link ütközést egy eszközzel"
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "A konfiklus-fájl nem létezik."
-
-#: lib/mergetool.tcl:264
+#: lib/tools.tcl:119
 #, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "Nem GUI merge eszköz: %s"
+msgid "Running: %s"
+msgstr "Futtatás: %s..."
 
-#: lib/mergetool.tcl:268
+#: lib/tools.tcl:158
 #, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "A(z) '%s' merge eszköz nem támogatott"
+msgid "Tool completed successfully: %s"
+msgstr "Az eszköz sikeresen befejeződött: %s"
 
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr "A merge eszköz már fut, le legyen állítva?"
-
-#: lib/mergetool.tcl:323
+#: lib/tools.tcl:160
 #, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Hiba a verziók kinyerése közben:\n"
-"%s"
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-"A merge eszköz indítása sikertelen:\n"
-"\n"
-"%s"
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr "A merge eszköz futtatása..."
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr "A merge eszköz nem sikerült."
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr "Érvénytelen globális kódolás '%s'"
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr "Érvénytelen repó kódolás '%s'"
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr "Alapértelmezés visszaállítása"
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr "Mentés"
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr "%s Repó"
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr "Globális (minden repó)"
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr "Felhasználónév"
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr "Email cím"
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr "A merge commitok összegzése"
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr "Merge beszédesség"
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr "Diffstat mutatása merge után"
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr "Merge eszköz használata"
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr "A fájl módosítási dátumok megbízhatóak"
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr "A követő branchek eltávolítása letöltés alatt"
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr "A követő branchek egyeztetése"
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr "A blame másolás bekapcsolása csak megváltozott fájlokra"
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr "Minimum betűszám blame másolás-érzékeléshez"
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr "Blame történet környezet sugár (napokban)"
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr "A diff környezeti sorok száma"
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr "Commit üzenet szövegének szélessége"
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr "Új branch név sablon"
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr "Alapértelmezett fájltartalom-kódolás"
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr "Megváltoztatás"
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr "Helyesírás-ellenőrző szótár:"
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr "Betűtípus megváltoztatása"
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr "%s választása"
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr "pt."
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr "Beállítások"
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr "Nem sikerült teljesen elmenteni a beállításokat:"
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr "Remote eltávolítása"
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr "Törlés innen"
-
-# tcl-format
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr "Letöltés innen"
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr "Push ide"
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
-msgstr "Remote hozzáadása"
-
-#: lib/remote_add.tcl:24
-msgid "Add New Remote"
-msgstr "Új remote hozzáadása"
-
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
-msgid "Add"
-msgstr "Hozzáadás"
-
-#: lib/remote_add.tcl:37
-msgid "Remote Details"
-msgstr "Remote részletei"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Hely:"
-
-#: lib/remote_add.tcl:62
-msgid "Further Action"
-msgstr "Következő művelet"
-
-#: lib/remote_add.tcl:65
-msgid "Fetch Immediately"
-msgstr "Letöltés most"
-
-#: lib/remote_add.tcl:71
-msgid "Initialize Remote Repository and Push"
-msgstr "Távoli repó inicializálása és push"
-
-#: lib/remote_add.tcl:77
-msgid "Do Nothing Else Now"
-msgstr "Ne csináljunk semmit"
-
-#: lib/remote_add.tcl:101
-msgid "Please supply a remote name."
-msgstr "Adjunk megy egy remote nevet."
-
-#: lib/remote_add.tcl:114
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "A(z) '%s' nem egy elfogadható remote név."
-
-#: lib/remote_add.tcl:125
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Nem sikerült a(t) '%s' remote hozzáadása innen: '%s'."
-
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "a(z) %s letöltése"
-
-#: lib/remote_add.tcl:134
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "A(z) %s letöltése"
-
-#: lib/remote_add.tcl:157
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Nem tudni, hogy hogy kell a(z) '%s' helyen repót inicializálni."
-
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:63
-#: lib/transport.tcl:81
-#, tcl-format
-msgid "push %s"
-msgstr "%s push-olása"
-
-#: lib/remote_add.tcl:164
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "A(z) %s beállítása itt: %s"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Távoli Branch törlése"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "Forrás repó"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:134
-msgid "Remote:"
-msgstr "Távoli:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:149
-msgid "Arbitrary Location:"
-msgstr "Önkényes hely:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Branchek"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Törlés csak akkor ha"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Merge-ölt a következőbe:"
-
-#: lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Mindig (Ne végezzen merge vizsgálatokat)"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "Egy branch szükséges a 'Merge-ölt a következőbe'-hez."
-
-#: lib/remote_branch_delete.tcl:184
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-"A következő branchek nem teljesen lettek merge-ölve ebbe: %s:\n"
-" - %s"
-
-#: lib/remote_branch_delete.tcl:189
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-"Egy vagy több merge teszt hibát jelzett, mivel nem töltöttük le a megfelelő "
-"commitokat. Próbáljunk meg letölteni a következőből: %s először."
-
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Válasszunk ki egy vagy több branchet törlésre."
-
-#: lib/remote_branch_delete.tcl:216
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr ""
-"A törölt branchek visszaállítása nehéz.\n"
-"\n"
-"Töröljük a kiválasztott brancheket?"
-
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Brancek törlése innen: %s"
-
-#: lib/remote_branch_delete.tcl:286
-msgid "No repository selected."
-msgstr "Nincs kiválasztott repó."
-
-#: lib/remote_branch_delete.tcl:291
-#, tcl-format
-msgid "Scanning %s..."
-msgstr "Keresés itt: %s..."
-
-#: lib/search.tcl:21
-msgid "Find:"
-msgstr "Keresés:"
-
-#: lib/search.tcl:23
-msgid "Next"
-msgstr "Következő"
-
-#: lib/search.tcl:24
-msgid "Prev"
-msgstr "Előző"
-
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
-msgstr "Kisbetű-nagybetű számít"
-
-#: lib/shortcut.tcl:20 lib/shortcut.tcl:61
-msgid "Cannot write shortcut:"
-msgstr "Nem sikerült írni a gyorsbillentyűt:"
-
-#: lib/shortcut.tcl:136
-msgid "Cannot write icon:"
-msgstr "Nem sikerült írni az ikont:"
+msgid "Tool failed: %s"
+msgstr "Az eszköz sikertelen: %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Branch checkoutolása"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Branch checkoutolása"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Checkout"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Opciók"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Követő branch letöltése"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Helyi branch leválasztása"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -2313,6 +1261,1011 @@ msgstr "Nem várt EOF a helyesírás-ellenőrzőtől"
 msgid "Spell Checker Failed"
 msgstr "A helyesírás-ellenőrzés sikertelen"
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s ... %*i / %*i %s (%3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Nincsenek változások.\n"
+"\n"
+"A(z) %s módosítatlan.\n"
+"\n"
+"A fájl módosítási dátumát frissítette egy másik alkalmazás, de a fájl "
+"tartalma változatlan.\n"
+"\n"
+"Egy újrakeresés fog indulni a hasonló állapotú fájlok megtalálása érdekében."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "A(z) %s diff-jének betöltése..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"HELYI: törölve\n"
+"TÁVOLI:\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"TÁVOLI: törölve\n"
+"HELYI:\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "HELYI:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "TÁVOLI:\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Nem lehet megjeleníteni a következőt: %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Hiba a fájl betöltése közben:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Git repó (alprojekt)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Bináris fájl (tartalom elrejtése)."
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* Nem követett fájlt levágta a(z) %s.\n"
+"* A teljes tartalom megjelenítéséhez használjunk külső szövegszerkesztőt.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Hiba a diff betöltése közben:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Nem visszavonni a hunk kiválasztását."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Nem sikerült kiválasztani a hunkot."
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Nem sikerült visszavonni a sor kiválasztását."
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Nem sikerült kiválasztani a sort."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Push ide"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Remote eltávolítása"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Törlés innen"
+
+# tcl-format
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Letöltés innen"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Kiválaszt"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Font család"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Font méret"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Font példa"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Ez egy példa szöveg.\n"
+"Ha ez megfelel, ez lehet a betűtípus."
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr "Érvénytelen globális kódolás '%s'"
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr "Érvénytelen repó kódolás '%s'"
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Alapértelmezés visszaállítása"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Mentés"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "%s Repó"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Globális (minden repó)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Felhasználónév"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Email cím"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "A merge commitok összegzése"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Merge beszédesség"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Diffstat mutatása merge után"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr "Merge eszköz használata"
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "A fájl módosítási dátumok megbízhatóak"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr "A követő branchek eltávolítása letöltés alatt"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "A követő branchek egyeztetése"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr "A blame másolás bekapcsolása csak megváltozott fájlokra"
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Legutóbbi repók"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr "Minimum betűszám blame másolás-érzékeléshez"
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr "Blame történet környezet sugár (napokban)"
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "A diff környezeti sorok száma"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Commit üzenet szövegének szélessége"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Új branch név sablon"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr "Alapértelmezett fájltartalom-kódolás"
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr "Megváltoztatás"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Helyesírás-ellenőrző szótár:"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Betűtípus megváltoztatása"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "%s választása"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "pt."
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Beállítások"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "Nem sikerült teljesen elmenteni a beállításokat:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Feloldás erőltetése az alap verzióhoz?"
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Feloldás erőltetése ehhez a branch-hez?"
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Feloldás erőltetése a másik branch-hez?"
+
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"Megjegyzés: csak az ütköző különbségek látszanak.\n"
+"\n"
+"A(z) %s felül lesz írva.\n"
+"\n"
+"Ez a művelet csak a merge újraindításával lesz visszavonható."
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+"A(z) %s fájl nem feloldott ütközéseket tartalmaz, mégis legyen kiválasztva?"
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr "Feloldás hozzáadása a(z) %s számára"
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr "Nem lehet feloldani törlési vagy link ütközést egy eszközzel"
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "A konfiklus-fájl nem létezik."
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "Nem GUI merge eszköz: %s"
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr "A(z) '%s' merge eszköz nem támogatott"
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "A merge eszköz már fut, le legyen állítva?"
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Hiba a verziók kinyerése közben:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+"A merge eszköz indítása sikertelen:\n"
+"\n"
+"%s"
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "A merge eszköz futtatása..."
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "A merge eszköz nem sikerült."
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "Eszköz hozzáadása"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "Új eszköz-parancs hozzáadása"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "Globális hozzáadás"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "Eszköz részletei"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "Használjunk '/' szeparátorokat almenü-fa létrehozásához:"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "Parancs:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "Parancsablak mutatása futtatás előtt"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr ""
+"Megkéri a felhasználót, hogy válasszon ki egy revíziót (a $REVISION-t "
+"állítja)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "Megkérdezi a felhasználót további argumentumokért (a $ARGS-ot állítja)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "Ne mutassa a parancs kimeneti ablakát"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "Futtatás csak ha egy diff ki van választva (a $FILENAME nem üres)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "Adjunk meg egy eszköz nevet."
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "A(z) '%s' eszköz már létezik."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+"Az eszköz nem hozzáadható:\n"
+"%s"
+
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "Eszköz eltávolítása"
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "Eszköz parancsok eltávolítása"
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "Eltávolítás"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(Kék jelzi a repó-specifikus eszközöket)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Rendszer (%s)"
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "Parancs futtatása: %s"
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "Argumentumok"
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "OK"
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Keresés:"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Következő"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Előző"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Asztal ikon létrehozása"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Nem sikerült írni a gyorsbillentyűt:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Nem sikerült írni az ikont:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Branch átnevezése"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Branch átnevezése"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Átnevezés"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Branch:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Új név:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Válasszunk ki egy átnevezendő branchet."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Adjunk megy egy branch nevet."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "A(z) '%s' nem egy elfogadható branch név."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Nem sikerült átnevezni: '%s'."
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Távoli Branch törlése"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Távoli Branch törlése"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Forrás repó"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Branchek"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Törlés csak akkor ha"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Merge-ölt a következőbe:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Mindig (Ne végezzen merge vizsgálatokat)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "Egy branch szükséges a 'Merge-ölt a következőbe'-hez."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"A következő branchek nem teljesen lettek merge-ölve ebbe: %s:\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Egy vagy több merge teszt hibát jelzett, mivel nem töltöttük le a megfelelő "
+"commitokat. Próbáljunk meg letölteni a következőből: %s először."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Válasszunk ki egy vagy több branchet törlésre."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"A törölt branchek visszaállítása nehéz.\n"
+"\n"
+"Töröljük a kiválasztott brancheket?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Brancek törlése innen: %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Nincs kiválasztott repó."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Keresés itt: %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Új repó létrehozása"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Új..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Létező repó másolása"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Másolás..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Létező könyvtár megnyitása"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Meggyitás..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Legutóbbi repók"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Legutóbbi repók megnyitása:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Nem sikerült letrehozni a(z) %s repót:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Létrehozás"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Könyvtár:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Git repó"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "A(z) '%s' könyvtár már létezik."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "A(z) '%s' fájl már létezik."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Bezárás"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Forrás helye:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Cél könyvtár:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Másolás típusa:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Általános (Gyors, félig-redundáns, hardlinkek)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Teljes másolás (Lassabb, redundáns biztonsági mentés)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Megosztott (Leggyorsabb, nem ajánlott, nincs mentés)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Nem Git repó: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "A standard csak helyi repókra érhető el."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "A megosztott csak helyi repókra érhető el."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "A(z) '%s' hely már létezik."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Nem sikerült beállítani az origint"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Objektumok számolása"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "vödrök"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Nem sikerült másolni az objects/info/alternates-t: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Semmi másolni való nincs innen: %s"
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "A 'master' branch nincs inicializálva."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Nem érhetőek el hardlinkek.  Másolás használata."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Másolás innen: %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Objektumok másolása"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Nem sikerült másolni az objektumot: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Objektumok összefűzése"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "objektum"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Nem sikerült hardlinkelni az objektumot: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Nem sikerült letölteni a branch-eket és az objektumokat.  Bővebben a "
+"konzolos kimenetben."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr "Nem sikerült letölteni a tageket.  Bővebben a konzolos kimenetben."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr "Nem sikerült megállapítani a HEAD-et.  Bővebben a konzolos kimenetben."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Nem sikerült tiszítani: %s."
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "A másolás nem sikerült."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Nincs alapértelmezett branch."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Nem sikerült felöldani a(z) %s objektumot commitként."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Munkakönyvtár létrehozása"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "fájl"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Másolás innen: %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "A kezdeti fájl-kibontás sikertelen."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Megnyitás"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Repó:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Nem sikerült megnyitni a(z) %s repót:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - egy grafikus felület a Githez."
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Fájl néző"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Commit:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Commit másolása"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Szöveg keresése..."
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Másolás..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Teljes másolat-érzékelés bekapcsolása"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Történeti környezet mutatása"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Szülő commit vizsgálata"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "A(z) %s olvasása..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "A másolást/átnevezést követő annotációk betöltése..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "sor annotálva"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Az eredeti hely annotációk betöltése..."
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Az annotáció kész."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Elfoglalt"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "Az annotációs folyamat már fut."
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Futtatás másolás-érzékelésen keresztül..."
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Az annotáció betöltése..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Szerző:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Commiter:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Eredeti fájl:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Nem található a HEAD commit:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Nem található a szülő commit:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Nem lehet megjeleníteni a szülőt"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Eredeti szerző:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "Ebben a fájlban:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Ide másolta vagy helyezte:"
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr "Nincsenek kulcsok."
@@ -2326,19 +2279,19 @@ msgstr "Nyilvános kulcs található ebben: %s"
 msgid "Generate Key"
 msgstr "Kulcs generálása"
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "Másolás vágólapra"
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "Az OpenSSH publikus kulcsunk"
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Generálás..."
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2349,206 +2302,559 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr "A generálás nem sikerült."
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr "A generálás sikeres, de egy kulcs se található."
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "A kulcsunk itt van: %s"
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Branch létrehozása"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Új branch létrehozása"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Branch neve"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Egyeztetendő követési branch név"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "A következő revíziótól"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Létező branch frissítése"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Nem"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Csak fast forward"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Checkout létrehozás után"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Válasszunk ki egy követő branchet."
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s ... %*i / %*i %s (%3i%%)"
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "A(z) %s követő branch nem branch a távoli repóban."
 
-#: lib/tools.tcl:75
-#, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "A(z) %s futtatása egy kiválasztott fájlt igényel."
-
-#: lib/tools.tcl:90
-#, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Biztos benne, hogy futtatni kívánja: %s?"
-
-#: lib/tools.tcl:110
-#, tcl-format
-msgid "Tool: %s"
-msgstr "Eszköz: %s"
-
-#: lib/tools.tcl:111
-#, tcl-format
-msgid "Running: %s"
-msgstr "Futtatás: %s..."
-
-#: lib/tools.tcl:149
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Az eszköz sikeresen befejeződött: %s"
-
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "Az eszköz sikertelen: %s"
-
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "Eszköz hozzáadása"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "Új eszköz-parancs hozzáadása"
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr "Globális hozzáadás"
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr "Eszköz részletei"
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "Használjunk '/' szeparátorokat almenü-fa létrehozásához:"
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr "Parancs:"
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr "Parancsablak mutatása futtatás előtt"
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
 msgstr ""
-"Megkéri a felhasználót, hogy válasszon ki egy revíziót (a $REVISION-t "
-"állítja)"
+"Nincs semmi javítanivaló.\n"
+"\n"
+"Az első commit létrehozása előtt nincs semmilyen commit amit javitani "
+"lehetne.\n"
 
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "Megkérdezi a felhasználót további argumentumokért (a $ARGS-ot állítja)"
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Nem lehet javítani merge alatt.\n"
+"\n"
+"A jelenlegi merge még nem teljesen fejeződött be. Csak akkor javíthat egy "
+"előbbi commitot, hogyha megszakítja a jelenlegi merge folyamatot.\n"
 
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr "Ne mutassa a parancs kimeneti ablakát"
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Hiba a javítandó commit adat betöltése közben:"
 
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "Futtatás csak ha egy diff ki van választva (a $FILENAME nem üres)"
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Nem sikerült megállapítani az azonosítót:"
 
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr "Adjunk meg egy eszköz nevet."
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Érvénytelen GIT_COMMITTER_IDENT:"
 
-#: lib/tools_dlg.tcl:129
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "A(z) '%s' eszköz már létezik."
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "figyelmeztetés: a Tcl nem támogatja a(z) '%s' kódolást."
 
-#: lib/tools_dlg.tcl:151
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Az utolsó keresési állapot nem egyezik meg a repó állapotával.\n"
+"\n"
+"Egy másik Git program módosította ezt a repót az utolsó keresés óta. Egy "
+"újrakeresés mindenképpen szükséges mielőtt a jelenlegi branchet módosítani "
+"lehetne.\n"
+"\n"
+"Az újrakeresés most automatikusan el fog indulni.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Nem commitolhatunk fájlokat merge előtt.\n"
+"\n"
+"A(z) %s fájlban ütközések vannak. Egyszer azokat ki kell javítani, majd "
+"hozzá ki kell választani a fájlt mielőtt commitolni lehetne.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Ismeretlen fájl típus %s érzékelve.\n"
+"\n"
+"A(z) %s fájlt nem tudja ez a program commitolni.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Nincs commitolandó változtatás.\n"
+"\n"
+"Legalább egy fájl ki kell választani, hogy commitolni lehessen.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Adjunk megy egy commit üzenetet.\n"
+"\n"
+"Egy jó commit üzenetnek a következő a formátuma:\n"
+"\n"
+"- Első sor: Egy mondatban leírja, hogy mit csináltunk.\n"
+"- Második sor: Üres\n"
+"- A többi sor: Leírja, hogy miért jó ez a változtatás.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "A pre-commit hurok meghívása..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "A commitot megakadályozta a pre-commit hurok. "
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "A commit-msg hurok meghívása..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "A commiot megakadályozta a commit-msg hurok."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "A változtatások commitolása..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "a write-tree sikertelen:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "A commit nem sikerült."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "A(z) %s commit sérültnek tűnik"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Nincs commitolandó változtatás.\n"
+"\n"
+"Egyetlen fájlt se módosított ez a commit és merge commit se volt.\n"
+"\n"
+"Az újrakeresés most automatikusan el fog indulni.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Nincs commitolandó változtatás."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "a commit-tree sikertelen:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "az update-ref sikertelen:"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "Létrejött a %s commit: %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Branch törlése"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Helyi branch törlése"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Helyi branchek"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Csak már merge-ölt törlése"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "A következő branchek nem teljesen lettek merge-ölve ebbe: %s:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
 #, tcl-format
 msgid ""
-"Could not add tool:\n"
+"Failed to delete branches:\n"
 "%s"
 msgstr ""
-"Az eszköz nem hozzáadható:\n"
+"Nem sikerült törölni a következő brancheket:\n"
 "%s"
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
-msgstr "Eszköz eltávolítása"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Nem sikerült az index zárolásának feloldása."
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
-msgstr "Eszköz parancsok eltávolítása"
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Index hiba"
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
-msgstr "Eltávolítás"
-
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
-msgstr "(Kék jelzi a repó-specifikus eszközöket)"
-
-#: lib/tools_dlg.tcl:297
-#, tcl-format
-msgid "Run Command: %s"
-msgstr "Parancs futtatása: %s"
-
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
-msgstr "Argumentumok"
-
-#: lib/tools_dlg.tcl:348
-msgid "OK"
-msgstr "OK"
-
-#: lib/transport.tcl:7
-#, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Új változások letöltése innen: %s"
-
-#: lib/transport.tcl:18
-#, tcl-format
-msgid "remote prune %s"
-msgstr "a(z) %s távoli törlése"
-
-#: lib/transport.tcl:19
-#, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "A %s repóból törölt követő branchek törlése"
-
-#: lib/transport.tcl:26
-#, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Változások pusholása ide: %s"
-
-#: lib/transport.tcl:64
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr "Tükrözés a következő helyre: %s"
-
-#: lib/transport.tcl:82
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Pusholás: %s %s, ide: %s"
-
-#: lib/transport.tcl:100
-msgid "Push Branches"
-msgstr "Branchek pusholása"
-
-#: lib/transport.tcl:114
-msgid "Source Branches"
-msgstr "Forrás branchek"
-
-#: lib/transport.tcl:131
-msgid "Destination Repository"
-msgstr "Cél repó"
-
-#: lib/transport.tcl:169
-msgid "Transfer Options"
-msgstr "Átviteli opciók"
-
-#: lib/transport.tcl:171
-msgid "Force overwrite existing branch (may discard changes)"
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
 msgstr ""
-"Létező branch felülírásának erőltetése (lehet, hogy el fog dobni "
-"változtatásokat)"
+"A Git index frissítése sikertelen volt.  Egy újraolvasás automatikusan "
+"elindult, hogy a git-gui újra szinkonban legyen."
 
-#: lib/transport.tcl:175
-msgid "Use thin pack (for slow network connections)"
-msgstr "Vékony csomagok használata (lassú hálózati kapcsolatok számára)"
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Folytatás"
 
-#: lib/transport.tcl:179
-msgid "Include tags"
-msgstr "Tageket is"
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Index zárolásának feloldása"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "A(z) %s commitba való kiválasztásának visszavonása"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "A(z) %s commitba való kiválasztásának visszavonása"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Commitolásra kész."
+
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "A kiválasztott fájlok visszaállítása"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "A(z) %s hozzáadása..."
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr ""
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Visszaállítja a változtatásokat a(z) %s fájlban?"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Visszaállítja a változtatásokat ebben e %i fájlban?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Minden nem kiválasztott változtatás el fog veszni ezáltal a visszaállítás "
+"által."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Ne csináljunk semmit"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Brancek törlése innen: %s"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Visszaállítja a változtatásokat ebben e %i fájlban?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Törlés"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "A kiválasztott fájlok visszaállítása"
+
+#: lib/index.tcl:532
+#, tcl-format
+msgid "Reverting %s"
+msgstr "%s visszaállítása"
+
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Alapértelmezés"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr "Rendszer (%s)"
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Más"
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Érvénytelen dátum a Git-től: %s"
+
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Ez a leválasztott checkout"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Revízió kifejezés:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Helyi branch"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Követő branch"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Tag"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Érvénytelen revízió: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Nincs kiválasztva revízió."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "A revízió kifejezés üres."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Frissítve"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Elvesztett objektumok száma"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Elveszett objektumok által elfoglalt lemezterület"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Csomagolt objektumok számra"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Csomagok száma"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "A csomagolt objektumok által használt lemezterület"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Eltávolításra váró csomagolt objektumok számra"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Hulladék fájlok"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Adatbázis statisztikák"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Az objektum adatbázis tömörítése"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Az objektum adatbázis ellenőrzése az fsck-objects használatával"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Ennek a repónak jelenleg %i különálló objektuma van.\n"
+"\n"
+"Az optimális teljesítményhez erősen ajánlott az adatbázis tömörítése, ha "
+"több mint %i objektum létezik.\n"
+"\n"
+"Lehet most tömöríteni az adatbázist?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "hiba"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "figyelmeztetés"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "Az eszköz sikertelen: %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Ki kell javítanunk a fenti hibákat commit előtt."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Cannot use funny .git directory:"
+#~ msgstr "Nem használható vicces .git könyvtár:"
+
+#~ msgid "Preferences..."
+#~ msgstr "Beállítások..."
+
+#~ msgid "Always (Do not perform merge test.)"
+#~ msgstr "Mindig (Ne legyen merge teszt.)"
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Nem követett fájl %d bájttal.\n"
+#~ "* Csak az első %d bájt mutatása.\n"
+
+#~ msgid "Case-Sensitive"
+#~ msgstr "Kisbetű-nagybetű számít"
 
 #~ msgid ""
 #~ "Unable to start gitk:\n"

--- a/po/it.po
+++ b/po/it.po
@@ -3,56 +3,57 @@
 # This file is distributed under the same license as the git-gui package.
 # Paolo Ciarrocchi <paolo.ciarrocchi@gmail.com>, 2007
 # Michele Ballabio <barra_cuda@katamail.com>, 2007.
-#
-#
+# 
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-01-26 15:47-0800\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2010-01-28 10:04+0100\n"
 "Last-Translator: Michele Ballabio <barra_cuda@katamail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:41 git-gui.sh:793 git-gui.sh:807 git-gui.sh:820 git-gui.sh:903
-#: git-gui.sh:922
-msgid "git-gui: fatal error"
-msgstr "git-gui: errore grave"
-
-#: git-gui.sh:743
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Caratteri non validi specificati in %s:"
 
-#: git-gui.sh:779
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Caratteri principali"
 
-#: git-gui.sh:780
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Caratteri per confronti e terminale"
 
-#: git-gui.sh:794
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: errore grave"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Impossibile trovare git nel PATH"
 
-#: git-gui.sh:821
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Impossibile determinare la versione di Git:"
 
-#: git-gui.sh:839
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "La versione di Git non può essere determinata.\n"
 "\n"
@@ -62,483 +63,515 @@ msgstr ""
 "\n"
 "Assumere che '%s' sia alla versione 1.5.0?\n"
 
-#: git-gui.sh:1128
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Non trovo la directory di git: "
 
-#: git-gui.sh:1146
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Impossibile spostarsi sulla directory principale del progetto:"
 
-#: git-gui.sh:1154
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Impossibile usare un archivio senza directory di lavoro:"
 
-#: git-gui.sh:1162
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Nessuna directory di lavoro"
 
-#: git-gui.sh:1334 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Controllo dello stato dei file in corso..."
 
-#: git-gui.sh:1390
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Ricerca di file modificati in corso..."
 
-#: git-gui.sh:1454
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "Avvio prepare-commit-msg hook..."
 
-#: git-gui.sh:1471
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "Revisione rifiutata dal prepare-commit-msg hook."
 
-#: git-gui.sh:1629 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Pronto."
 
-#: git-gui.sh:1787
+#: git-gui.sh:1966
 #, tcl-format
-msgid "Displaying only %s of %s files."
-msgstr "Saranno mostrati solo %s file su %s."
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
 
-#: git-gui.sh:1913
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Non modificato"
 
-#: git-gui.sh:1915
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Modificato, non preparato per una nuova revisione"
 
-#: git-gui.sh:1916 git-gui.sh:1924
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Preparato per una nuova revisione"
 
-#: git-gui.sh:1917 git-gui.sh:1925
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Parti preparate per una nuova revisione"
 
-#: git-gui.sh:1918 git-gui.sh:1926
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Preparato per una nuova revisione, mancante"
 
-#: git-gui.sh:1920
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Tipo di file modificato, non preparato per una nuova revisione"
 
-#: git-gui.sh:1921
+#: git-gui.sh:2097 git-gui.sh:2098
+#, fuzzy
+msgid "File type changed, old type staged for commit"
+msgstr "Tipo di file modificato, non preparato per una nuova revisione"
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Tipo di file modificato, preparato per una nuova revisione"
 
-#: git-gui.sh:1923
+#: git-gui.sh:2100
+#, fuzzy
+msgid "File type change staged, modification not staged"
+msgstr "Tipo di file modificato, non preparato per una nuova revisione"
+
+#: git-gui.sh:2101
+#, fuzzy
+msgid "File type change staged, file missing"
+msgstr "Tipo di file modificato, preparato per una nuova revisione"
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Non tracciato, non preparato per una nuova revisione"
 
-#: git-gui.sh:1928
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Mancante"
 
-#: git-gui.sh:1929
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Preparato per la rimozione"
 
-#: git-gui.sh:1930
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Preparato alla rimozione, ancora presente"
 
-#: git-gui.sh:1932 git-gui.sh:1933 git-gui.sh:1934 git-gui.sh:1935
-#: git-gui.sh:1936 git-gui.sh:1937
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Richiede risoluzione dei conflitti"
 
-#: git-gui.sh:1972
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Avvio di gitk... attendere..."
 
-#: git-gui.sh:1984
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Impossibile trovare gitk nel PATH"
 
-#: git-gui.sh:2043
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "Impossibile trovare git gui nel PATH"
 
-#: git-gui.sh:2455 lib/choose_repository.tcl:36
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Archivio"
 
-#: git-gui.sh:2456
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Modifica"
 
-#: git-gui.sh:2458 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Ramo"
 
-#: git-gui.sh:2461 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Revisione"
 
-#: git-gui.sh:2464 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Fusione (Merge)"
 
-#: git-gui.sh:2465 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Remoto"
 
-#: git-gui.sh:2468
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Accessori"
 
-#: git-gui.sh:2477
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Esplora copia di lavoro"
 
-#: git-gui.sh:2483
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Esplora i file del ramo attuale"
 
-#: git-gui.sh:2487
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Esplora i file del ramo..."
 
-#: git-gui.sh:2492
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Visualizza la cronologia del ramo attuale"
 
-#: git-gui.sh:2496
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Visualizza la cronologia di tutti i rami"
 
-#: git-gui.sh:2503
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Esplora i file di %s"
 
-#: git-gui.sh:2505
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Visualizza la cronologia di %s"
 
-#: git-gui.sh:2510 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Statistiche dell'archivio"
 
-#: git-gui.sh:2513 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Comprimi l'archivio"
 
-#: git-gui.sh:2516
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Verifica l'archivio"
 
-#: git-gui.sh:2523 git-gui.sh:2527 git-gui.sh:2531 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Crea icona desktop"
 
-#: git-gui.sh:2539 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Esci"
 
-#: git-gui.sh:2547
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Annulla"
 
-#: git-gui.sh:2550
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Ripeti"
 
-#: git-gui.sh:2554 git-gui.sh:3109
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Taglia"
 
-#: git-gui.sh:2557 git-gui.sh:3112 git-gui.sh:3186 git-gui.sh:3259
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Copia"
 
-#: git-gui.sh:2560 git-gui.sh:3115
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Incolla"
 
-#: git-gui.sh:2563 git-gui.sh:3118 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Elimina"
 
-#: git-gui.sh:2567 git-gui.sh:3122 git-gui.sh:3263 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: git-gui.sh:2576
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Crea..."
 
-#: git-gui.sh:2582
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Attiva..."
 
-#: git-gui.sh:2588
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Rinomina"
 
-#: git-gui.sh:2593
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Elimina..."
 
-#: git-gui.sh:2598
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Ripristina..."
 
-#: git-gui.sh:2608
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Fatto"
 
-#: git-gui.sh:2610
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Nuova revisione"
 
-#: git-gui.sh:2619 git-gui.sh:3050
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Nuova revisione"
 
-#: git-gui.sh:2627 git-gui.sh:3057
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Correggi l'ultima revisione"
 
-#: git-gui.sh:2637 git-gui.sh:3011 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Analizza nuovamente"
 
-#: git-gui.sh:2643
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Prepara per una nuova revisione"
 
-#: git-gui.sh:2649
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Prepara i file modificati per una nuova revisione"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Annulla preparazione"
 
-#: git-gui.sh:2661 lib/index.tcl:412
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Annulla modifiche"
 
-#: git-gui.sh:2669 git-gui.sh:3310 git-gui.sh:3341
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Mostra meno contesto"
 
-#: git-gui.sh:2673 git-gui.sh:3314 git-gui.sh:3345
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Mostra più contesto"
 
-#: git-gui.sh:2680 git-gui.sh:3024 git-gui.sh:3133
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Sign Off"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Fusione locale..."
 
-#: git-gui.sh:2701
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Interrompi fusione..."
 
-#: git-gui.sh:2713 git-gui.sh:2741
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Aggiungi..."
 
-#: git-gui.sh:2717
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Propaga..."
 
-#: git-gui.sh:2721
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Elimina ramo..."
 
-#: git-gui.sh:2731 git-gui.sh:3292
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Opzioni..."
 
-#: git-gui.sh:2742
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Rimuovi..."
 
-#: git-gui.sh:2751 lib/choose_repository.tcl:50
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Aiuto"
 
-#: git-gui.sh:2755 git-gui.sh:2759 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Informazioni su %s"
 
-#: git-gui.sh:2783
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Documentazione sul web"
 
-#: git-gui.sh:2786 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Mostra chave SSH"
 
-#: git-gui.sh:2893
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "errore"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "errore grave: impossibile effettuare lo stat del path %s: file o directory "
 "non trovata"
 
-#: git-gui.sh:2926
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Ramo attuale:"
 
-#: git-gui.sh:2947
-msgid "Staged Changes (Will Commit)"
-msgstr "Modifiche preparate (saranno nella nuova revisione)"
-
-#: git-gui.sh:2967
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Modifiche non preparate"
 
-#: git-gui.sh:3017
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Modifiche preparate (saranno nella nuova revisione)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Prepara modificati"
 
-#: git-gui.sh:3036 lib/transport.tcl:104 lib/transport.tcl:193
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Propaga (Push)"
 
-#: git-gui.sh:3071
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Messaggio di revisione iniziale:"
 
-#: git-gui.sh:3072
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Messaggio di revisione corretto:"
 
-#: git-gui.sh:3073
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Messaggio iniziale di revisione corretto:"
 
-#: git-gui.sh:3074
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Messaggio di fusione corretto:"
 
-#: git-gui.sh:3075
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Messaggio di fusione:"
 
-#: git-gui.sh:3076
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Messaggio di revisione:"
 
-#: git-gui.sh:3125 git-gui.sh:3267 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Copia tutto"
 
-#: git-gui.sh:3149 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "File:"
 
-#: git-gui.sh:3255
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Rinfresca"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Diminuisci dimensione caratteri"
 
-#: git-gui.sh:3280
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Aumenta dimensione caratteri"
 
-#: git-gui.sh:3288 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Codifica"
 
-#: git-gui.sh:3299
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Applica/Inverti sezione"
 
-#: git-gui.sh:3304
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Applica/Inverti riga"
 
-#: git-gui.sh:3323
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Avvia programma esterno per la risoluzione dei conflitti"
 
-#: git-gui.sh:3328
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Usa versione remota"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Usa versione locale"
 
-#: git-gui.sh:3336
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Ritorna alla revisione comune"
 
-#: git-gui.sh:3354
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Visualizza queste modifiche nel sottomodulo"
 
-#: git-gui.sh:3358
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Visualizza la cronologia del ramo attuale nel sottomodulo"
 
-#: git-gui.sh:3362
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Visualizza la cronologia di tutti i rami nel sottomodulo"
 
-#: git-gui.sh:3367
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Avvia git gui nel sottomodulo"
 
-#: git-gui.sh:3389
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Annulla preparazione della sezione per una nuova revisione"
 
-#: git-gui.sh:3391
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Annulla preparazione delle linee per una nuova revisione"
 
-#: git-gui.sh:3393
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Annulla preparazione della linea per una nuova revisione"
 
-#: git-gui.sh:3396
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Prepara sezione per una nuova revisione"
 
-#: git-gui.sh:3398
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Prepara linee per una nuova revisione"
 
-#: git-gui.sh:3400
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Prepara linea per una nuova revisione"
 
-#: git-gui.sh:3424
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Inizializzazione..."
 
-#: git-gui.sh:3541
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Possibili problemi con le variabili d'ambiente.\n"
 "\n"
@@ -547,25 +580,26 @@ msgstr ""
 "da %s:\n"
 "\n"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Ciò è dovuto a un problema conosciuto\n"
 "causato dall'eseguibile Tcl distribuito da Cygwin."
 
-#: git-gui.sh:3575
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -573,315 +607,30 @@ msgstr ""
 "consiste nell'assegnare valori alle variabili di configurazione\n"
 "user.name e user.email nel tuo file ~/.gitconfig personale.\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - un'interfaccia grafica per Git."
-
-#: lib/blame.tcl:72
-msgid "File Viewer"
-msgstr "Mostra file"
-
-#: lib/blame.tcl:78
-msgid "Commit:"
-msgstr "Revisione:"
-
-#: lib/blame.tcl:271
-msgid "Copy Commit"
-msgstr "Copia revisione"
-
-#: lib/blame.tcl:275
-msgid "Find Text..."
-msgstr "Trova testo..."
-
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr "Ricerca accurata delle copie"
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr "Mostra contesto nella cronologia"
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
-msgstr "Annota la revisione precedente"
-
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Lettura di %s..."
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
-msgstr "Caricamento annotazioni per copie/spostamenti..."
-
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr "linee annotate"
-
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr "Caricamento annotazioni per posizione originaria..."
-
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr "Annotazione completata."
-
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr "Occupato"
-
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr "Il processo di annotazione è già in corso."
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr "Ricerca accurata delle copie in corso..."
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr "Caricamento annotazioni..."
-
-#: lib/blame.tcl:963
-msgid "Author:"
-msgstr "Autore:"
-
-#: lib/blame.tcl:967
-msgid "Committer:"
-msgstr "Revisione creata da:"
-
-#: lib/blame.tcl:972
-msgid "Original File:"
-msgstr "File originario:"
-
-#: lib/blame.tcl:1020
-msgid "Cannot find HEAD commit:"
-msgstr "Impossibile trovare la revisione HEAD:"
-
-#: lib/blame.tcl:1075
-msgid "Cannot find parent commit:"
-msgstr "Impossibile trovare la revisione precedente:"
-
-#: lib/blame.tcl:1090
-msgid "Unable to display parent"
-msgstr "Impossibile visualizzare la revisione precedente"
-
-#: lib/blame.tcl:1091 lib/diff.tcl:320
-msgid "Error loading diff:"
-msgstr "Errore nel caricamento delle differenze:"
-
-#: lib/blame.tcl:1231
-msgid "Originally By:"
-msgstr "In origine da:"
-
-#: lib/blame.tcl:1237
-msgid "In File:"
-msgstr "Nel file:"
-
-#: lib/blame.tcl:1242
-msgid "Copied Or Moved Here By:"
-msgstr "Copiato o spostato qui da:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Attiva ramo"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Attiva"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:579 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:108
-msgid "Cancel"
-msgstr "Annulla"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr "Revisione"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr "Opzioni"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Recupera duplicato locale di ramo remoto"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Stacca da ramo locale"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Crea ramo"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Crea nuovo ramo"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:381
-msgid "Create"
-msgstr "Crea"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Nome del ramo"
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr "Nome:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Appaia nome del duplicato locale di ramo remoto"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Revisione iniziale"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Aggiorna ramo esistente:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "No"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Solo fast forward"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr "Ripristina"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Attiva dopo la creazione"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Scegliere un duplicato locale di ramo remoto"
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
-"Il duplicato locale del ramo remoto %s non è un ramo nell'archivio remoto."
 
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Inserire un nome per il ramo."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "'%s' non è utilizzabile come nome di ramo."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Elimina ramo"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Elimina ramo locale"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Rami locali"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Cancella solo se fuso con un altro ramo"
-
-#: lib/branch_delete.tcl:54 lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Sempre (non verificare le fusioni)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "I rami seguenti non sono stati fusi completamente in %s:"
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:217
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
-"Ripristinare rami cancellati è difficile.\n"
-"\n"
-"Cancellare i rami selezionati?"
 
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-"Impossibile cancellare i rami:\n"
-"%s"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Elaborazione in corso... attendere..."
 
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Rinomina ramo"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Chiudi"
 
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Rinomina"
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Successo"
 
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Ramo:"
-
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Nuovo Nome:"
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Scegliere un ramo da rinominare."
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "Il ramo '%s' esiste già."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Impossibile rinominare '%s'."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Avvio in corso..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "File browser"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Caricamento %s..."
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[Directory superiore]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "Esplora i file del ramo"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:398
-#: lib/choose_repository.tcl:486 lib/choose_repository.tcl:497
-#: lib/choose_repository.tcl:1028
-msgid "Browse"
-msgstr "Esplora"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Errore: comando non riuscito"
 
 #: lib/checkout_op.tcl:85
 #, tcl-format
@@ -893,11 +642,6 @@ msgstr "Recupero %s da %s"
 msgid "fatal: Cannot resolve %s"
 msgstr "errore grave: impossibile risolvere %s"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr "Chiudi"
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -907,6 +651,11 @@ msgstr "Il ramo '%s' non esiste."
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Impossibile configurare git-pull semplificato per '%s'."
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "Il ramo '%s' esiste già."
 
 #: lib/checkout_op.tcl:229
 #, tcl-format
@@ -937,13 +686,14 @@ msgstr ""
 "L'area di preparazione per una nuova revisione (indice) è già bloccata."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "L'ultimo stato analizzato non corrisponde allo stato dell'archivio.\n"
 "\n"
@@ -977,9 +727,10 @@ msgid "Staying on branch '%s'."
 msgstr "Si rimarrà sul ramo '%s'."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -1008,18 +759,31 @@ msgstr "Ricomporre le revisioni perdute potrebbe non essere semplice."
 msgid "Reset '%s'?"
 msgstr "Ripristinare '%s'?"
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Visualizza"
 
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Ripristina"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Annulla"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Impossibile preparare il ramo attuale.\n"
@@ -1030,752 +794,220 @@ msgstr ""
 "\n"
 "Questo non sarebbe dovuto succedere.  %s ora terminerà senza altre azioni."
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Seleziona"
-
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Famiglia di caratteri"
-
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Dimensione caratteri"
-
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Esempio caratteri"
-
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
-msgstr ""
-"Questo è un testo d'esempio.\n"
-"Se ti piace questo testo, scegli questo carattere."
-
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
-
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:386
-msgid "Create New Repository"
-msgstr "Crea nuovo archivio"
-
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr "Nuovo..."
-
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:471
-msgid "Clone Existing Repository"
-msgstr "Clona archivio esistente"
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr "Clona..."
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:1016
-msgid "Open Existing Repository"
-msgstr "Apri archivio esistente"
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr "Apri..."
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr "Archivi recenti"
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr "Apri archivio recente:"
-
-#: lib/choose_repository.tcl:306 lib/choose_repository.tcl:313
-#: lib/choose_repository.tcl:320
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
 #, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Impossibile creare l'archivio %s:"
+msgid "fetch %s"
+msgstr "recupera da %s"
 
-#: lib/choose_repository.tcl:391
-msgid "Directory:"
-msgstr "Directory:"
-
-#: lib/choose_repository.tcl:423 lib/choose_repository.tcl:550
-#: lib/choose_repository.tcl:1052
-msgid "Git Repository"
-msgstr "Archivio Git"
-
-#: lib/choose_repository.tcl:448
+#: lib/transport.tcl:7
 #, tcl-format
-msgid "Directory %s already exists."
-msgstr "La directory %s esiste già."
+msgid "Fetching new changes from %s"
+msgstr "Recupero nuove modifiche da %s"
 
-#: lib/choose_repository.tcl:452
+#: lib/transport.tcl:18
 #, tcl-format
-msgid "File %s already exists."
-msgstr "Il file %s esiste già."
+msgid "remote prune %s"
+msgstr "potatura remota di %s"
 
-#: lib/choose_repository.tcl:466
-msgid "Clone"
-msgstr "Clona"
-
-#: lib/choose_repository.tcl:479
-msgid "Source Location:"
-msgstr "Posizione sorgente:"
-
-#: lib/choose_repository.tcl:490
-msgid "Target Directory:"
-msgstr "Directory di destinazione:"
-
-#: lib/choose_repository.tcl:502
-msgid "Clone Type:"
-msgstr "Tipo di clone:"
-
-#: lib/choose_repository.tcl:508
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Standard (veloce, semi-ridondante, con hardlink)"
-
-#: lib/choose_repository.tcl:514
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Copia completa (più lento, backup ridondante)"
-
-#: lib/choose_repository.tcl:520
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Shared (il più veloce, non raccomandato, nessun backup)"
-
-#: lib/choose_repository.tcl:556 lib/choose_repository.tcl:603
-#: lib/choose_repository.tcl:749 lib/choose_repository.tcl:819
-#: lib/choose_repository.tcl:1058 lib/choose_repository.tcl:1066
+#: lib/transport.tcl:19
 #, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "%s non è un archivio Git."
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Effettua potatura dei duplicati locali di rami remoti cancellati da %s"
 
-#: lib/choose_repository.tcl:592
-msgid "Standard only available for local repository."
-msgstr "Standard è disponibile solo per archivi locali."
-
-#: lib/choose_repository.tcl:596
-msgid "Shared only available for local repository."
-msgstr "Shared è disponibile solo per archivi locali."
-
-#: lib/choose_repository.tcl:617
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "Il file/directory %s esiste già."
-
-#: lib/choose_repository.tcl:628
-msgid "Failed to configure origin"
-msgstr "Impossibile configurare origin"
-
-#: lib/choose_repository.tcl:640
-msgid "Counting objects"
-msgstr "Calcolo oggetti"
-
-#: lib/choose_repository.tcl:641
-msgid "buckets"
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
 
-#: lib/choose_repository.tcl:665
+#: lib/transport.tcl:26
+#, fuzzy
+msgid "Fetching new changes from all remotes"
+msgstr "Recupero nuove modifiche da %s"
+
+#: lib/transport.tcl:40
+#, fuzzy
+msgid "remote prune all remotes"
+msgstr "potatura remota di %s"
+
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Effettua potatura dei duplicati locali di rami remoti cancellati da %s"
+
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Impossibile copiare oggetti/info/alternate: %s"
+msgid "push %s"
+msgstr "propaga verso %s"
 
-#: lib/choose_repository.tcl:701
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Niente da clonare da %s."
+msgid "Pushing changes to %s"
+msgstr "Propagazione modifiche a %s"
 
-#: lib/choose_repository.tcl:703 lib/choose_repository.tcl:917
-#: lib/choose_repository.tcl:929
-msgid "The 'master' branch has not been initialized."
-msgstr "Il ramo 'master' non è stato inizializzato."
-
-#: lib/choose_repository.tcl:716
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Impossibile utilizzare gli hardlink. Si ricorrerà alla copia."
-
-#: lib/choose_repository.tcl:728
+#: lib/transport.tcl:93
 #, tcl-format
-msgid "Cloning from %s"
-msgstr "Clonazione da %s"
+msgid "Mirroring to %s"
+msgstr "Mirroring verso %s"
 
-#: lib/choose_repository.tcl:759
-msgid "Copying objects"
-msgstr "Copia degli oggetti"
-
-#: lib/choose_repository.tcl:760
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:784
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Impossibile copiare oggetto: %s"
+msgid "Pushing %s %s to %s"
+msgstr "Propagazione %s %s a %s"
 
-#: lib/choose_repository.tcl:794
-msgid "Linking objects"
-msgstr "Collegamento oggetti"
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Propaga rami"
 
-#: lib/choose_repository.tcl:795
-msgid "objects"
-msgstr "oggetti"
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Rami di origine"
 
-#: lib/choose_repository.tcl:803
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Archivio di destinazione"
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Remoto:"
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Posizione specifica:"
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Opzioni di trasferimento"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr "Sovrascrivi ramo esistente (alcune modifiche potrebbero essere perse)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Utilizza 'thin pack' (per connessioni lente)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Includi etichette"
+
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Hardlink impossibile sull'oggetto: %s"
-
-#: lib/choose_repository.tcl:858
-msgid "Cannot fetch branches and objects.  See console output for details."
+msgid "%s (%s): Push"
 msgstr ""
-"Impossibile recuperare rami e oggetti. Controllare i dettagli forniti dalla "
-"console."
 
-#: lib/choose_repository.tcl:869
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-"Impossibile recuperare le etichette. Controllare i dettagli forniti dalla "
-"console."
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "Aggiungi archivio remoto"
 
-#: lib/choose_repository.tcl:893
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-"Impossibile determinare HEAD. Controllare i dettagli forniti dalla console."
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Aggiungi nuovo archivio remoto"
 
-#: lib/choose_repository.tcl:902
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Aggiungi"
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Dettagli sull'archivio remoto"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Nome:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Posizione:"
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Altra azione"
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Recupera subito"
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Inizializza l'archivio remoto e propaga"
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr "Non fare altro"
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Inserire un nome per l'archivio remoto."
+
+#: lib/remote_add.tcl:113
 #, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Impossibile ripulire %s"
+msgid "'%s' is not an acceptable remote name."
+msgstr "'%s' non è utilizzabile come nome di archivio remoto."
 
-#: lib/choose_repository.tcl:908
-msgid "Clone failed."
-msgstr "Clonazione non riuscita."
-
-#: lib/choose_repository.tcl:915
-msgid "No default branch obtained."
-msgstr "Non è stato trovato un ramo predefinito."
-
-#: lib/choose_repository.tcl:926
+#: lib/remote_add.tcl:124
 #, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Impossibile risolvere %s come una revisione."
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Impossibile aggiungere l'archivio remoto '%s' posto in '%s'."
 
-#: lib/choose_repository.tcl:938
-msgid "Creating working directory"
-msgstr "Creazione directory di lavoro"
-
-#: lib/choose_repository.tcl:939 lib/index.tcl:67 lib/index.tcl:130
-#: lib/index.tcl:198
-msgid "files"
-msgstr "file"
-
-#: lib/choose_repository.tcl:968
-msgid "Initial file checkout failed."
-msgstr "Attivazione iniziale non riuscita."
-
-#: lib/choose_repository.tcl:1011
-msgid "Open"
-msgstr "Apri"
-
-#: lib/choose_repository.tcl:1021
-msgid "Repository:"
-msgstr "Archivio:"
-
-#: lib/choose_repository.tcl:1072
+#: lib/remote_add.tcl:133
 #, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Impossibile accedere all'archivio %s:"
+msgid "Fetching the %s"
+msgstr "Recupero %s"
 
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "Questa revisione attiva staccata"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Espressione di revisione:"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Ramo locale"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Duplicato locale di ramo remoto"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Etichetta"
-
-#: lib/choose_rev.tcl:317
+#: lib/remote_add.tcl:156
 #, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Revisione non valida: %s"
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "Impossibile inizializzare l'archivio posto in '%s'."
 
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Nessuna revisione selezionata."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "L'espressione di revisione è vuota."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Aggiornato"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"Non c'è niente da correggere.\n"
-"\n"
-"Stai per creare la revisione iniziale. Non esiste una revisione precedente "
-"da correggere.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Non è possibile effettuare una correzione durante una fusione.\n"
-"\n"
-"In questo momento si sta effettuando una fusione che non è stata del tutto "
-"completata. Non puoi correggere la revisione precedente a meno che prima tu "
-"non interrompa l'operazione di fusione in corso.\n"
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Errore durante il caricamento dei dati della revisione da correggere:"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Impossibile ottenere la tua identità:"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "GIT_COMMITTER_IDENT non valida:"
-
-#: lib/commit.tcl:129
+#: lib/remote_add.tcl:163
 #, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "attenzione: Tcl non supporta la codifica '%s'."
+msgid "Setting up the %s (at %s)"
+msgstr "Imposto %s (in %s)"
 
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"L'ultimo stato analizzato non corrisponde allo stato dell'archivio.\n"
-"\n"
-"Un altro programma Git ha modificato questo archivio dall'ultima analisi. "
-"Bisogna effettuare una nuova analisi prima di poter creare una nuova "
-"revisione.\n"
-"\n"
-"La nuova analisi comincerà ora.\n"
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Avvio in corso..."
 
-#: lib/commit.tcl:172
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "File browser"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
 #, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"Non è possibile creare una revisione con file non sottoposti a fusione.\n"
-"\n"
-"Il file %s presenta dei conflitti. Devi risolverli e preparare il file per "
-"creare una nuova revisione prima di effettuare questa azione.\n"
-
-#: lib/commit.tcl:180
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Stato di file %s sconosciuto.\n"
-"\n"
-"Questo programma non può creare una revisione contenente il file %s.\n"
-
-#: lib/commit.tcl:188
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Nessuna modifica per la nuova revisione.\n"
-"\n"
-"Devi preparare per una nuova revisione almeno 1 file prima di effettuare "
-"questa operazione.\n"
-
-#: lib/commit.tcl:203
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Bisogna fornire un messaggio di revisione.\n"
-"\n"
-"Un buon messaggio di revisione ha il seguente formato:\n"
-"\n"
-"- Prima linea: descrivi in una frase ciò che hai fatto.\n"
-"- Seconda linea: vuota.\n"
-"- Terza linea: spiega a cosa serve la tua modifica.\n"
-
-#: lib/commit.tcl:234
-msgid "Calling pre-commit hook..."
-msgstr "Avvio pre-commit hook..."
-
-#: lib/commit.tcl:249
-msgid "Commit declined by pre-commit hook."
-msgstr "Revisione rifiutata dal pre-commit hook."
-
-#: lib/commit.tcl:272
-msgid "Calling commit-msg hook..."
-msgstr "Avvio commit-msg hook..."
-
-#: lib/commit.tcl:287
-msgid "Commit declined by commit-msg hook."
-msgstr "Revisione rifiutata dal commit-msg hook."
-
-#: lib/commit.tcl:300
-msgid "Committing changes..."
-msgstr "Archiviazione modifiche..."
-
-#: lib/commit.tcl:316
-msgid "write-tree failed:"
-msgstr "write-tree non riuscito:"
-
-#: lib/commit.tcl:317 lib/commit.tcl:361 lib/commit.tcl:382
-msgid "Commit failed."
-msgstr "Impossibile creare una nuova revisione."
-
-#: lib/commit.tcl:334
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "La revisione %s sembra essere danneggiata"
-
-#: lib/commit.tcl:339
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Nessuna modifica per la nuova revisione.\n"
-"\n"
-"Questa revisione non modifica alcun file e non effettua alcuna fusione.\n"
-"\n"
-"Si procederà subito ad una nuova analisi.\n"
-
-#: lib/commit.tcl:346
-msgid "No changes to commit."
-msgstr "Nessuna modifica per la nuova revisione."
-
-#: lib/commit.tcl:360
-msgid "commit-tree failed:"
-msgstr "commit-tree non riuscito:"
-
-#: lib/commit.tcl:381
-msgid "update-ref failed:"
-msgstr "update-ref non riuscito:"
-
-#: lib/commit.tcl:469
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Creata revisione %s: %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Elaborazione in corso... attendere..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Successo"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Errore: comando non riuscito"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Numero di oggetti slegati"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Spazio su disco utilizzato da oggetti slegati"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Numero di oggetti impacchettati"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Numero di pacchetti"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "Spazio su disco utilizzato da oggetti impacchettati"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Oggetti impacchettati che attendono la potatura"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "File inutili"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Compressione dell'archivio in corso"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Verifica dell'archivio con fsck-objects in corso"
-
-#: lib/database.tcl:107
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Questo archivio attualmente ha circa %i oggetti slegati.\n"
-"\n"
-"Per mantenere buone prestazioni si raccomanda di comprimere l'archivio.\n"
-"\n"
-"Comprimere l'archivio ora?"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Git ha restituito una data non valida: %s"
-
-#: lib/diff.tcl:64
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Non sono state trovate differenze.\n"
-"\n"
-"%s non ha modifiche.\n"
-"\n"
-"La data di modifica di questo file è stata cambiata da un'altra "
-"applicazione, ma il contenuto del file è rimasto invariato.\n"
-"\n"
-"Si procederà automaticamente ad una nuova analisi per trovare altri file che "
-"potrebbero avere lo stesso stato."
-
-#: lib/diff.tcl:104
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Caricamento delle differenze di %s..."
-
-#: lib/diff.tcl:125
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-"LOCALE: cancellato\n"
-"REMOTO:\n"
-
-#: lib/diff.tcl:130
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-"REMOTO: cancellato\n"
-"LOCALE:\n"
-
-#: lib/diff.tcl:137
-msgid "LOCAL:\n"
-msgstr "LOCALE:\n"
-
-#: lib/diff.tcl:140
-msgid "REMOTE:\n"
-msgstr "REMOTO:\n"
-
-#: lib/diff.tcl:202 lib/diff.tcl:319
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Impossibile visualizzare %s"
-
-#: lib/diff.tcl:203
-msgid "Error loading file:"
-msgstr "Errore nel caricamento del file:"
-
-#: lib/diff.tcl:210
-msgid "Git Repository (subproject)"
-msgstr "Archivio Git (sottoprogetto)"
-
-#: lib/diff.tcl:222
-msgid "* Binary file (not showing content)."
-msgstr "* File binario (il contenuto non sarà mostrato)."
-
-#: lib/diff.tcl:227
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* Il file non tracciato è di %d byte.\n"
-"* Saranno visualizzati solo i primi %d byte.\n"
-
-#: lib/diff.tcl:233
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-"\n"
-"* %s non visualizza completamente questo file non tracciato.\n"
-"* Per visualizzare il file completo, usare un programma esterno.\n"
-
-#: lib/diff.tcl:482
-msgid "Failed to unstage selected hunk."
-msgstr "Impossibile rimuovere la sezione scelta dalla nuova revisione."
-
-#: lib/diff.tcl:489
-msgid "Failed to stage selected hunk."
-msgstr "Impossibile preparare la sezione scelta per una nuova revisione."
-
-#: lib/diff.tcl:568
-msgid "Failed to unstage selected line."
-msgstr "Impossibile rimuovere la riga scelta dalla nuova revisione."
-
-#: lib/diff.tcl:576
-msgid "Failed to stage selected line."
-msgstr "Impossibile preparare la riga scelta per una nuova revisione."
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Predefinito"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Codifica di sistema (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Altro"
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "errore"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "attenzione"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr ""
-"Bisogna correggere gli errori suddetti prima di creare una nuova revisione."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Impossibile sbloccare l'accesso all'indice"
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Errore nell'indice"
-
-#: lib/index.tcl:17
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"Impossibile aggiornare l'indice. Ora sarà avviata una nuova analisi che "
-"aggiornerà git-gui."
-
-#: lib/index.tcl:28
-msgid "Continue"
-msgstr "Continua"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Sblocca l'accesso all'indice"
-
-#: lib/index.tcl:289
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "%s non farà parte della prossima revisione"
-
-#: lib/index.tcl:328
-msgid "Ready to commit."
-msgstr "Pronto per creare una nuova revisione."
-
-#: lib/index.tcl:341
-#, tcl-format
-msgid "Adding %s"
-msgstr "Aggiunta di %s in corso"
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Annullare le modifiche nel file %s?"
-
-#: lib/index.tcl:400
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Annullare le modifiche in questi %i file?"
-
-#: lib/index.tcl:408
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Tutte le modifiche non preparate per una nuova revisione saranno perse per "
-"sempre."
-
-#: lib/index.tcl:411
-msgid "Do Nothing"
-msgstr "Non fare niente"
-
-#: lib/index.tcl:429
-msgid "Reverting selected files"
-msgstr "Annullo le modifiche nei file selezionati"
-
-#: lib/index.tcl:433
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Annullo le modifiche in %s"
+msgid "Loading %s..."
+msgstr "Caricamento %s..."
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Directory superiore]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Esplora i file del ramo"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Esplora i file del ramo"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Esplora"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Revisione"
 
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Non posso effettuare fusioni durante una correzione.\n"
 "\n"
@@ -1783,13 +1015,14 @@ msgstr ""
 "qualunque fusione.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "L'ultimo stato analizzato non corrisponde allo stato dell'archivio.\n"
 "\n"
@@ -1799,14 +1032,14 @@ msgstr ""
 "La nuova analisi comincerà ora.\n"
 
 #: lib/merge.tcl:45
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "Sei nel mezzo di una fusione con conflitti.\n"
 "\n"
@@ -1817,14 +1050,14 @@ msgstr ""
 "iniziare un'altra fusione.\n"
 
 #: lib/merge.tcl:55
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "Sei nel mezzo di una modifica.\n"
 "\n"
@@ -1834,49 +1067,57 @@ msgstr ""
 "una fusione. In questo modo sarà più facile interrompere una fusione non "
 "riuscita, nel caso ce ne fosse bisogno.\n"
 
-#: lib/merge.tcl:107
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s di %s"
 
-#: lib/merge.tcl:120
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Fusione di %s e %s in corso..."
 
-#: lib/merge.tcl:131
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "Fusione completata con successo."
 
-#: lib/merge.tcl:133
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "Fusione non riuscita. Bisogna risolvere i conflitti."
 
-#: lib/merge.tcl:158
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Fusione in %s"
 
-#: lib/merge.tcl:177
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Revisione da fondere"
 
-#: lib/merge.tcl:212
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "Interruzione impossibile durante una correzione.\n"
 "\n"
 "Bisogna finire di correggere questa revisione.\n"
 
-#: lib/merge.tcl:222
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Interrompere fusione?\n"
@@ -1886,12 +1127,13 @@ msgstr ""
 "\n"
 "Continuare con l'interruzione della fusione attuale?"
 
-#: lib/merge.tcl:228
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Ripristinare la revisione attuale e annullare le modifiche?\n"
@@ -1901,423 +1143,81 @@ msgstr ""
 "\n"
 "Continuare con l'annullamento delle modifiche attuali?"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Interruzione"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "ripristino file"
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "Interruzione non riuscita."
 
-#: lib/merge.tcl:269
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "Interruzione completata. Pronto."
 
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Imporre la risoluzione alla revisione comune?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Imporre la risoluzione al ramo attuale?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Imporre la risoluzione all'altro ramo?"
-
-#: lib/mergetool.tcl:14
+#: lib/tools.tcl:76
 #, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Si stanno mostrando solo le modifiche con conflitti.\n"
-"\n"
-"%s sarà sovrascritto.\n"
-"\n"
-"Questa operazione può essere modificata solo ricominciando la fusione."
+msgid "Running %s requires a selected file."
+msgstr "Bisogna selezionare un file prima di eseguire %s."
 
-#: lib/mergetool.tcl:45
+#: lib/tools.tcl:92
+#, fuzzy, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Vuoi davvero eseguire %s?"
+
+#: lib/tools.tcl:96
 #, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-"Il file %s sembra contenere conflitti non risolti, preparare per la prossima "
-"revisione?"
+msgid "Are you sure you want to run %s?"
+msgstr "Vuoi davvero eseguire %s?"
 
-#: lib/mergetool.tcl:60
+#: lib/tools.tcl:118
 #, tcl-format
-msgid "Adding resolution for %s"
-msgstr ""
-"La risoluzione dei conflitti per %s è preparata per la prossima revisione"
+msgid "Tool: %s"
+msgstr "Accessorio: %s"
 
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-"Non è possibile risolvere i conflitti per cancellazioni o link con un "
-"programma esterno"
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "Non esiste un file con conflitti."
-
-#: lib/mergetool.tcl:264
+#: lib/tools.tcl:119
 #, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "'%s' non è una GUI per la risoluzione dei conflitti."
+msgid "Running: %s"
+msgstr "Eseguo: %s"
 
-#: lib/mergetool.tcl:268
+#: lib/tools.tcl:158
 #, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "Il programma '%s' non è supportato"
+msgid "Tool completed successfully: %s"
+msgstr "Il programma esterno è terminato con successo: %s"
 
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr "La risoluzione dei conflitti è già avviata, terminarla?"
-
-#: lib/mergetool.tcl:323
+#: lib/tools.tcl:160
 #, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Errore: revisione non trovata:\n"
-"%s"
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-"Impossibile avviare la risoluzione dei conflitti:\n"
-"\n"
-"%s"
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr "Avvio del programma per la risoluzione dei conflitti in corso..."
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr "Risoluzione dei conflitti non riuscita."
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr ""
-"La codifica dei caratteri '%s' specificata per tutti gli archivi non è valida"
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr ""
-"La codifica dei caratteri '%s' specificata per l'archivio attuale  non è "
-"valida"
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr "Ripristina valori predefiniti"
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr "Salva"
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr "Archivio di %s"
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr "Tutti gli archivi"
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr "Nome utente"
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr "Indirizzo Email"
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr "Riepilogo nelle revisioni di fusione"
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr "Prolissità della fusione"
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr "Mostra statistiche delle differenze dopo la fusione"
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr "Programma da utilizzare per la risoluzione dei conflitti"
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr "Fidati delle date di modifica dei file"
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr ""
-"Effettua potatura dei duplicati locali di rami remoti durante il recupero"
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr "Appaia duplicati locali di rami remoti"
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr "Ricerca copie solo nei file modificati"
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr "Numero minimo di lettere che attivano la ricerca delle copie"
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr "Giorni di contesto nella cronologia delle annotazioni"
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr "Numero di linee di contesto nelle differenze"
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr "Larghezza del messaggio di revisione"
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr "Modello per il nome di un nuovo ramo"
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr "Codifica predefinita per il contenuto dei file"
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr "Cambia"
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr "Lingua dizionario:"
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr "Cambia caratteri"
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr "Scegli %s"
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr "pt."
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr "Preferenze"
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr "Impossibile salvare completamente le opzioni:"
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr "Rimuovi archivio remoto"
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr "Effettua potatura da"
-
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr "Recupera da"
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr "Propaga verso"
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
-msgstr "Aggiungi archivio remoto"
-
-#: lib/remote_add.tcl:24
-msgid "Add New Remote"
-msgstr "Aggiungi nuovo archivio remoto"
-
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
-msgid "Add"
-msgstr "Aggiungi"
-
-#: lib/remote_add.tcl:37
-msgid "Remote Details"
-msgstr "Dettagli sull'archivio remoto"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Posizione:"
-
-#: lib/remote_add.tcl:62
-msgid "Further Action"
-msgstr "Altra azione"
-
-#: lib/remote_add.tcl:65
-msgid "Fetch Immediately"
-msgstr "Recupera subito"
-
-#: lib/remote_add.tcl:71
-msgid "Initialize Remote Repository and Push"
-msgstr "Inizializza l'archivio remoto e propaga"
-
-#: lib/remote_add.tcl:77
-msgid "Do Nothing Else Now"
-msgstr "Non fare altro"
-
-#: lib/remote_add.tcl:101
-msgid "Please supply a remote name."
-msgstr "Inserire un nome per l'archivio remoto."
-
-#: lib/remote_add.tcl:114
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "'%s' non è utilizzabile come nome di archivio remoto."
-
-#: lib/remote_add.tcl:125
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Impossibile aggiungere l'archivio remoto '%s' posto in '%s'."
-
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "recupera da %s"
-
-#: lib/remote_add.tcl:134
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "Recupero %s"
-
-#: lib/remote_add.tcl:157
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Impossibile inizializzare l'archivio posto in '%s'."
-
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:63
-#: lib/transport.tcl:81
-#, tcl-format
-msgid "push %s"
-msgstr "propaga verso %s"
-
-#: lib/remote_add.tcl:164
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "Imposto %s (in %s)"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Elimina ramo remoto"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "Da archivio"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:134
-msgid "Remote:"
-msgstr "Remoto:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:149
-msgid "Arbitrary Location:"
-msgstr "Posizione specifica:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Rami"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Elimina solo se"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Fuso in:"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "Si richiede un ramo per 'Fuso in'."
-
-#: lib/remote_branch_delete.tcl:184
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-"I rami seguenti non sono stati fusi completamente in %s:\n"
-"\n"
-" - %s"
-
-#: lib/remote_branch_delete.tcl:189
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-"Impossibile verificare una o più fusioni: mancano le revisioni necessarie. "
-"Prova prima a recuperarle da %s."
-
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Scegliere uno o più rami da cancellare."
-
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Cancellazione rami da %s"
-
-#: lib/remote_branch_delete.tcl:292
-msgid "No repository selected."
-msgstr "Nessun archivio selezionato."
-
-#: lib/remote_branch_delete.tcl:297
-#, tcl-format
-msgid "Scanning %s..."
-msgstr "Analisi in corso %s..."
-
-#: lib/search.tcl:21
-msgid "Find:"
-msgstr "Trova:"
-
-#: lib/search.tcl:23
-msgid "Next"
-msgstr "Succ"
-
-#: lib/search.tcl:24
-msgid "Prev"
-msgstr "Prec"
-
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
-msgstr "Distingui maiuscole"
-
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "Impossibile scrivere shortcut:"
-
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "Impossibile scrivere icona:"
+msgid "Tool failed: %s"
+msgstr "Il programma esterno ha riportato un errore: %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Attiva ramo"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Attiva ramo"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Attiva"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Opzioni"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Recupera duplicato locale di ramo remoto"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Stacca da ramo locale"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -2356,6 +1256,1022 @@ msgstr "Il correttore ortografico ha mandato un EOF inaspettato"
 msgid "Spell Checker Failed"
 msgstr "Errore nel correttore ortografico"
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%1$s ... %6$s: %2$*i di %4$*i (%7$3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Non sono state trovate differenze.\n"
+"\n"
+"%s non ha modifiche.\n"
+"\n"
+"La data di modifica di questo file è stata cambiata da un'altra "
+"applicazione, ma il contenuto del file è rimasto invariato.\n"
+"\n"
+"Si procederà automaticamente ad una nuova analisi per trovare altri file che "
+"potrebbero avere lo stesso stato."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Caricamento delle differenze di %s..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"LOCALE: cancellato\n"
+"REMOTO:\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"REMOTO: cancellato\n"
+"LOCALE:\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "LOCALE:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "REMOTO:\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Impossibile visualizzare %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Errore nel caricamento del file:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Archivio Git (sottoprogetto)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* File binario (il contenuto non sarà mostrato)."
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* %s non visualizza completamente questo file non tracciato.\n"
+"* Per visualizzare il file completo, usare un programma esterno.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Errore nel caricamento delle differenze:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Impossibile rimuovere la sezione scelta dalla nuova revisione."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Impossibile preparare la sezione scelta per una nuova revisione."
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Impossibile rimuovere la riga scelta dalla nuova revisione."
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Impossibile preparare la riga scelta per una nuova revisione."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Propaga verso"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Rimuovi archivio remoto"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Effettua potatura da"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Recupera da"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Seleziona"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Famiglia di caratteri"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Dimensione caratteri"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Esempio caratteri"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Questo è un testo d'esempio.\n"
+"Se ti piace questo testo, scegli questo carattere."
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr ""
+"La codifica dei caratteri '%s' specificata per tutti gli archivi non è valida"
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr ""
+"La codifica dei caratteri '%s' specificata per l'archivio attuale  non è "
+"valida"
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Ripristina valori predefiniti"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Salva"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "Archivio di %s"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Tutti gli archivi"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Nome utente"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Indirizzo Email"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "Riepilogo nelle revisioni di fusione"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Prolissità della fusione"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Mostra statistiche delle differenze dopo la fusione"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr "Programma da utilizzare per la risoluzione dei conflitti"
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "Fidati delle date di modifica dei file"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr ""
+"Effettua potatura dei duplicati locali di rami remoti durante il recupero"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "Appaia duplicati locali di rami remoti"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr "Ricerca copie solo nei file modificati"
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Archivi recenti"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr "Numero minimo di lettere che attivano la ricerca delle copie"
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr "Giorni di contesto nella cronologia delle annotazioni"
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Numero di linee di contesto nelle differenze"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Larghezza del messaggio di revisione"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Modello per il nome di un nuovo ramo"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr "Codifica predefinita per il contenuto dei file"
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr "Cambia"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Lingua dizionario:"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Cambia caratteri"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "Scegli %s"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "pt."
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "Impossibile salvare completamente le opzioni:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Imporre la risoluzione alla revisione comune?"
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Imporre la risoluzione al ramo attuale?"
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Imporre la risoluzione all'altro ramo?"
+
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"Si stanno mostrando solo le modifiche con conflitti.\n"
+"\n"
+"%s sarà sovrascritto.\n"
+"\n"
+"Questa operazione può essere modificata solo ricominciando la fusione."
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+"Il file %s sembra contenere conflitti non risolti, preparare per la prossima "
+"revisione?"
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr ""
+"La risoluzione dei conflitti per %s è preparata per la prossima revisione"
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+"Non è possibile risolvere i conflitti per cancellazioni o link con un "
+"programma esterno"
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "Non esiste un file con conflitti."
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "'%s' non è una GUI per la risoluzione dei conflitti."
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr "Il programma '%s' non è supportato"
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "La risoluzione dei conflitti è già avviata, terminarla?"
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Errore: revisione non trovata:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+"Impossibile avviare la risoluzione dei conflitti:\n"
+"\n"
+"%s"
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "Avvio del programma per la risoluzione dei conflitti in corso..."
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "Risoluzione dei conflitti non riuscita."
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "Aggiungi accessorio"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "Aggiungi un nuovo comando"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "Aggiungi per tutti gli archivi"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "Dettagli sull'accessorio"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "Utilizza il separatore '/' per creare un albero di sottomenu:"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "Comando:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "Mostra una finestra di dialogo prima dell'avvio"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr "Chiedi all'utente di scegliere una revisione (imposta $REVISION)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "Chiedi all'utente di fornire argomenti aggiuntivi (imposta $ARGS)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "Non mostrare la finestra di comando"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "Avvia solo se è selezionata una differenza ($FILENAME non è vuoto)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "Bisogna dare un nome all'accessorio."
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "L'accessorio '%s' esiste già."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+"Impossibile aggiungere l'accessorio:\n"
+"\n"
+"%s"
+
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "Rimuovi accessorio"
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "Rimuovi i comandi accessori"
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "Rimuovi"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(Il colore blu indica accessori per l'archivio locale)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Codifica di sistema (%s)"
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "Avvia il comando: %s"
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "Argomenti"
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "OK"
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Trova:"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Succ"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Prec"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Crea icona desktop"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Impossibile scrivere shortcut:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Impossibile scrivere icona:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Rinomina ramo"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Rinomina ramo"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Rinomina"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Ramo:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Nuovo Nome:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Scegliere un ramo da rinominare."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Inserire un nome per il ramo."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "'%s' non è utilizzabile come nome di ramo."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Impossibile rinominare '%s'."
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Elimina ramo remoto"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Elimina ramo remoto"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Da archivio"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Rami"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Elimina solo se"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Fuso in:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Sempre (non verificare le fusioni)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "Si richiede un ramo per 'Fuso in'."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"I rami seguenti non sono stati fusi completamente in %s:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Impossibile verificare una o più fusioni: mancano le revisioni necessarie. "
+"Prova prima a recuperarle da %s."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Scegliere uno o più rami da cancellare."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Ripristinare rami cancellati è difficile.\n"
+"\n"
+"Cancellare i rami selezionati?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Cancellazione rami da %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Nessun archivio selezionato."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Analisi in corso %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Crea nuovo archivio"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Nuovo..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Clona archivio esistente"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Clona..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Apri archivio esistente"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Apri..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Archivi recenti"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Apri archivio recente:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Impossibile creare l'archivio %s:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Crea"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Directory:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Archivio Git"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "La directory %s esiste già."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Il file %s esiste già."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Clona"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Posizione sorgente:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Directory di destinazione:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Tipo di clone:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Standard (veloce, semi-ridondante, con hardlink)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Copia completa (più lento, backup ridondante)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Shared (il più veloce, non raccomandato, nessun backup)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "%s non è un archivio Git."
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Standard è disponibile solo per archivi locali."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "Shared è disponibile solo per archivi locali."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "Il file/directory %s esiste già."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Impossibile configurare origin"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Calcolo oggetti"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr ""
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Impossibile copiare oggetti/info/alternate: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Niente da clonare da %s."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "Il ramo 'master' non è stato inizializzato."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Impossibile utilizzare gli hardlink. Si ricorrerà alla copia."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Clonazione da %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Copia degli oggetti"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Impossibile copiare oggetto: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Collegamento oggetti"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "oggetti"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Hardlink impossibile sull'oggetto: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Impossibile recuperare rami e oggetti. Controllare i dettagli forniti dalla "
+"console."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+"Impossibile recuperare le etichette. Controllare i dettagli forniti dalla "
+"console."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+"Impossibile determinare HEAD. Controllare i dettagli forniti dalla console."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Impossibile ripulire %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Clonazione non riuscita."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Non è stato trovato un ramo predefinito."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Impossibile risolvere %s come una revisione."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Creazione directory di lavoro"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "file"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Clonazione da %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Attivazione iniziale non riuscita."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Apri"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Archivio:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Impossibile accedere all'archivio %s:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - un'interfaccia grafica per Git."
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Mostra file"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Revisione:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Copia revisione"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Trova testo..."
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Clona..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Ricerca accurata delle copie"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Mostra contesto nella cronologia"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Annota la revisione precedente"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Lettura di %s..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Caricamento annotazioni per copie/spostamenti..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "linee annotate"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Caricamento annotazioni per posizione originaria..."
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Annotazione completata."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Occupato"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "Il processo di annotazione è già in corso."
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Ricerca accurata delle copie in corso..."
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Caricamento annotazioni..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Autore:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Revisione creata da:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "File originario:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Impossibile trovare la revisione HEAD:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Impossibile trovare la revisione precedente:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Impossibile visualizzare la revisione precedente"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "In origine da:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "Nel file:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Copiato o spostato qui da:"
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr "Chiavi non trovate."
@@ -2369,19 +2285,19 @@ msgstr "Chiave pubblica trovata in: %s"
 msgid "Generate Key"
 msgstr "Crea chiave"
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "Copia negli appunti"
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "La tua chiave pubblica OpenSSH"
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Creazione chiave in corso..."
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2392,200 +2308,553 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr "Errore durante la creazione della chiave."
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr "La chiave è stata creata con successo, ma non è stata trovata."
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "La chiave è in: %s"
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Crea ramo"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Crea nuovo ramo"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Nome del ramo"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Appaia nome del duplicato locale di ramo remoto"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Revisione iniziale"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Aggiorna ramo esistente:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "No"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Solo fast forward"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Attiva dopo la creazione"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Scegliere un duplicato locale di ramo remoto"
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%1$s ... %6$s: %2$*i di %4$*i (%7$3i%%)"
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr ""
+"Il duplicato locale del ramo remoto %s non è un ramo nell'archivio remoto."
 
-#: lib/tools.tcl:75
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Non c'è niente da correggere.\n"
+"\n"
+"Stai per creare la revisione iniziale. Non esiste una revisione precedente "
+"da correggere.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Non è possibile effettuare una correzione durante una fusione.\n"
+"\n"
+"In questo momento si sta effettuando una fusione che non è stata del tutto "
+"completata. Non puoi correggere la revisione precedente a meno che prima tu "
+"non interrompa l'operazione di fusione in corso.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Errore durante il caricamento dei dati della revisione da correggere:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Impossibile ottenere la tua identità:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "GIT_COMMITTER_IDENT non valida:"
+
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "Bisogna selezionare un file prima di eseguire %s."
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "attenzione: Tcl non supporta la codifica '%s'."
 
-#: lib/tools.tcl:90
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"L'ultimo stato analizzato non corrisponde allo stato dell'archivio.\n"
+"\n"
+"Un altro programma Git ha modificato questo archivio dall'ultima analisi. "
+"Bisogna effettuare una nuova analisi prima di poter creare una nuova "
+"revisione.\n"
+"\n"
+"La nuova analisi comincerà ora.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Non è possibile creare una revisione con file non sottoposti a fusione.\n"
+"\n"
+"Il file %s presenta dei conflitti. Devi risolverli e preparare il file per "
+"creare una nuova revisione prima di effettuare questa azione.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Stato di file %s sconosciuto.\n"
+"\n"
+"Questo programma non può creare una revisione contenente il file %s.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Nessuna modifica per la nuova revisione.\n"
+"\n"
+"Devi preparare per una nuova revisione almeno 1 file prima di effettuare "
+"questa operazione.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Bisogna fornire un messaggio di revisione.\n"
+"\n"
+"Un buon messaggio di revisione ha il seguente formato:\n"
+"\n"
+"- Prima linea: descrivi in una frase ciò che hai fatto.\n"
+"- Seconda linea: vuota.\n"
+"- Terza linea: spiega a cosa serve la tua modifica.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Avvio pre-commit hook..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Revisione rifiutata dal pre-commit hook."
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Avvio commit-msg hook..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Revisione rifiutata dal commit-msg hook."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Archiviazione modifiche..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "write-tree non riuscito:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Impossibile creare una nuova revisione."
+
+#: lib/commit.tcl:356
 #, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Vuoi davvero eseguire %s?"
+msgid "Commit %s appears to be corrupt"
+msgstr "La revisione %s sembra essere danneggiata"
 
-#: lib/tools.tcl:110
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Nessuna modifica per la nuova revisione.\n"
+"\n"
+"Questa revisione non modifica alcun file e non effettua alcuna fusione.\n"
+"\n"
+"Si procederà subito ad una nuova analisi.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Nessuna modifica per la nuova revisione."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree non riuscito:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref non riuscito:"
+
+#: lib/commit.tcl:508
 #, tcl-format
-msgid "Tool: %s"
-msgstr "Accessorio: %s"
+msgid "Created commit %s: %s"
+msgstr "Creata revisione %s: %s"
 
-#: lib/tools.tcl:111
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Elimina ramo"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Elimina ramo locale"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Rami locali"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Cancella solo se fuso con un altro ramo"
+
+#: lib/branch_delete.tcl:103
 #, tcl-format
-msgid "Running: %s"
-msgstr "Eseguo: %s"
+msgid "The following branches are not completely merged into %s:"
+msgstr "I rami seguenti non sono stati fusi completamente in %s:"
 
-#: lib/tools.tcl:149
+#: lib/branch_delete.tcl:131
 #, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Il programma esterno è terminato con successo: %s"
+msgid " - %s:"
+msgstr ""
 
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "Il programma esterno ha riportato un errore: %s"
-
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "Aggiungi accessorio"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "Aggiungi un nuovo comando"
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr "Aggiungi per tutti gli archivi"
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr "Dettagli sull'accessorio"
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "Utilizza il separatore '/' per creare un albero di sottomenu:"
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr "Comando:"
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr "Mostra una finestra di dialogo prima dell'avvio"
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr "Chiedi all'utente di scegliere una revisione (imposta $REVISION)"
-
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "Chiedi all'utente di fornire argomenti aggiuntivi (imposta $ARGS)"
-
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr "Non mostrare la finestra di comando"
-
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "Avvia solo se è selezionata una differenza ($FILENAME non è vuoto)"
-
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr "Bisogna dare un nome all'accessorio."
-
-#: lib/tools_dlg.tcl:129
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "L'accessorio '%s' esiste già."
-
-#: lib/tools_dlg.tcl:151
+#: lib/branch_delete.tcl:141
 #, tcl-format
 msgid ""
-"Could not add tool:\n"
+"Failed to delete branches:\n"
 "%s"
 msgstr ""
-"Impossibile aggiungere l'accessorio:\n"
-"\n"
+"Impossibile cancellare i rami:\n"
 "%s"
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
-msgstr "Rimuovi accessorio"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Impossibile sbloccare l'accesso all'indice"
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
-msgstr "Rimuovi i comandi accessori"
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Errore nell'indice"
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
-msgstr "Rimuovi"
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Impossibile aggiornare l'indice. Ora sarà avviata una nuova analisi che "
+"aggiornerà git-gui."
 
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
-msgstr "(Il colore blu indica accessori per l'archivio locale)"
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Continua"
 
-#: lib/tools_dlg.tcl:297
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Sblocca l'accesso all'indice"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "%s non farà parte della prossima revisione"
+
+#: lib/index.tcl:298
 #, tcl-format
-msgid "Run Command: %s"
-msgstr "Avvia il comando: %s"
+msgid "Unstaging %s from commit"
+msgstr "%s non farà parte della prossima revisione"
 
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
-msgstr "Argomenti"
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Pronto per creare una nuova revisione."
 
-#: lib/tools_dlg.tcl:348
-msgid "OK"
-msgstr "OK"
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Annullo le modifiche nei file selezionati"
 
-#: lib/transport.tcl:7
+#: lib/index.tcl:350
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Recupero nuove modifiche da %s"
+msgid "Adding %s"
+msgstr "Aggiunta di %s in corso"
 
-#: lib/transport.tcl:18
+#: lib/index.tcl:380
 #, tcl-format
-msgid "remote prune %s"
-msgstr "potatura remota di %s"
+msgid "Stage %d untracked files?"
+msgstr ""
 
-#: lib/transport.tcl:19
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Effettua potatura dei duplicati locali di rami remoti cancellati da %s"
+msgid "Revert changes in file %s?"
+msgstr "Annullare le modifiche nel file %s?"
 
-#: lib/transport.tcl:26
+#: lib/index.tcl:442
 #, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Propagazione modifiche a %s"
+msgid "Revert changes in these %i files?"
+msgstr "Annullare le modifiche in questi %i file?"
 
-#: lib/transport.tcl:64
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Tutte le modifiche non preparate per una nuova revisione saranno perse per "
+"sempre."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Non fare niente"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Cancellazione rami da %s"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Annullare le modifiche in questi %i file?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Elimina"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Annullo le modifiche nei file selezionati"
+
+#: lib/index.tcl:532
 #, tcl-format
-msgid "Mirroring to %s"
-msgstr "Mirroring verso %s"
+msgid "Reverting %s"
+msgstr "Annullo le modifiche in %s"
 
-#: lib/transport.tcl:82
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Predefinito"
+
+#: lib/encoding.tcl:448
 #, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Propagazione %s %s a %s"
+msgid "System (%s)"
+msgstr "Codifica di sistema (%s)"
 
-#: lib/transport.tcl:100
-msgid "Push Branches"
-msgstr "Propaga rami"
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Altro"
 
-#: lib/transport.tcl:114
-msgid "Source Branches"
-msgstr "Rami di origine"
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Git ha restituito una data non valida: %s"
 
-#: lib/transport.tcl:131
-msgid "Destination Repository"
-msgstr "Archivio di destinazione"
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Questa revisione attiva staccata"
 
-#: lib/transport.tcl:169
-msgid "Transfer Options"
-msgstr "Opzioni di trasferimento"
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Espressione di revisione:"
 
-#: lib/transport.tcl:171
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr "Sovrascrivi ramo esistente (alcune modifiche potrebbero essere perse)"
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Ramo locale"
 
-#: lib/transport.tcl:175
-msgid "Use thin pack (for slow network connections)"
-msgstr "Utilizza 'thin pack' (per connessioni lente)"
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Duplicato locale di ramo remoto"
 
-#: lib/transport.tcl:179
-msgid "Include tags"
-msgstr "Includi etichette"
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Etichetta"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Revisione non valida: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Nessuna revisione selezionata."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "L'espressione di revisione è vuota."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Aggiornato"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Numero di oggetti slegati"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Spazio su disco utilizzato da oggetti slegati"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Numero di oggetti impacchettati"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Numero di pacchetti"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Spazio su disco utilizzato da oggetti impacchettati"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Oggetti impacchettati che attendono la potatura"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "File inutili"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Statistiche dell'archivio"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Compressione dell'archivio in corso"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Verifica dell'archivio con fsck-objects in corso"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Questo archivio attualmente ha circa %i oggetti slegati.\n"
+"\n"
+"Per mantenere buone prestazioni si raccomanda di comprimere l'archivio.\n"
+"\n"
+"Comprimere l'archivio ora?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "errore"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "attenzione"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "Il programma esterno ha riportato un errore: %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr ""
+"Bisogna correggere gli errori suddetti prima di creare una nuova revisione."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Displaying only %s of %s files."
+#~ msgstr "Saranno mostrati solo %s file su %s."
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Il file non tracciato è di %d byte.\n"
+#~ "* Saranno visualizzati solo i primi %d byte.\n"
+
+#~ msgid "Case-Sensitive"
+#~ msgstr "Distingui maiuscole"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,15 +1,15 @@
 # Translation of git-gui to Japanese
 # Copyright (C) 2007 Shawn Pearce
 # This file is distributed under the same license as the git-gui package.
-#
+# 
 # しらいし ななこ <nanako3@bluebottle.com>, 2007.
 # Satoshi Yasushima <s.yasushima@gmail.com>, 2016.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-27 17:52+0900\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2016-06-22 12:50+0900\n"
 "Last-Translator: Satoshi Yasushima <s.yasushima@gmail.com>\n"
 "Language-Team: Japanese\n"
@@ -18,42 +18,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:861
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "%s に無効なフォントが指定されています:"
 
-#: git-gui.sh:915
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "主フォント"
 
-#: git-gui.sh:916
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "diff/コンソール・フォント"
 
-#: git-gui.sh:931 git-gui.sh:945 git-gui.sh:958 git-gui.sh:1048 git-gui.sh:1067
-#: git-gui.sh:3125
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
 msgid "git-gui: fatal error"
 msgstr "git-gui: 致命的なエラー"
 
-#: git-gui.sh:932
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "PATH 中に git が見つかりません"
 
-#: git-gui.sh:959
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Git バージョン名が理解できません:"
 
-#: git-gui.sh:984
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Git のバージョンが確認できません。\n"
 "\n"
@@ -63,43 +63,43 @@ msgstr ""
 "\n"
 "'%s' はバージョン 1.5.0 と思って良いですか？\n"
 
-#: git-gui.sh:1281
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Git ディレクトリが見つかりません:"
 
-#: git-gui.sh:1315
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "作業ディレクトリの最上位に移動できません"
 
-#: git-gui.sh:1323
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "裸のリポジトリは使えません:"
 
-#: git-gui.sh:1331
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "作業ディレクトリがありません"
 
-#: git-gui.sh:1503 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "ファイル状態を更新しています…"
 
-#: git-gui.sh:1563
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "変更されたファイルをスキャンしています…"
 
-#: git-gui.sh:1639
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "prepare-commit-msg フックを実行中・・・"
 
-#: git-gui.sh:1656
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "prepare-commit-msg フックがコミットを拒否しました"
 
-#: git-gui.sh:1814 lib/browser.tcl:252
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "準備完了"
 
-#: git-gui.sh:1978
+#: git-gui.sh:1966
 #, tcl-format
 msgid ""
 "Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
@@ -107,841 +107,516 @@ msgstr ""
 "表示可能な限界 (gui.maxfilesdisplayed = %s) に達しため、全体で%s個のファイル"
 "を表示できません"
 
-#: git-gui.sh:2101
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "変更無し"
 
-#: git-gui.sh:2103
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "変更あり、コミット未予定"
 
-#: git-gui.sh:2104 git-gui.sh:2116
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "コミット予定済"
 
-#: git-gui.sh:2105 git-gui.sh:2117
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "部分的にコミット予定済"
 
-#: git-gui.sh:2106 git-gui.sh:2118
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "コミット予定済、ファイル無し"
 
-#: git-gui.sh:2108
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "ファイル型変更、コミット未予定"
 
-#: git-gui.sh:2109 git-gui.sh:2110
+#: git-gui.sh:2097 git-gui.sh:2098
 msgid "File type changed, old type staged for commit"
 msgstr "ファイル型変更、旧型コミット予定済"
 
-#: git-gui.sh:2111
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "ファイル型変更、コミット予定済"
 
-#: git-gui.sh:2112
+#: git-gui.sh:2100
 msgid "File type change staged, modification not staged"
 msgstr "ファイル型変更コミット予定済、変更コミット未予定"
 
-#: git-gui.sh:2113
+#: git-gui.sh:2101
 msgid "File type change staged, file missing"
 msgstr "ファイル型変更コミット予定済、ファイル無し"
 
-#: git-gui.sh:2115
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "管理外、コミット未予定"
 
-#: git-gui.sh:2120
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "ファイル無し"
 
-#: git-gui.sh:2121
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "削除予定済"
 
-#: git-gui.sh:2122
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "削除予定済、ファイル未削除"
 
-#: git-gui.sh:2124 git-gui.sh:2125 git-gui.sh:2126 git-gui.sh:2127
-#: git-gui.sh:2128 git-gui.sh:2129
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "要マージ解決"
 
-#: git-gui.sh:2164
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "gitk を起動中…お待ち下さい…"
 
-#: git-gui.sh:2176
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "PATH 中に gitk が見つかりません"
 
-#: git-gui.sh:2235
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "PATH 中に git gui が見つかりません"
 
-#: git-gui.sh:2654 lib/choose_repository.tcl:41
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "リポジトリ"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "編集"
 
-#: git-gui.sh:2657 lib/choose_rev.tcl:567
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "ブランチ"
 
-#: git-gui.sh:2660 lib/choose_rev.tcl:554
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "コミット"
 
-#: git-gui.sh:2663 lib/merge.tcl:123 lib/merge.tcl:152 lib/merge.tcl:170
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "マージ"
 
-#: git-gui.sh:2664 lib/choose_rev.tcl:563
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "リモート"
 
-#: git-gui.sh:2667
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "ツール"
 
-#: git-gui.sh:2676
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "ワーキングコピーをブラウズ"
 
-#: git-gui.sh:2682
+#: git-gui.sh:2686
 msgid "Git Bash"
 msgstr ""
 
-#: git-gui.sh:2692
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "現在のブランチのファイルを見る"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "ブランチのファイルを見る…"
 
-#: git-gui.sh:2701
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "現在のブランチの履歴を見る"
 
-#: git-gui.sh:2705
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "全てのブランチの履歴を見る"
 
-#: git-gui.sh:2712
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "ブランチ %s のファイルを見る"
 
-#: git-gui.sh:2714
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "ブランチ %s の履歴を見る"
 
-#: git-gui.sh:2719 lib/database.tcl:40 lib/database.tcl:66
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "データベース統計"
 
-#: git-gui.sh:2722 lib/database.tcl:33
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "データベース圧縮"
 
-#: git-gui.sh:2725
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "データベース検証"
 
-#: git-gui.sh:2732 git-gui.sh:2736 git-gui.sh:2740 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "デスクトップ・アイコンを作る"
 
-#: git-gui.sh:2748 lib/choose_repository.tcl:193 lib/choose_repository.tcl:201
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "終了"
 
-#: git-gui.sh:2756
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "元に戻す"
 
-#: git-gui.sh:2759
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "やり直し"
 
-#: git-gui.sh:2763 git-gui.sh:3368
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "切り取り"
 
-#: git-gui.sh:2766 git-gui.sh:3371 git-gui.sh:3445 git-gui.sh:3530
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "コピー"
 
-#: git-gui.sh:2769 git-gui.sh:3374
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "貼り付け"
 
-#: git-gui.sh:2772 git-gui.sh:3377 lib/remote_branch_delete.tcl:39
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
 #: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "削除"
 
-#: git-gui.sh:2776 git-gui.sh:3381 git-gui.sh:3534 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "全て選択"
 
-#: git-gui.sh:2785
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "作成…"
 
-#: git-gui.sh:2791
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "チェックアウト"
 
-#: git-gui.sh:2797
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "名前変更…"
 
-#: git-gui.sh:2802
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "削除…"
 
-#: git-gui.sh:2807
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "リセット…"
 
-#: git-gui.sh:2817
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "完了"
 
-#: git-gui.sh:2819
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "コミット"
 
-#: git-gui.sh:2828 git-gui.sh:3309
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "新規コミット"
 
-#: git-gui.sh:2836 git-gui.sh:3316
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "最新コミットを訂正"
 
-#: git-gui.sh:2846 git-gui.sh:3270 lib/remote_branch_delete.tcl:101
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "再スキャン"
 
-#: git-gui.sh:2852
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "コミット予定する"
 
-#: git-gui.sh:2858
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "変更されたファイルをコミット予定"
 
-#: git-gui.sh:2864
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "コミットから降ろす"
 
-#: git-gui.sh:2870 lib/index.tcl:442
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "変更を元に戻す"
 
-#: git-gui.sh:2878 git-gui.sh:3581 git-gui.sh:3612
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "文脈を少なく"
 
-#: git-gui.sh:2882 git-gui.sh:3585 git-gui.sh:3616
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "文脈を多く"
 
-#: git-gui.sh:2889 git-gui.sh:3283 git-gui.sh:3392
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "署名"
 
-#: git-gui.sh:2905
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "ローカル・マージ…"
 
-#: git-gui.sh:2910
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "マージ中止…"
 
-#: git-gui.sh:2922 git-gui.sh:2950
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "追加"
 
-#: git-gui.sh:2926
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "プッシュ…"
 
-#: git-gui.sh:2930
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "ブランチ削除..."
 
-#: git-gui.sh:2940 git-gui.sh:3563
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "オプション…"
 
-#: git-gui.sh:2951
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "削除..."
 
-#: git-gui.sh:2960 lib/choose_repository.tcl:55
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "ヘルプ"
 
-#: git-gui.sh:2964 git-gui.sh:2968 lib/about.tcl:14
-#: lib/choose_repository.tcl:49 lib/choose_repository.tcl:58
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "%s について"
 
-#: git-gui.sh:2992
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "オンライン・ドキュメント"
 
-#: git-gui.sh:2995 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "SSH キーを表示"
 
 #: git-gui.sh:3014 git-gui.sh:3146
+#, fuzzy
+msgid "usage:"
+msgstr "使い方"
+
+#: git-gui.sh:3018 git-gui.sh:3150
 msgid "Usage"
 msgstr "使い方"
 
-#: git-gui.sh:3095 lib/blame.tcl:573
+#: git-gui.sh:3099 lib/blame.tcl:573
 msgid "Error"
 msgstr "エラー"
 
-#: git-gui.sh:3126
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "致命的: パス %s が stat できません。そのようなファイルやディレクトリはありま"
 "せん"
 
-#: git-gui.sh:3159
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "現在のブランチ"
 
-#: git-gui.sh:3185
-msgid "Staged Changes (Will Commit)"
-msgstr "ステージングされた（コミット予定済の）変更"
-
-#: git-gui.sh:3205
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "コミット予定に入っていない変更"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "ステージングされた（コミット予定済の）変更"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "変更をコミット予定に入れる"
 
-#: git-gui.sh:3295 lib/transport.tcl:137 lib/transport.tcl:229
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "プッシュ"
 
-#: git-gui.sh:3330
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "最初のコミットメッセージ:"
 
-#: git-gui.sh:3331
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "訂正したコミットメッセージ:"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "訂正した最初のコミットメッセージ:"
 
-#: git-gui.sh:3333
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "訂正したマージコミットメッセージ:"
 
-#: git-gui.sh:3334
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "マージコミットメッセージ:"
 
-#: git-gui.sh:3335
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "コミットメッセージ:"
 
-#: git-gui.sh:3384 git-gui.sh:3538 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "全てコピー"
 
-#: git-gui.sh:3408 lib/blame.tcl:105
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "ファイル:"
 
-#: git-gui.sh:3526
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "再読み込み"
 
-#: git-gui.sh:3547
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "フォントを小さく"
 
-#: git-gui.sh:3551
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "フォントを大きく"
 
-#: git-gui.sh:3559 lib/blame.tcl:294
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "エンコーディング"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "パッチを適用/取り消す"
 
-#: git-gui.sh:3575
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "パッチ行を適用/取り消す"
 
-#: git-gui.sh:3594
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "マージツールを起動"
 
-#: git-gui.sh:3599
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "リモートの方を採用"
 
-#: git-gui.sh:3603
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "ローカルの方を採用"
 
-#: git-gui.sh:3607
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "ベース版を採用"
 
-#: git-gui.sh:3625
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "サブモジュール内のこれらの変更を見る"
 
-#: git-gui.sh:3629
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "サブモジュール内で現在のブランチの履歴を見る"
 
-#: git-gui.sh:3633
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "サブモジュール内で全てのブランチの履歴を見る"
 
-#: git-gui.sh:3638
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "サブモジュール内でgit guiを起動する"
 
-#: git-gui.sh:3673
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "パッチをコミット予定から外す"
 
-#: git-gui.sh:3675
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "コミット予定から行を外す"
 
-#: git-gui.sh:3677
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "コミット予定から行を外す"
 
-#: git-gui.sh:3680
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "パッチをコミット予定に加える"
 
-#: git-gui.sh:3682
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "パッチ行をコミット予定に加える"
 
-#: git-gui.sh:3684
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "パッチ行をコミット予定に加える"
 
-#: git-gui.sh:3709
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "初期化しています…"
 
-#: git-gui.sh:3852
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "環境に問題がある可能性があります\n"
 "\n"
 "以下の環境変数は %s が起動する Git サブプロセスによって無視されるでしょう:\n"
 "\n"
 
-#: git-gui.sh:3881
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "これは Cygwin で配布されている Tcl バイナリに\n"
 "関しての既知の問題によります"
 
-#: git-gui.sh:3886
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
 "個人的な ~/.gitconfig ファイル内で user.name と user.email の値を設定\n"
 "するのが、%s の良い代用となります\n"
 
-#: lib/merge.tcl:13
-msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
-msgstr ""
-"訂正中にはマージできません。\n"
-"\n"
-"訂正処理を完了するまでは新たにマージを開始できません。\n"
+#: lib/line.tcl:17
+msgid "Goto Line:"
+msgstr "行番号"
 
-#: lib/merge.tcl:27
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"最後にスキャンした状態はリポジトリの状態と合致しません。\n"
-"\n"
-"最後にスキャンして以後、別の Git プログラムがリポジトリを変更しています。マー"
-"ジを開始する前に、再スキャンが必要です。\n"
-"\n"
-"自動的に再スキャンを開始します。\n"
-
-#: lib/merge.tcl:45
-#, tcl-format
-msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
-"You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
-msgstr ""
-"衝突のあったマージの途中です。\n"
-"\n"
-"ファイル %s にはマージ中の衝突が残っています。\n"
-"\n"
-"このファイルの衝突を解決し、コミット予定に加えて、コミットすることでマージを"
-"完了します。そうやって始めて、新たなマージを開始できるようになります。\n"
-
-#: lib/merge.tcl:55
-#, tcl-format
-msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
-"You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
-msgstr ""
-"変更の途中です。\n"
-"\n"
-"ファイル %s は変更中です。\n"
-"\n"
-"現在のコミットを完了してからマージを開始して下さい。そうする方がマージに失敗"
-"したときの回復が楽です。\n"
-
-#: lib/merge.tcl:108
-#, tcl-format
-msgid "%s of %s"
-msgstr "%s の %s ブランチ"
-
-#: lib/merge.tcl:122
-#, tcl-format
-msgid "Merging %s and %s..."
-msgstr "%s と %s をマージ中・・・"
-
-#: lib/merge.tcl:133
-msgid "Merge completed successfully."
-msgstr "マージが完了しました"
-
-#: lib/merge.tcl:135
-msgid "Merge failed.  Conflict resolution is required."
-msgstr "マージが失敗しました。衝突の解決が必要です。"
-
-#: lib/merge.tcl:160
-#, tcl-format
-msgid "Merge Into %s"
-msgstr "%s にマージ"
-
-#: lib/merge.tcl:166 lib/checkout_op.tcl:567 lib/tools_dlg.tcl:336
-msgid "Visualize"
-msgstr "可視化"
-
-#: lib/merge.tcl:174 lib/remote_branch_delete.tcl:43 lib/branch_delete.tcl:34
-#: lib/checkout_op.tcl:579 lib/branch_rename.tcl:32 lib/tools_dlg.tcl:41
-#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/option.tcl:127
-#: lib/transport.tcl:141 lib/choose_font.tcl:45 lib/branch_checkout.tcl:30
-#: lib/browser.tcl:292 lib/remote_add.tcl:34 lib/branch_create.tcl:37
-msgid "Cancel"
-msgstr "中止"
-
-#: lib/merge.tcl:179
-msgid "Revision To Merge"
-msgstr "マージするリビジョン"
-
-#: lib/merge.tcl:214
-msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
-msgstr ""
-"訂正中には中止できません。\n"
-"\n"
-"まず今のコミット訂正を完了させて下さい。\n"
-
-#: lib/merge.tcl:224
-msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with aborting the current merge?"
-msgstr ""
-"マージを中断しますか？\n"
-"\n"
-"現在のマージを中断すると、コミットしていない全ての変更が失われます。\n"
-"\n"
-"マージを中断してよろしいですか？"
-
-#: lib/merge.tcl:230
-msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with resetting the current changes?"
-msgstr ""
-"変更点をリセットしますか？\n"
-"\n"
-"変更点をリセットすると、コミットしていない全ての変更が失われます。\n"
-"\n"
-"リセットしてよろしいですか？"
-
-#: lib/merge.tcl:241
-msgid "Aborting"
-msgstr "中断しています"
-
-#: lib/merge.tcl:241
-msgid "files reset"
-msgstr "リセットしたファイル"
-
-#: lib/merge.tcl:269
-msgid "Abort failed."
-msgstr "中断に失敗しました。"
-
-#: lib/merge.tcl:271
-msgid "Abort completed.  Ready."
-msgstr "中断完了。"
-
-#: lib/error.tcl:20 lib/error.tcl:116
-msgid "error"
-msgstr "エラー"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "警告"
-
-#: lib/error.tcl:96
-msgid "You must correct the above errors before committing."
-msgstr "コミットする前に、以上のエラーを修正して下さい"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Git から出た無効な日付: %s"
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "デフォールト"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "システム (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "その他"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "リモートブランチ削除"
-
-#: lib/remote_branch_delete.tcl:48
-msgid "From Repository"
-msgstr "元のリポジトリ"
-
-#: lib/remote_branch_delete.tcl:51 lib/transport.tcl:165
-msgid "Remote:"
-msgstr "リモート:"
-
-#: lib/remote_branch_delete.tcl:72 lib/transport.tcl:187
-msgid "Arbitrary Location:"
-msgstr "任意の位置:"
-
-#: lib/remote_branch_delete.tcl:88
-msgid "Branches"
-msgstr "ブランチ"
-
-#: lib/remote_branch_delete.tcl:110
-msgid "Delete Only If"
-msgstr "条件付で削除"
-
-#: lib/remote_branch_delete.tcl:112
-msgid "Merged Into:"
-msgstr "マージ先:"
-
-#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
-msgid "Always (Do not perform merge checks)"
-msgstr "無条件（マージ検査をしない）"
-
-#: lib/remote_branch_delete.tcl:153
-msgid "A branch is required for 'Merged Into'."
-msgstr "'マージ先' にはブランチが必要です。"
-
-#: lib/remote_branch_delete.tcl:185
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-"以下のブランチは %s に完全にマージされていません:\n"
-"\n"
-" - %s"
-
-#: lib/remote_branch_delete.tcl:190
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-"必要なコミットが不足しているために、マージ検査が失敗しました。まず %s から"
-"フェッチして下さい。"
-
-#: lib/remote_branch_delete.tcl:208
-msgid "Please select one or more branches to delete."
-msgstr "削除するブランチを選択して下さい。"
-
-#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr ""
-"削除したブランチを回復するのは困難です。\n"
-"\n"
-"選択したブランチを削除して良いですか？"
-
-#: lib/remote_branch_delete.tcl:227
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "%s からブランチを削除しています。"
-
-#: lib/remote_branch_delete.tcl:300
-msgid "No repository selected."
-msgstr "リポジトリが選択されていません。"
-
-#: lib/remote_branch_delete.tcl:305
-#, tcl-format
-msgid "Scanning %s..."
-msgstr "%s をスキャンしています…"
-
-#: lib/branch_delete.tcl:16
-msgid "Delete Branch"
-msgstr "ブランチ削除"
-
-#: lib/branch_delete.tcl:21
-msgid "Delete Local Branch"
-msgstr "ローカル・ブランチを削除"
-
-#: lib/branch_delete.tcl:39
-msgid "Local Branches"
-msgstr "ローカル・ブランチ"
-
-#: lib/branch_delete.tcl:51
-msgid "Delete Only If Merged Into"
-msgstr "マージ済みの時のみ削除"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "以下のブランチは %s に完全にマージされていません:"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-"以下のブランチを削除できません:\n"
-"%s"
-
-#: lib/choose_rev.tcl:52
-msgid "This Detached Checkout"
-msgstr "分離されたチェックアウト"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "リビジョン式:"
-
-#: lib/choose_rev.tcl:72
-msgid "Local Branch"
-msgstr "ローカル・ブランチ"
-
-#: lib/choose_rev.tcl:77
-msgid "Tracking Branch"
-msgstr "トラッキング・ブランチ"
-
-#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
-msgid "Tag"
-msgstr "タグ"
-
-#: lib/choose_rev.tcl:321
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "無効なリビジョン: %s"
-
-#: lib/choose_rev.tcl:342
-msgid "No revision selected."
-msgstr "リビジョンが未選択です。"
-
-#: lib/choose_rev.tcl:350
-msgid "Revision expression is empty."
-msgstr "リビジョン式が空です。"
-
-#: lib/choose_rev.tcl:537
-msgid "Updated"
-msgstr "更新しました"
-
-#: lib/choose_rev.tcl:565
-msgid "URL"
-msgstr "URL"
+#: lib/line.tcl:23
+msgid "Go"
+msgstr "移動"
 
 #: lib/console.tcl:59
 msgid "Working... please wait..."
 msgstr "実行中…お待ち下さい…"
 
-#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/database.tcl:30
-#: lib/sshkey.tcl:55
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
 msgid "Close"
 msgstr "閉じる"
 
@@ -1006,13 +681,14 @@ msgid "Staging area (index) is already locked."
 msgstr "インデックスは既にロックされています。"
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "最後にスキャンした状態はリポジトリの状態と合致しません。\n"
 "\n"
@@ -1045,9 +721,10 @@ msgid "Staying on branch '%s'."
 msgstr "ブランチ '%s' に滞まります。"
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -1075,18 +752,31 @@ msgstr "失なわれたコミットを回復するのは簡単ではありませ
 msgid "Reset '%s'?"
 msgstr "'%s' をリセットしますか？"
 
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
+msgid "Visualize"
+msgstr "可視化"
+
 #: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
 msgid "Reset"
 msgstr "リセット"
 
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "中止"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "現在のブランチを設定できません。\n"
@@ -1095,660 +785,612 @@ msgstr ""
 "ましたが、 Git の内部データを更新できませんでした。\n"
 "起こるはずのないエラーです。あきらめて %s を終了します。"
 
-#: lib/blame.tcl:73
-msgid "File Viewer"
-msgstr "ファイルピューワ"
-
-#: lib/blame.tcl:79
-msgid "Commit:"
-msgstr "コミット:"
-
-#: lib/blame.tcl:280
-msgid "Copy Commit"
-msgstr "コミットをコピー"
-
-#: lib/blame.tcl:284
-msgid "Find Text..."
-msgstr "テキストを検索"
-
-#: lib/blame.tcl:288
-msgid "Goto Line..."
-msgstr "指定行に移動…"
-
-#: lib/blame.tcl:297
-msgid "Do Full Copy Detection"
-msgstr "コピー検知"
-
-#: lib/blame.tcl:301
-msgid "Show History Context"
-msgstr "文脈を見せる"
-
-#: lib/blame.tcl:304
-msgid "Blame Parent Commit"
-msgstr "親コミットを注釈"
-
-#: lib/blame.tcl:466
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
 #, tcl-format
-msgid "Reading %s..."
-msgstr "%s を読んでいます…"
+msgid "fetch %s"
+msgstr "%s を取得"
 
-#: lib/blame.tcl:594
-msgid "Loading copy/move tracking annotations..."
-msgstr "コピー・移動追跡データを読んでいます…"
-
-#: lib/blame.tcl:614
-msgid "lines annotated"
-msgstr "行を注釈しました"
-
-#: lib/blame.tcl:806
-msgid "Loading original location annotations..."
-msgstr "元位置行の注釈データを読んでいます…"
-
-#: lib/blame.tcl:809
-msgid "Annotation complete."
-msgstr "注釈完了しました"
-
-#: lib/blame.tcl:839
-msgid "Busy"
-msgstr "実行中"
-
-#: lib/blame.tcl:840
-msgid "Annotation process is already running."
-msgstr "すでに blame プロセスを実行中です。"
-
-#: lib/blame.tcl:879
-msgid "Running thorough copy detection..."
-msgstr "コピー検知を実行中…"
-
-#: lib/blame.tcl:947
-msgid "Loading annotation..."
-msgstr "注釈を読み込んでいます…"
-
-#: lib/blame.tcl:1000
-msgid "Author:"
-msgstr "作者:"
-
-#: lib/blame.tcl:1004
-msgid "Committer:"
-msgstr "コミット者:"
-
-#: lib/blame.tcl:1009
-msgid "Original File:"
-msgstr "元ファイル"
-
-#: lib/blame.tcl:1057
-msgid "Cannot find HEAD commit:"
-msgstr "HEAD コミットが見つかりません"
-
-#: lib/blame.tcl:1112
-msgid "Cannot find parent commit:"
-msgstr "親コミットが見つかりません:"
-
-#: lib/blame.tcl:1127
-msgid "Unable to display parent"
-msgstr "親を表示できません"
-
-#: lib/blame.tcl:1128 lib/diff.tcl:356
-msgid "Error loading diff:"
-msgstr "diff を読む際のエラーです:"
-
-#: lib/blame.tcl:1269
-msgid "Originally By:"
-msgstr "原作者:"
-
-#: lib/blame.tcl:1275
-msgid "In File:"
-msgstr "ファイル:"
-
-#: lib/blame.tcl:1280
-msgid "Copied Or Moved Here By:"
-msgstr "複写・移動者:"
-
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "Git のグラフィカルUI git-gui"
-
-#: lib/choose_repository.tcl:33
-msgid "Git Gui"
-msgstr "Git GUI"
-
-#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:412
-msgid "Create New Repository"
-msgstr "新しいリポジトリを作る"
-
-#: lib/choose_repository.tcl:98
-msgid "New..."
-msgstr "新規…"
-
-#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:496
-msgid "Clone Existing Repository"
-msgstr "既存リポジトリを複製する"
-
-#: lib/choose_repository.tcl:116
-msgid "Clone..."
-msgstr "複製…"
-
-#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1064
-msgid "Open Existing Repository"
-msgstr "既存リポジトリを開く"
-
-#: lib/choose_repository.tcl:129
-msgid "Open..."
-msgstr "開く…"
-
-#: lib/choose_repository.tcl:142
-msgid "Recent Repositories"
-msgstr "最近使ったリポジトリ"
-
-#: lib/choose_repository.tcl:148
-msgid "Open Recent Repository:"
-msgstr "最近使ったリポジトリを開く"
-
-#: lib/choose_repository.tcl:316 lib/choose_repository.tcl:323
-#: lib/choose_repository.tcl:330
+#: lib/transport.tcl:7
 #, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "リポジトリ %s を作製できません:"
+msgid "Fetching new changes from %s"
+msgstr "%s から新しい変更をフェッチしています"
 
-#: lib/choose_repository.tcl:407 lib/branch_create.tcl:33
-msgid "Create"
-msgstr "作成"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "リモート刈込 %s"
 
-#: lib/choose_repository.tcl:417
-msgid "Directory:"
-msgstr "ディレクトリ:"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "%s から削除されたトラッキング・ブランチを刈っています"
 
-#: lib/choose_repository.tcl:422 lib/choose_repository.tcl:509
-#: lib/choose_repository.tcl:518 lib/choose_repository.tcl:1074
-#: lib/browser.tcl:288
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
+msgstr "すべてのリモートを取得"
+
+#: lib/transport.tcl:26
+msgid "Fetching new changes from all remotes"
+msgstr "すべてのリモートから新しい変更をフェッチしています"
+
+#: lib/transport.tcl:40
+msgid "remote prune all remotes"
+msgstr "リモート刈込 すべてのリモート"
+
+#: lib/transport.tcl:41
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "すべてのリモートから削除されたトラッキング・ブランチを刈っています"
+
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
+#, tcl-format
+msgid "push %s"
+msgstr "%s をプッシュ"
+
+#: lib/transport.tcl:55
+#, tcl-format
+msgid "Pushing changes to %s"
+msgstr "%s へ変更をプッシュしています"
+
+#: lib/transport.tcl:93
+#, tcl-format
+msgid "Mirroring to %s"
+msgstr "%s へミラーしています"
+
+#: lib/transport.tcl:111
+#, tcl-format
+msgid "Pushing %s %s to %s"
+msgstr "%3$s へ %1$s %2$s をプッシュしています"
+
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "ブランチをプッシュ"
+
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "元のブランチ"
+
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "送り先リポジトリ"
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "リモート:"
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "任意の位置:"
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "通信オプション"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr "既存ブランチを上書き(変更を破棄する可能性があります)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Thin Pack を使う（遅いネットワーク接続）"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "タグを含める"
+
+#: lib/transport.tcl:229
+#, tcl-format
+msgid "%s (%s): Push"
+msgstr ""
+
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "リモートを追加"
+
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "リモートを新規に追加"
+
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "追加"
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "リモートの詳細"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "名前:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "場所:"
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "その他の動作"
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "即座に取得"
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "リモートレポジトリを初期化してプッシュ"
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr "何もしない"
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "リモート名を指定して下さい。"
+
+#: lib/remote_add.tcl:113
+#, tcl-format
+msgid "'%s' is not an acceptable remote name."
+msgstr "'%s' はリモート名に使えません。"
+
+#: lib/remote_add.tcl:124
+#, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "場所 '%2$s' のリモート '%1$s'の名前変更に失敗しました。"
+
+#: lib/remote_add.tcl:133
+#, tcl-format
+msgid "Fetching the %s"
+msgstr "%s からフェッチしています"
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "リポジトリ '%s' を初期化できません。"
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr "%2$s にある %1$s をセットアップします"
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "起動中…"
+
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "ファイル・ブラウザ"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr "%s をロード中…"
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[上位フォルダへ]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "現在のブランチのファイルを見る"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "現在のブランチのファイルを見る"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
 msgid "Browse"
 msgstr "ブラウズ"
 
-#: lib/choose_repository.tcl:447 lib/choose_repository.tcl:573
-#: lib/choose_repository.tcl:1098
-msgid "Git Repository"
-msgstr "GIT リポジトリ"
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "リビジョン"
 
-#: lib/choose_repository.tcl:472
+#: lib/merge.tcl:13
+#, fuzzy
+msgid ""
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
+msgstr ""
+"訂正中にはマージできません。\n"
+"\n"
+"訂正処理を完了するまでは新たにマージを開始できません。\n"
+
+#: lib/merge.tcl:27
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"最後にスキャンした状態はリポジトリの状態と合致しません。\n"
+"\n"
+"最後にスキャンして以後、別の Git プログラムがリポジトリを変更しています。マー"
+"ジを開始する前に、再スキャンが必要です。\n"
+"\n"
+"自動的に再スキャンを開始します。\n"
+
+#: lib/merge.tcl:45
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
+"You must resolve them, stage the file, and commit to complete the current "
+"merge.  Only then can you begin another merge.\r\n"
+msgstr ""
+"衝突のあったマージの途中です。\n"
+"\n"
+"ファイル %s にはマージ中の衝突が残っています。\n"
+"\n"
+"このファイルの衝突を解決し、コミット予定に加えて、コミットすることでマージを"
+"完了します。そうやって始めて、新たなマージを開始できるようになります。\n"
+
+#: lib/merge.tcl:55
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
+"You should complete the current commit before starting a merge.  Doing so "
+"will help you abort a failed merge, should the need arise.\r\n"
+msgstr ""
+"変更の途中です。\n"
+"\n"
+"ファイル %s は変更中です。\n"
+"\n"
+"現在のコミットを完了してからマージを開始して下さい。そうする方がマージに失敗"
+"したときの回復が楽です。\n"
+
+#: lib/merge.tcl:108
 #, tcl-format
-msgid "Directory %s already exists."
-msgstr "ディレクトリ '%s' は既に存在します。"
+msgid "%s of %s"
+msgstr "%s の %s ブランチ"
 
-#: lib/choose_repository.tcl:476
+#: lib/merge.tcl:126
 #, tcl-format
-msgid "File %s already exists."
-msgstr "ファイル '%s' は既に存在します。"
+msgid "Merging %s and %s..."
+msgstr "%s と %s をマージ中・・・"
 
-#: lib/choose_repository.tcl:491
-msgid "Clone"
-msgstr "複製"
+#: lib/merge.tcl:137
+msgid "Merge completed successfully."
+msgstr "マージが完了しました"
 
-#: lib/choose_repository.tcl:504
-msgid "Source Location:"
-msgstr "ソースの位置"
+#: lib/merge.tcl:139
+msgid "Merge failed.  Conflict resolution is required."
+msgstr "マージが失敗しました。衝突の解決が必要です。"
 
-#: lib/choose_repository.tcl:513
-msgid "Target Directory:"
-msgstr "先ディレクトリ:"
-
-#: lib/choose_repository.tcl:523
-msgid "Clone Type:"
-msgstr "複製方式:"
-
-#: lib/choose_repository.tcl:528
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "標準(高速・中冗長度・ハードリンク)"
-
-#: lib/choose_repository.tcl:533
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "全複写(低速・冗長バックアップ)"
-
-#: lib/choose_repository.tcl:538
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "共有(最高速・非推奨・バックアップ無し)"
-
-#: lib/choose_repository.tcl:545
-msgid "Recursively clone submodules too"
-msgstr "サブモジュールも再帰的に複製する"
-
-#: lib/choose_repository.tcl:579 lib/choose_repository.tcl:626
-#: lib/choose_repository.tcl:772 lib/choose_repository.tcl:842
-#: lib/choose_repository.tcl:1104 lib/choose_repository.tcl:1112
+#: lib/merge.tcl:156
 #, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Git リポジトリではありません: %s"
+msgid "%s (%s): Merge"
+msgstr ""
 
-#: lib/choose_repository.tcl:615
-msgid "Standard only available for local repository."
-msgstr "標準方式は同一計算機上のリポジトリにのみ使えます。"
-
-#: lib/choose_repository.tcl:619
-msgid "Shared only available for local repository."
-msgstr "共有方式は同一計算機上のリポジトリにのみ使えます。"
-
-#: lib/choose_repository.tcl:640
+#: lib/merge.tcl:164
 #, tcl-format
-msgid "Location %s already exists."
-msgstr "'%s' は既に存在します。"
+msgid "Merge Into %s"
+msgstr "%s にマージ"
 
-#: lib/choose_repository.tcl:651
-msgid "Failed to configure origin"
-msgstr "origin を設定できませんでした"
+#: lib/merge.tcl:183
+msgid "Revision To Merge"
+msgstr "マージするリビジョン"
 
-#: lib/choose_repository.tcl:663
-msgid "Counting objects"
-msgstr "オブジェクトを数えています"
+#: lib/merge.tcl:218
+#, fuzzy
+msgid ""
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
+msgstr ""
+"訂正中には中止できません。\n"
+"\n"
+"まず今のコミット訂正を完了させて下さい。\n"
 
-#: lib/choose_repository.tcl:664
-msgid "buckets"
-msgstr "バケツ"
+#: lib/merge.tcl:228
+#, fuzzy
+msgid ""
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
+"Continue with aborting the current merge?"
+msgstr ""
+"マージを中断しますか？\n"
+"\n"
+"現在のマージを中断すると、コミットしていない全ての変更が失われます。\n"
+"\n"
+"マージを中断してよろしいですか？"
 
-#: lib/choose_repository.tcl:688
+#: lib/merge.tcl:234
+#, fuzzy
+msgid ""
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
+"Continue with resetting the current changes?"
+msgstr ""
+"変更点をリセットしますか？\n"
+"\n"
+"変更点をリセットすると、コミットしていない全ての変更が失われます。\n"
+"\n"
+"リセットしてよろしいですか？"
+
+#: lib/merge.tcl:245
+msgid "Aborting"
+msgstr "中断しています"
+
+#: lib/merge.tcl:245
+msgid "files reset"
+msgstr "リセットしたファイル"
+
+#: lib/merge.tcl:273
+msgid "Abort failed."
+msgstr "中断に失敗しました。"
+
+#: lib/merge.tcl:275
+msgid "Abort completed.  Ready."
+msgstr "中断完了。"
+
+#: lib/tools.tcl:76
 #, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "objects/info/alternates を複写できません: %s"
+msgid "Running %s requires a selected file."
+msgstr "ファイルを選択してから %s を起動してください。"
 
-#: lib/choose_repository.tcl:724
+#: lib/tools.tcl:92
 #, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "%s から複製する内容はありません"
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "本当にファイル \"%2$s\"で %1$s を起動しますか?"
 
-#: lib/choose_repository.tcl:726 lib/choose_repository.tcl:940
-#: lib/choose_repository.tcl:952
-msgid "The 'master' branch has not been initialized."
-msgstr "'master' ブランチが初期化されていません"
-
-#: lib/choose_repository.tcl:739
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "ハードリンクが作れないので、コピーします"
-
-#: lib/choose_repository.tcl:751
+#: lib/tools.tcl:96
 #, tcl-format
-msgid "Cloning from %s"
-msgstr "%s から複製しています"
+msgid "Are you sure you want to run %s?"
+msgstr "本当に %s を起動しますか?"
 
-#: lib/choose_repository.tcl:782
-msgid "Copying objects"
-msgstr "オブジェクトを複写しています"
-
-#: lib/choose_repository.tcl:783
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:807
+#: lib/tools.tcl:118
 #, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "オブジェクトを複写できません: %s"
+msgid "Tool: %s"
+msgstr "ツール: %s"
 
-#: lib/choose_repository.tcl:817
-msgid "Linking objects"
-msgstr "オブジェクトを連結しています"
-
-#: lib/choose_repository.tcl:818
-msgid "objects"
-msgstr "オブジェクト"
-
-#: lib/choose_repository.tcl:826
+#: lib/tools.tcl:119
 #, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "オブジェクトをハードリンクできません: %s"
+msgid "Running: %s"
+msgstr "実行中: %s"
 
-#: lib/choose_repository.tcl:881
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr "ブランチやオブジェクトを取得できません。コンソール出力を見て下さい"
-
-#: lib/choose_repository.tcl:892
-msgid "Cannot fetch tags.  See console output for details."
-msgstr "タグを取得できません。コンソール出力を見て下さい"
-
-#: lib/choose_repository.tcl:916
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr "HEAD を確定できません。コンソール出力を見て下さい"
-
-#: lib/choose_repository.tcl:925
+#: lib/tools.tcl:158
 #, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "%s を掃除できません"
+msgid "Tool completed successfully: %s"
+msgstr "ツールが完了しました: %s"
 
-#: lib/choose_repository.tcl:931
-msgid "Clone failed."
-msgstr "複写に失敗しました。"
-
-#: lib/choose_repository.tcl:938
-msgid "No default branch obtained."
-msgstr "デフォールト・ブランチが取得されませんでした"
-
-#: lib/choose_repository.tcl:949
+#: lib/tools.tcl:160
 #, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "%s をコミットとして解釈できません"
+msgid "Tool failed: %s"
+msgstr "ツールが失敗しました: %s"
 
-#: lib/choose_repository.tcl:961
-msgid "Creating working directory"
-msgstr "作業ディレクトリを作成しています"
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "ブランチをチェックアウト"
 
-#: lib/choose_repository.tcl:962 lib/index.tcl:70 lib/index.tcl:136
-#: lib/index.tcl:207
-msgid "files"
-msgstr "ファイル"
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "ブランチをチェックアウト"
 
-#: lib/choose_repository.tcl:981
-msgid "Cannot clone submodules."
-msgstr "サブモジュールが複製できません。"
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "チェックアウト"
 
-#: lib/choose_repository.tcl:990
-msgid "Cloning submodules"
-msgstr "サブモジュールを複製しています"
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "オプション"
 
-#: lib/choose_repository.tcl:1015
-msgid "Initial file checkout failed."
-msgstr "初期チェックアウトに失敗しました"
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "トラッキング・ブランチをフェッチ"
 
-#: lib/choose_repository.tcl:1059
-msgid "Open"
-msgstr "開く"
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "ローカル・ブランチから削除"
 
-#: lib/choose_repository.tcl:1069
-msgid "Repository:"
-msgstr "リポジトリ:"
+#: lib/spellcheck.tcl:57
+msgid "Unsupported spell checker"
+msgstr "サポートされていないスペルチェッカーです"
 
-#: lib/choose_repository.tcl:1118
+#: lib/spellcheck.tcl:65
+msgid "Spell checking is unavailable"
+msgstr "スペルチェック機能は使えません"
+
+#: lib/spellcheck.tcl:68
+msgid "Invalid spell checking configuration"
+msgstr "スペルチェックの設定が不正です"
+
+#: lib/spellcheck.tcl:70
 #, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "リポジトリ %s を開けません:"
+msgid "Reverting dictionary to %s."
+msgstr "辞書を %s に巻き戻します"
 
-#: lib/branch_rename.tcl:15 lib/branch_rename.tcl:23
-msgid "Rename Branch"
-msgstr "ブランチの名前変更"
+#: lib/spellcheck.tcl:73
+msgid "Spell checker silently failed on startup"
+msgstr "スペルチェッカーの起動に失敗しました"
 
-#: lib/branch_rename.tcl:28
-msgid "Rename"
-msgstr "名前変更"
+#: lib/spellcheck.tcl:80
+msgid "Unrecognized spell checker"
+msgstr "スペルチェッカーが判別できません"
 
-#: lib/branch_rename.tcl:38
-msgid "Branch:"
-msgstr "ブランチ:"
+#: lib/spellcheck.tcl:186
+msgid "No Suggestions"
+msgstr "提案なし"
 
-#: lib/branch_rename.tcl:46
-msgid "New Name:"
-msgstr "新しい名前:"
+#: lib/spellcheck.tcl:388
+msgid "Unexpected EOF from spell checker"
+msgstr "スペルチェッカーが予想外の EOF を返しました"
 
-#: lib/branch_rename.tcl:81
-msgid "Please select a branch to rename."
-msgstr "名前を変更するブランチを選んで下さい。"
-
-#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
-msgid "Please supply a branch name."
-msgstr "ブランチ名を指定して下さい。"
-
-#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "'%s' はブランチ名に使えません。"
-
-#: lib/branch_rename.tcl:123
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "'%s'の名前変更に失敗しました。"
-
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "ショートカットが書けません:"
-
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "アイコンが書けません:"
-
-#: lib/search.tcl:48
-msgid "Find:"
-msgstr "検索:"
-
-#: lib/search.tcl:50
-msgid "Next"
-msgstr "次"
-
-#: lib/search.tcl:51
-msgid "Prev"
-msgstr "前"
-
-#: lib/search.tcl:52
-msgid "RegExp"
-msgstr "正規表現"
-
-#: lib/search.tcl:54
-msgid "Case"
-msgstr "大文字小文字を区別"
+#: lib/spellcheck.tcl:392
+msgid "Spell Checker Failed"
+msgstr "スペルチェック失敗"
 
 #: lib/status_bar.tcl:87
 #, tcl-format
 msgid "%s ... %*i of %*i %s (%3i%%)"
 msgstr "%1$s ... %4$*i %6$s 中の %2$*i (%7$3i%%)"
 
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "ツールの追加"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "新規ツールコマンドの追加"
-
-#: lib/tools_dlg.tcl:34
-msgid "Add globally"
-msgstr "全体に追加"
-
-#: lib/tools_dlg.tcl:37 lib/remote_add.tcl:30
-msgid "Add"
-msgstr "追加"
-
-#: lib/tools_dlg.tcl:46
-msgid "Tool Details"
-msgstr "ツールの詳細"
-
-#: lib/tools_dlg.tcl:49
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "'/' でサブメニューを区切ります:"
-
-#: lib/tools_dlg.tcl:51 lib/remote_add.tcl:41 lib/branch_create.tcl:44
-msgid "Name:"
-msgstr "名前:"
-
-#: lib/tools_dlg.tcl:60
-msgid "Command:"
-msgstr "コマンド:"
-
-#: lib/tools_dlg.tcl:71
-msgid "Show a dialog before running"
-msgstr "起動する前にダイアログを表示"
-
-#: lib/tools_dlg.tcl:77
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr "ユーザにコミットを一つ選ばせる ($REVISION にセットします)"
-
-#: lib/tools_dlg.tcl:82
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "ユーザに他の引数を追加させる ($ARGS にセットします)"
-
-#: lib/tools_dlg.tcl:89
-msgid "Don't show the command output window"
-msgstr "コマンドからの出力ウィンドウを見せない"
-
-#: lib/tools_dlg.tcl:94
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "パッチが選ばれているときだけ動かす($FILENAME が空でない)"
-
-#: lib/tools_dlg.tcl:118
-msgid "Please supply a name for the tool."
-msgstr "ツール名を指定して下さい。"
-
-#: lib/tools_dlg.tcl:126
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "ツール '%s' は既に存在します。"
-
-#: lib/tools_dlg.tcl:148
-#, tcl-format
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
 msgid ""
-"Could not add tool:\n"
-"%s"
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
 msgstr ""
-"ツールを追加できません:\n"
-"%s"
+"変更がありません。\n"
+"\n"
+"%s には変更がありません。\n"
+"\n"
+"このファイルの変更時刻は他のアプリケーションによって更新されていますがファイ"
+"ル内容には変更がありません。\n"
+"\n"
+"同様な状態のファイルを探すために、自動的に再スキャンを開始します。"
 
-#: lib/tools_dlg.tcl:187
-msgid "Remove Tool"
-msgstr "ツールの削除"
-
-#: lib/tools_dlg.tcl:193
-msgid "Remove Tool Commands"
-msgstr "ツールコマンドの削除"
-
-#: lib/tools_dlg.tcl:198
-msgid "Remove"
-msgstr "削除"
-
-#: lib/tools_dlg.tcl:231
-msgid "(Blue denotes repository-local tools)"
-msgstr "(青色はローカルレポジトリのツールです)"
-
-#: lib/tools_dlg.tcl:292
+#: lib/diff.tcl:117
 #, tcl-format
-msgid "Run Command: %s"
-msgstr "コマンドを起動: %s"
+msgid "Loading diff of %s..."
+msgstr "%s の変更点をロード中…"
 
-#: lib/tools_dlg.tcl:306
-msgid "Arguments"
-msgstr "引数"
-
-#: lib/tools_dlg.tcl:321 lib/branch_checkout.tcl:35 lib/browser.tcl:297
-msgid "Revision"
-msgstr "リビジョン"
-
-#: lib/tools_dlg.tcl:341
-msgid "OK"
-msgstr "OK"
-
-#: lib/tools.tcl:75
-#, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "ファイルを選択してから %s を起動してください。"
-
-#: lib/tools.tcl:91
-#, tcl-format
-msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
-msgstr "本当にファイル \"%2$s\"で %1$s を起動しますか?"
-
-#: lib/tools.tcl:95
-#, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "本当に %s を起動しますか?"
-
-#: lib/tools.tcl:116
-#, tcl-format
-msgid "Tool: %s"
-msgstr "ツール: %s"
-
-#: lib/tools.tcl:117
-#, tcl-format
-msgid "Running: %s"
-msgstr "実行中: %s"
-
-#: lib/tools.tcl:155
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "ツールが完了しました: %s"
-
-#: lib/tools.tcl:157
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "ツールが失敗しました: %s"
-
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "共通の版を使いますか?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "自分の側の版を使いますか?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "相手制の版を使いますか?"
-
-#: lib/mergetool.tcl:14
-#, tcl-format
+#: lib/diff.tcl:143
 msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
+"LOCAL: deleted\n"
+"REMOTE:\n"
 msgstr ""
-"競合する変更点だけが表示されていることに注意してください。\n"
-"\n"
-"%s は上書きされます。\n"
-"\n"
-"やり直すにはマージ全体をやり直してください。"
+"LOCAL: 削除\n"
+"Remote:\n"
 
-#: lib/mergetool.tcl:45
-#, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-"ファイル %s には解決していない競合部分がまだあるようですが、いいですか?"
-
-#: lib/mergetool.tcl:60
-#, tcl-format
-msgid "Adding resolution for %s"
-msgstr "%s への解決をステージします"
-
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr "ツールでは削除やリンク競合は扱えません"
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "競合ファイルは存在しません。"
-
-#: lib/mergetool.tcl:246
-#, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "GUI マージツールではありません: %s"
-
-#: lib/mergetool.tcl:275
-#, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "マージツール '%s' はサポートしていません"
-
-#: lib/mergetool.tcl:310
-msgid "Merge tool is already running, terminate it?"
-msgstr "マージツールはすでに起動しています。終了しますか?"
-
-#: lib/mergetool.tcl:330
-#, tcl-format
+#: lib/diff.tcl:148
 msgid ""
-"Error retrieving versions:\n"
-"%s"
+"REMOTE: deleted\n"
+"LOCAL:\n"
 msgstr ""
-"版の取り出し時にエラーが出ました:\n"
-"%s"
+"REMOTE: 削除\n"
+"LOCAL:\n"
 
-#: lib/mergetool.tcl:350
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "LOCAL:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "REMOTE\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
 #, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
+msgid "Unable to display %s"
+msgstr "%s を表示できません"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "ファイルを読む際のエラーです:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Git リポジトリ(サブプロジェクト)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* バイナリファイル(内容は表示しません)"
+
+#: lib/diff.tcl:243
+msgid "\r"
 msgstr ""
-"マージツールが起動できません:\n"
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
 "\n"
-"%s"
+"\n"
+"* %s は管理外のファイルをここで切りおとしました。\n"
+"* 全体を見るには外部エディタを使ってください。\n"
 
-#: lib/mergetool.tcl:354
-msgid "Running merge tool..."
-msgstr "マージツールを実行しています..."
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "diff を読む際のエラーです:"
 
-#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
-msgid "Merge tool failed."
-msgstr "マージツールが失敗しました。"
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "選択されたパッチをコミット予定から外せません。"
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "選択されたパッチをコミット予定に加えられません。"
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "選択されたパッチ行をコミット予定から外せません。"
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "選択されたパッチ行をコミット予定に加えられません。"
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "プッシュ先"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "リモートを削除"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "から刈込む…"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "取得元"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "選択"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "フォント・ファミリー"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "フォントの大きさ"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "フォント・サンプル"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"これはサンプル文です。\n"
+"このフォントが気に入ればお使いになれます。"
 
 #: lib/option.tcl:11
 #, tcl-format
@@ -1869,6 +1511,12 @@ msgstr "管理外のファイルを表示する"
 msgid "Tab spacing"
 msgstr "タブ幅"
 
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
 #: lib/option.tcl:210
 msgid "Change"
 msgstr "変更"
@@ -1894,381 +1542,701 @@ msgstr "ポイント"
 msgid "Preferences"
 msgstr "設定"
 
-#: lib/option.tcl:310 lib/branch_checkout.tcl:39 lib/branch_create.tcl:69
-msgid "Options"
-msgstr "オプション"
-
 #: lib/option.tcl:345
 msgid "Failed to completely save options:"
 msgstr "完全にオプションを保存できません:"
 
-#: lib/database.tcl:42
-msgid "Number of loose objects"
-msgstr "ばらばらなオブジェクトの数"
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "共通の版を使いますか?"
 
-#: lib/database.tcl:43
-msgid "Disk space used by loose objects"
-msgstr "ばらばらなオブジェクトの使用するディスク量"
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "自分の側の版を使いますか?"
 
-#: lib/database.tcl:44
-msgid "Number of packed objects"
-msgstr "パックされたオブジェクトの数"
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "相手制の版を使いますか?"
 
-#: lib/database.tcl:45
-msgid "Number of packs"
-msgstr "パックの数"
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"競合する変更点だけが表示されていることに注意してください。\n"
+"\n"
+"%s は上書きされます。\n"
+"\n"
+"やり直すにはマージ全体をやり直してください。"
 
-#: lib/database.tcl:46
-msgid "Disk space used by packed objects"
-msgstr "パックされたオブジェクトの使用するディスク量"
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+"ファイル %s には解決していない競合部分がまだあるようですが、いいですか?"
 
-#: lib/database.tcl:47
-msgid "Packed objects waiting for pruning"
-msgstr "パックに存在するので捨てて良いオブジェクトの数"
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr "%s への解決をステージします"
 
-#: lib/database.tcl:48
-msgid "Garbage files"
-msgstr "ゴミファイル"
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr "ツールでは削除やリンク競合は扱えません"
 
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "データベース圧縮"
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "競合ファイルは存在しません。"
 
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "fsck-objects でオブジェクト・データベースを検証しています"
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "GUI マージツールではありません: %s"
 
-#: lib/database.tcl:107
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr "マージツール '%s' はサポートしていません"
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "マージツールはすでに起動しています。終了しますか?"
+
+#: lib/mergetool.tcl:330
 #, tcl-format
 msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
+"Error retrieving versions:\n"
+"%s"
 msgstr ""
-"このリポジトリにはおおよそ %i 個の個別オブジェクトがあります\n"
-"\n"
-"最適な性能を保つために、データベースを圧縮することを推奨します\n"
-"\n"
-"データベースを圧縮しますか？"
+"版の取り出し時にエラーが出ました:\n"
+"%s"
 
-#: lib/transport.tcl:6 lib/remote_add.tcl:132
-#, tcl-format
-msgid "fetch %s"
-msgstr "%s を取得"
-
-#: lib/transport.tcl:7
-#, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "%s から新しい変更をフェッチしています"
-
-#: lib/transport.tcl:18
-#, tcl-format
-msgid "remote prune %s"
-msgstr "リモート刈込 %s"
-
-#: lib/transport.tcl:19
-#, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "%s から削除されたトラッキング・ブランチを刈っています"
-
-#: lib/transport.tcl:25
-msgid "fetch all remotes"
-msgstr "すべてのリモートを取得"
-
-#: lib/transport.tcl:26
-msgid "Fetching new changes from all remotes"
-msgstr "すべてのリモートから新しい変更をフェッチしています"
-
-#: lib/transport.tcl:40
-msgid "remote prune all remotes"
-msgstr "リモート刈込 すべてのリモート"
-
-#: lib/transport.tcl:41
-msgid "Pruning tracking branches deleted from all remotes"
-msgstr "すべてのリモートから削除されたトラッキング・ブランチを刈っています"
-
-#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
-#: lib/remote_add.tcl:162
-#, tcl-format
-msgid "push %s"
-msgstr "%s をプッシュ"
-
-#: lib/transport.tcl:55
-#, tcl-format
-msgid "Pushing changes to %s"
-msgstr "%s へ変更をプッシュしています"
-
-#: lib/transport.tcl:93
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr "%s へミラーしています"
-
-#: lib/transport.tcl:111
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "%3$s へ %1$s %2$s をプッシュしています"
-
-#: lib/transport.tcl:132
-msgid "Push Branches"
-msgstr "ブランチをプッシュ"
-
-#: lib/transport.tcl:147
-msgid "Source Branches"
-msgstr "元のブランチ"
-
-#: lib/transport.tcl:162
-msgid "Destination Repository"
-msgstr "送り先リポジトリ"
-
-#: lib/transport.tcl:205
-msgid "Transfer Options"
-msgstr "通信オプション"
-
-#: lib/transport.tcl:207
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr "既存ブランチを上書き(変更を破棄する可能性があります)"
-
-#: lib/transport.tcl:211
-msgid "Use thin pack (for slow network connections)"
-msgstr "Thin Pack を使う（遅いネットワーク接続）"
-
-#: lib/transport.tcl:215
-msgid "Include tags"
-msgstr "タグを含める"
-
-#: lib/choose_font.tcl:41
-msgid "Select"
-msgstr "選択"
-
-#: lib/choose_font.tcl:55
-msgid "Font Family"
-msgstr "フォント・ファミリー"
-
-#: lib/choose_font.tcl:76
-msgid "Font Size"
-msgstr "フォントの大きさ"
-
-#: lib/choose_font.tcl:93
-msgid "Font Example"
-msgstr "フォント・サンプル"
-
-#: lib/choose_font.tcl:105
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
-msgstr ""
-"これはサンプル文です。\n"
-"このフォントが気に入ればお使いになれます。"
-
-#: lib/remote.tcl:200
-msgid "Push to"
-msgstr "プッシュ先"
-
-#: lib/remote.tcl:218
-msgid "Remove Remote"
-msgstr "リモートを削除"
-
-#: lib/remote.tcl:223
-msgid "Prune from"
-msgstr "から刈込む…"
-
-#: lib/remote.tcl:228
-msgid "Fetch from"
-msgstr "取得元"
-
-#: lib/diff.tcl:77
+#: lib/mergetool.tcl:350
 #, tcl-format
 msgid ""
-"No differences detected.\n"
+"Could not start the merge tool:\n"
 "\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
+"%s"
 msgstr ""
-"変更がありません。\n"
+"マージツールが起動できません:\n"
 "\n"
-"%s には変更がありません。\n"
-"\n"
-"このファイルの変更時刻は他のアプリケーションによって更新されていますがファイ"
-"ル内容には変更がありません。\n"
-"\n"
-"同様な状態のファイルを探すために、自動的に再スキャンを開始します。"
+"%s"
 
-#: lib/diff.tcl:117
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "マージツールを実行しています..."
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "マージツールが失敗しました。"
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "ツールの追加"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "新規ツールコマンドの追加"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "全体に追加"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "ツールの詳細"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "'/' でサブメニューを区切ります:"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "コマンド:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "起動する前にダイアログを表示"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr "ユーザにコミットを一つ選ばせる ($REVISION にセットします)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "ユーザに他の引数を追加させる ($ARGS にセットします)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "コマンドからの出力ウィンドウを見せない"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "パッチが選ばれているときだけ動かす($FILENAME が空でない)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "ツール名を指定して下さい。"
+
+#: lib/tools_dlg.tcl:126
 #, tcl-format
-msgid "Loading diff of %s..."
-msgstr "%s の変更点をロード中…"
+msgid "Tool '%s' already exists."
+msgstr "ツール '%s' は既に存在します。"
 
-#: lib/diff.tcl:140
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-"LOCAL: 削除\n"
-"Remote:\n"
-
-#: lib/diff.tcl:145
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-"REMOTE: 削除\n"
-"LOCAL:\n"
-
-#: lib/diff.tcl:152
-msgid "LOCAL:\n"
-msgstr "LOCAL:\n"
-
-#: lib/diff.tcl:155
-msgid "REMOTE:\n"
-msgstr "REMOTE\n"
-
-#: lib/diff.tcl:217 lib/diff.tcl:355
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "%s を表示できません"
-
-#: lib/diff.tcl:218
-msgid "Error loading file:"
-msgstr "ファイルを読む際のエラーです:"
-
-#: lib/diff.tcl:225
-msgid "Git Repository (subproject)"
-msgstr "Git リポジトリ(サブプロジェクト)"
-
-#: lib/diff.tcl:237
-msgid "* Binary file (not showing content)."
-msgstr "* バイナリファイル(内容は表示しません)"
-
-#: lib/diff.tcl:242
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* 管理外のファイルの大きさは %d バイトです。\n"
-"* 最初の %d バイトだけ表示しています。\n"
-
-#: lib/diff.tcl:248
+#: lib/tools_dlg.tcl:148
 #, tcl-format
 msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
+"Could not add tool:\n"
+"%s"
 msgstr ""
-"\n"
-"\n"
-"* %s は管理外のファイルをここで切りおとしました。\n"
-"* 全体を見るには外部エディタを使ってください。\n"
+"ツールを追加できません:\n"
+"%s"
 
-#: lib/diff.tcl:578
-msgid "Failed to unstage selected hunk."
-msgstr "選択されたパッチをコミット予定から外せません。"
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "ツールの削除"
 
-#: lib/diff.tcl:585
-msgid "Failed to stage selected hunk."
-msgstr "選択されたパッチをコミット予定に加えられません。"
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "ツールコマンドの削除"
 
-#: lib/diff.tcl:664
-msgid "Failed to unstage selected line."
-msgstr "選択されたパッチ行をコミット予定から外せません。"
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "削除"
 
-#: lib/diff.tcl:672
-msgid "Failed to stage selected line."
-msgstr "選択されたパッチ行をコミット予定に加えられません。"
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(青色はローカルレポジトリのツールです)"
 
-#: lib/branch_checkout.tcl:16 lib/branch_checkout.tcl:21
-msgid "Checkout Branch"
-msgstr "ブランチをチェックアウト"
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "システム (%s)"
 
-#: lib/branch_checkout.tcl:26
-msgid "Checkout"
-msgstr "チェックアウト"
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "コマンドを起動: %s"
 
-#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "トラッキング・ブランチをフェッチ"
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "引数"
 
-#: lib/branch_checkout.tcl:47
-msgid "Detach From Local Branch"
-msgstr "ローカル・ブランチから削除"
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "OK"
 
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "インデックスをロックできません"
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "検索:"
 
-#: lib/index.tcl:17
-msgid "Index Error"
-msgstr "索引エラー"
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "次"
 
-#: lib/index.tcl:19
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "前"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr "正規表現"
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr "大文字小文字を区別"
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "デスクトップ・アイコンを作る"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "ショートカットが書けません:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "アイコンが書けません:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "ブランチの名前変更"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "ブランチの名前変更"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "名前変更"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "ブランチ:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "新しい名前:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "名前を変更するブランチを選んで下さい。"
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "ブランチ名を指定して下さい。"
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "'%s' はブランチ名に使えません。"
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "'%s'の名前変更に失敗しました。"
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "リモートブランチ削除"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "リモートブランチ削除"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "元のリポジトリ"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "ブランチ"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "条件付で削除"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "マージ先:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "無条件（マージ検査をしない）"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "'マージ先' にはブランチが必要です。"
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
 msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
 msgstr ""
-"GIT インデックスの更新が失敗しました。git-gui と同期をとるために再スキャンし"
-"ます。"
+"以下のブランチは %s に完全にマージされていません:\n"
+"\n"
+" - %s"
 
-#: lib/index.tcl:30
-msgid "Continue"
-msgstr "続行"
-
-#: lib/index.tcl:33
-msgid "Unlock Index"
-msgstr "インデックスのロック解除"
-
-#: lib/index.tcl:298
+#: lib/remote_branch_delete.tcl:190
 #, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "コミットから '%s' を降ろす"
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"必要なコミットが不足しているために、マージ検査が失敗しました。まず %s から"
+"フェッチして下さい。"
 
-#: lib/index.tcl:337
-msgid "Ready to commit."
-msgstr "コミット準備完了"
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "削除するブランチを選択して下さい。"
 
-#: lib/index.tcl:350
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"削除したブランチを回復するのは困難です。\n"
+"\n"
+"選択したブランチを削除して良いですか？"
+
+#: lib/remote_branch_delete.tcl:227
 #, tcl-format
-msgid "Adding %s"
-msgstr "コミットに %s を加えています"
+msgid "Deleting branches from %s"
+msgstr "%s からブランチを削除しています。"
 
-#: lib/index.tcl:380
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "リポジトリが選択されていません。"
+
+#: lib/remote_branch_delete.tcl:305
 #, tcl-format
-msgid "Stage %d untracked files?"
-msgstr "管理外の %d ファイルをコミット予定としますか？"
+msgid "Scanning %s..."
+msgstr "%s をスキャンしています…"
 
-#: lib/index.tcl:428
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git GUI"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "新しいリポジトリを作る"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "新規…"
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "既存リポジトリを複製する"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "複製…"
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "既存リポジトリを開く"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "開く…"
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "最近使ったリポジトリ"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "最近使ったリポジトリを開く"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
 #, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "ファイル %s にした変更を元に戻しますか？"
+msgid "Failed to create repository %s:"
+msgstr "リポジトリ %s を作製できません:"
 
-#: lib/index.tcl:430
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "作成"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "ディレクトリ:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "GIT リポジトリ"
+
+#: lib/choose_repository.tcl:475
 #, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "これら %i 個のファイルにした変更を元に戻しますか？"
+msgid "Directory %s already exists."
+msgstr "ディレクトリ '%s' は既に存在します。"
 
-#: lib/index.tcl:438
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr "変更を元に戻すとコミット予定していない変更は全て失われます。"
-
-#: lib/index.tcl:441
-msgid "Do Nothing"
-msgstr "何もしない"
-
-#: lib/index.tcl:459
-msgid "Reverting selected files"
-msgstr "選択されたファイルにした変更を元に戻します"
-
-#: lib/index.tcl:463
+#: lib/choose_repository.tcl:479
 #, tcl-format
-msgid "Reverting %s"
-msgstr "%s にした変更を元に戻します"
+msgid "File %s already exists."
+msgstr "ファイル '%s' は既に存在します。"
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "複製"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "ソースの位置"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "先ディレクトリ:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "複製方式:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "標準(高速・中冗長度・ハードリンク)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "全複写(低速・冗長バックアップ)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "共有(最高速・非推奨・バックアップ無し)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr "サブモジュールも再帰的に複製する"
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Git リポジトリではありません: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "標準方式は同一計算機上のリポジトリにのみ使えます。"
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "共有方式は同一計算機上のリポジトリにのみ使えます。"
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "'%s' は既に存在します。"
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "origin を設定できませんでした"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "オブジェクトを数えています"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "バケツ"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "objects/info/alternates を複写できません: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "%s から複製する内容はありません"
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "'master' ブランチが初期化されていません"
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "ハードリンクが作れないので、コピーします"
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "%s から複製しています"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "オブジェクトを複写しています"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "オブジェクトを複写できません: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "オブジェクトを連結しています"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "オブジェクト"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "オブジェクトをハードリンクできません: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr "ブランチやオブジェクトを取得できません。コンソール出力を見て下さい"
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr "タグを取得できません。コンソール出力を見て下さい"
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr "HEAD を確定できません。コンソール出力を見て下さい"
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "%s を掃除できません"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "複写に失敗しました。"
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "デフォールト・ブランチが取得されませんでした"
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "%s をコミットとして解釈できません"
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "作業ディレクトリを作成しています"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "ファイル"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr "サブモジュールが複製できません。"
+
+#: lib/choose_repository.tcl:993
+msgid "Cloning submodules"
+msgstr "サブモジュールを複製しています"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "初期チェックアウトに失敗しました"
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "開く"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "リポジトリ:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "リポジトリ %s を開けません:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "Git のグラフィカルUI git-gui"
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "ファイルピューワ"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "コミット:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "コミットをコピー"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "テキストを検索"
+
+#: lib/blame.tcl:288
+msgid "Goto Line..."
+msgstr "指定行に移動…"
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "コピー検知"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "文脈を見せる"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "親コミットを注釈"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "%s を読んでいます…"
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "コピー・移動追跡データを読んでいます…"
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "行を注釈しました"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "元位置行の注釈データを読んでいます…"
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "注釈完了しました"
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "実行中"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "すでに blame プロセスを実行中です。"
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "コピー検知を実行中…"
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "注釈を読み込んでいます…"
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "作者:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "コミット者:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "元ファイル"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "HEAD コミットが見つかりません"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "親コミットが見つかりません:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "親を表示できません"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "原作者:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "ファイル:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "複写・移動者:"
 
 #: lib/sshkey.tcl:31
 msgid "No keys found."
@@ -2319,289 +2287,9 @@ msgstr "生成には成功しましたが、鍵が見つかりません。"
 msgid "Your key is in: %s"
 msgstr "あなたの鍵は %s にあります"
 
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"訂正するコミットがそもそもありません。\n"
-"\n"
-"これから作るのは最初のコミットです。その前にはまだ訂正するようなコミットはあ"
-"りません。\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"マージ中にコミットの訂正はできません。\n"
-"\n"
-"現在はまだマージの途中です。先にこのマージを中止しないと、前のコミットの訂正"
-"はできません\n"
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "訂正するコミットのデータを読めません:"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "ユーザの正体を確認できません:"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "GIT_COMMITTER_IDENT が無効です:"
-
-#: lib/commit.tcl:129
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "警告: Tcl はエンコーディング '%s' をサポートしていません"
-
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"最後にスキャンした状態はリポジトリの状態と合致しません。\n"
-"\n"
-"最後にスキャンして以後、別の Git プログラムがリポジトリを変更しています。新し"
-"くコミットする前に、再スキャンが必要です。\n"
-"\n"
-"自動的に再スキャンを開始します。\n"
-
-#: lib/commit.tcl:173
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"マージしていないファイルはコミットできません。\n"
-"\n"
-"ファイル %s にはマージ衝突が残っています。まず解決してコミット予定に加える必"
-"要があります。\n"
-
-#: lib/commit.tcl:181
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"不明なファイル状態 %s です。\n"
-"\n"
-"ファイル %s は本プログラムではコミットできません。\n"
-
-#: lib/commit.tcl:189
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"コミットする変更がありません。\n"
-"\n"
-"最低一つの変更をコミット予定に加えてからコミットして下さい。\n"
-
-#: lib/commit.tcl:204
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"コミット・メッセージを入力して下さい。\n"
-"\n"
-"正しいコミット・メッセージは:\n"
-"\n"
-"- 第１行: 何をしたか、を１行で要約。\n"
-"- 第２行: 空白\n"
-"- 残りの行: なぜ、この変更が良い変更か、の説明。\n"
-
-#: lib/commit.tcl:235
-msgid "Calling pre-commit hook..."
-msgstr "コミット前フックを実行中・・・"
-
-#: lib/commit.tcl:250
-msgid "Commit declined by pre-commit hook."
-msgstr "コミット前フックがコミットを拒否しました"
-
-#: lib/commit.tcl:269
-msgid ""
-"You are about to commit on a detached head. This is a potentially dangerous "
-"thing to do because if you switch to another branch you will lose your "
-"changes and it can be difficult to retrieve them later from the reflog. You "
-"should probably cancel this commit and create a new branch to continue.\n"
-" \n"
-" Do you really want to proceed with your Commit?"
-msgstr ""
-"分離 HEAD での変更をコミットしようとしています。"
-"これは潜在的に危険な行為で、理由は別のブランチへの切り替えで"
-"変更が消失し、reflog からの事後復旧も困難となるためです。"
-"おそらくこのコミットはキャンセルし新しく作成したブランチで"
-"行うべきです。\n"
-"\n"
-" 本当にコミットを続行しますか？"
-
-#: lib/commit.tcl:290
-msgid "Calling commit-msg hook..."
-msgstr "コミット・メッセージ・フックを実行中・・・"
-
-#: lib/commit.tcl:305
-msgid "Commit declined by commit-msg hook."
-msgstr "コミット・メッセージ・フックがコミットを拒否しました"
-
-#: lib/commit.tcl:318
-msgid "Committing changes..."
-msgstr "変更点をコミット中・・・"
-
-#: lib/commit.tcl:334
-msgid "write-tree failed:"
-msgstr "write-tree が失敗しました:"
-
-#: lib/commit.tcl:335 lib/commit.tcl:379 lib/commit.tcl:400
-msgid "Commit failed."
-msgstr "コミットに失敗しました。"
-
-#: lib/commit.tcl:352
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "コミット %s は壊れています"
-
-#: lib/commit.tcl:357
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"コミットする変更がありません。\n"
-"\n"
-"マージでなく、また、一つも変更点がありません。\n"
-"\n"
-"自動的に再スキャンを開始します。\n"
-
-#: lib/commit.tcl:364
-msgid "No changes to commit."
-msgstr "コミットする変更がありません。"
-
-#: lib/commit.tcl:378
-msgid "commit-tree failed:"
-msgstr "commit-tree が失敗しました:"
-
-#: lib/commit.tcl:399
-msgid "update-ref failed:"
-msgstr "update-ref が失敗しました:"
-
-#: lib/commit.tcl:492
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "コミット %s を作成しました: %s"
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "起動中…"
-
-#: lib/browser.tcl:27
-msgid "File Browser"
-msgstr "ファイル・ブラウザ"
-
-#: lib/browser.tcl:132 lib/browser.tcl:149
-#, tcl-format
-msgid "Loading %s..."
-msgstr "%s をロード中…"
-
-#: lib/browser.tcl:193
-msgid "[Up To Parent]"
-msgstr "[上位フォルダへ]"
-
-#: lib/browser.tcl:275 lib/browser.tcl:282
-msgid "Browse Branch Files"
-msgstr "現在のブランチのファイルを見る"
-
-#: lib/remote_add.tcl:20
-msgid "Add Remote"
-msgstr "リモートを追加"
-
-#: lib/remote_add.tcl:25
-msgid "Add New Remote"
-msgstr "リモートを新規に追加"
-
-#: lib/remote_add.tcl:39
-msgid "Remote Details"
-msgstr "リモートの詳細"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "場所:"
-
-#: lib/remote_add.tcl:60
-msgid "Further Action"
-msgstr "その他の動作"
-
-#: lib/remote_add.tcl:63
-msgid "Fetch Immediately"
-msgstr "即座に取得"
-
-#: lib/remote_add.tcl:69
-msgid "Initialize Remote Repository and Push"
-msgstr "リモートレポジトリを初期化してプッシュ"
-
-#: lib/remote_add.tcl:75
-msgid "Do Nothing Else Now"
-msgstr "何もしない"
-
-#: lib/remote_add.tcl:100
-msgid "Please supply a remote name."
-msgstr "リモート名を指定して下さい。"
-
-#: lib/remote_add.tcl:113
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "'%s' はリモート名に使えません。"
-
-#: lib/remote_add.tcl:124
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "場所 '%2$s' のリモート '%1$s'の名前変更に失敗しました。"
-
-#: lib/remote_add.tcl:133
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "%s からフェッチしています"
-
-#: lib/remote_add.tcl:156
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "リポジトリ '%s' を初期化できません。"
-
-#: lib/remote_add.tcl:163
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "%2$s にある %1$s をセットアップします"
-
-#: lib/line.tcl:17
-msgid "Goto Line:"
-msgstr "行番号"
-
-#: lib/line.tcl:23
-msgid "Go"
-msgstr "移動"
-
 #: lib/branch_create.tcl:23
-msgid "Create Branch"
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
 msgstr "ブランチを作成"
 
 #: lib/branch_create.tcl:28
@@ -2646,39 +2334,488 @@ msgid "Tracking branch %s is not a branch in the remote repository."
 msgstr ""
 "トラッキング・ブランチ %s はリモートリポジトリのブランチではありません。"
 
-#: lib/spellcheck.tcl:57
-msgid "Unsupported spell checker"
-msgstr "サポートされていないスペルチェッカーです"
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"訂正するコミットがそもそもありません。\n"
+"\n"
+"これから作るのは最初のコミットです。その前にはまだ訂正するようなコミットはあ"
+"りません。\n"
 
-#: lib/spellcheck.tcl:65
-msgid "Spell checking is unavailable"
-msgstr "スペルチェック機能は使えません"
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"マージ中にコミットの訂正はできません。\n"
+"\n"
+"現在はまだマージの途中です。先にこのマージを中止しないと、前のコミットの訂正"
+"はできません\n"
 
-#: lib/spellcheck.tcl:68
-msgid "Invalid spell checking configuration"
-msgstr "スペルチェックの設定が不正です"
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "訂正するコミットのデータを読めません:"
 
-#: lib/spellcheck.tcl:70
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "ユーザの正体を確認できません:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "GIT_COMMITTER_IDENT が無効です:"
+
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Reverting dictionary to %s."
-msgstr "辞書を %s に巻き戻します"
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "警告: Tcl はエンコーディング '%s' をサポートしていません"
 
-#: lib/spellcheck.tcl:73
-msgid "Spell checker silently failed on startup"
-msgstr "スペルチェッカーの起動に失敗しました"
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"最後にスキャンした状態はリポジトリの状態と合致しません。\n"
+"\n"
+"最後にスキャンして以後、別の Git プログラムがリポジトリを変更しています。新し"
+"くコミットする前に、再スキャンが必要です。\n"
+"\n"
+"自動的に再スキャンを開始します。\n"
 
-#: lib/spellcheck.tcl:80
-msgid "Unrecognized spell checker"
-msgstr "スペルチェッカーが判別できません"
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"マージしていないファイルはコミットできません。\n"
+"\n"
+"ファイル %s にはマージ衝突が残っています。まず解決してコミット予定に加える必"
+"要があります。\n"
 
-#: lib/spellcheck.tcl:186
-msgid "No Suggestions"
-msgstr "提案なし"
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"不明なファイル状態 %s です。\n"
+"\n"
+"ファイル %s は本プログラムではコミットできません。\n"
 
-#: lib/spellcheck.tcl:388
-msgid "Unexpected EOF from spell checker"
-msgstr "スペルチェッカーが予想外の EOF を返しました"
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"コミットする変更がありません。\n"
+"\n"
+"最低一つの変更をコミット予定に加えてからコミットして下さい。\n"
 
-#: lib/spellcheck.tcl:392
-msgid "Spell Checker Failed"
-msgstr "スペルチェック失敗"
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"コミット・メッセージを入力して下さい。\n"
+"\n"
+"正しいコミット・メッセージは:\n"
+"\n"
+"- 第１行: 何をしたか、を１行で要約。\n"
+"- 第２行: 空白\n"
+"- 残りの行: なぜ、この変更が良い変更か、の説明。\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "コミット前フックを実行中・・・"
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "コミット前フックがコミットを拒否しました"
+
+#: lib/commit.tcl:272
+#, fuzzy
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+"分離 HEAD での変更をコミットしようとしています。これは潜在的に危険な行為で、"
+"理由は別のブランチへの切り替えで変更が消失し、reflog からの事後復旧も困難とな"
+"るためです。おそらくこのコミットはキャンセルし新しく作成したブランチで行うべ"
+"きです。\n"
+"\n"
+" 本当にコミットを続行しますか？"
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "コミット・メッセージ・フックを実行中・・・"
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "コミット・メッセージ・フックがコミットを拒否しました"
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "変更点をコミット中・・・"
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "write-tree が失敗しました:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "コミットに失敗しました。"
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "コミット %s は壊れています"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"コミットする変更がありません。\n"
+"\n"
+"マージでなく、また、一つも変更点がありません。\n"
+"\n"
+"自動的に再スキャンを開始します。\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "コミットする変更がありません。"
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree が失敗しました:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref が失敗しました:"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "コミット %s を作成しました: %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "ブランチ削除"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "ローカル・ブランチを削除"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "ローカル・ブランチ"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "マージ済みの時のみ削除"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "以下のブランチは %s に完全にマージされていません:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+"以下のブランチを削除できません:\n"
+"%s"
+
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "インデックスをロックできません"
+
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "索引エラー"
+
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"GIT インデックスの更新が失敗しました。git-gui と同期をとるために再スキャンし"
+"ます。"
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "続行"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "インデックスのロック解除"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "コミットから '%s' を降ろす"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "コミットから '%s' を降ろす"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "コミット準備完了"
+
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "選択されたファイルにした変更を元に戻します"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "コミットに %s を加えています"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr "管理外の %d ファイルをコミット予定としますか？"
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "ファイル %s にした変更を元に戻しますか？"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "これら %i 個のファイルにした変更を元に戻しますか？"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr "変更を元に戻すとコミット予定していない変更は全て失われます。"
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "何もしない"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "管理外の %d ファイルをコミット予定としますか？"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "管理外の %d ファイルをコミット予定としますか？"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "削除"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "選択されたファイルにした変更を元に戻します"
+
+#: lib/index.tcl:532
+#, tcl-format
+msgid "Reverting %s"
+msgstr "%s にした変更を元に戻します"
+
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "デフォールト"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr "システム (%s)"
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "その他"
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Git から出た無効な日付: %s"
+
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "分離されたチェックアウト"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "リビジョン式:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "ローカル・ブランチ"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "トラッキング・ブランチ"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "タグ"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "無効なリビジョン: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "リビジョンが未選択です。"
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "リビジョン式が空です。"
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "更新しました"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "ばらばらなオブジェクトの数"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "ばらばらなオブジェクトの使用するディスク量"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "パックされたオブジェクトの数"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "パックの数"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "パックされたオブジェクトの使用するディスク量"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "パックに存在するので捨てて良いオブジェクトの数"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "ゴミファイル"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "データベース統計"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "データベース圧縮"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "fsck-objects でオブジェクト・データベースを検証しています"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"このリポジトリにはおおよそ %i 個の個別オブジェクトがあります\n"
+"\n"
+"最適な性能を保つために、データベースを圧縮することを推奨します\n"
+"\n"
+"データベースを圧縮しますか？"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "エラー"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "警告"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "ツールが失敗しました: %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "コミットする前に、以上のエラーを修正して下さい"
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* 管理外のファイルの大きさは %d バイトです。\n"
+#~ "* 最初の %d バイトだけ表示しています。\n"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,57 +1,58 @@
 # Norwegian (Bokmål) translation of git-gui.
 # Copyright (C) 2007-2008 Shawn Pearce, et al.
 # This file is distributed under the same license as the git-gui package.
-#
+# 
 # Fredrik Skolmli <fredrik@frsk.net>, 2008.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: nb\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-11-16 13:56-0800\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2008-12-03 16:05+0100\n"
 "Last-Translator: Fredrik Skolmli <fredrik@frsk.net>\n"
 "Language-Team: Norwegian Bokmål\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:41 git-gui.sh:737 git-gui.sh:751 git-gui.sh:764 git-gui.sh:847
-#: git-gui.sh:866
-msgid "git-gui: fatal error"
-msgstr "git-gui: Kritisk feil"
-
-#: git-gui.sh:689
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Ugyldig font spesifisert i %s:"
 
-#: git-gui.sh:723
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Hovedskrifttype"
 
-#: git-gui.sh:724
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Diff-/Konsollskrifttype"
 
-#: git-gui.sh:738
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: Kritisk feil"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Kan ikke finne git i PATH"
 
-#: git-gui.sh:765
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Kan ikke tyde Git's oppgitte versjon:"
 
-#: git-gui.sh:783
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Kan ikke avgjøre hvilken Git-versjon du har.\n"
 "\n"
@@ -61,798 +62,591 @@ msgstr ""
 "\n"
 "Anta at '%s' er versjon 1.5.0?\n"
 
-#: git-gui.sh:1062
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Git-katalog ikke funnet:"
 
-#: git-gui.sh:1069
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Kan ikke gå til toppen av arbeidskatalogen:"
 
-#: git-gui.sh:1076
-msgid "Cannot use funny .git directory:"
-msgstr ""
+#: git-gui.sh:1309
+#, fuzzy
+msgid "Cannot use bare repository:"
+msgstr "Opprett nytt arkiv"
 
-#: git-gui.sh:1081
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Ingen arbeidskatalog"
 
-#: git-gui.sh:1247 lib/checkout_op.tcl:305
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Oppdaterer filstatus..."
 
-#: git-gui.sh:1303
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Søker etter endrede filer..."
 
-#: git-gui.sh:1367
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr ""
 
-#: git-gui.sh:1384
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr ""
 
-#: git-gui.sh:1542 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Klar."
 
-#: git-gui.sh:1819
+#: git-gui.sh:1966
+#, tcl-format
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
+
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Uendret"
 
-#: git-gui.sh:1821
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Endret, ikke køet"
 
-#: git-gui.sh:1822 git-gui.sh:1830
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Køet for innsjekking"
 
-#: git-gui.sh:1823 git-gui.sh:1831
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Delvis køet for innsjekking"
 
-#: git-gui.sh:1824 git-gui.sh:1832
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Klar for innsjekking, fraværende"
 
-#: git-gui.sh:1826
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Filtype endret, ikke køet"
 
-#: git-gui.sh:1827
+#: git-gui.sh:2097 git-gui.sh:2098
+#, fuzzy
+msgid "File type changed, old type staged for commit"
+msgstr "Filtype endret, ikke køet"
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Filtype endret, køet"
 
-#: git-gui.sh:1829
+#: git-gui.sh:2100
+#, fuzzy
+msgid "File type change staged, modification not staged"
+msgstr "Filtype endret, ikke køet"
+
+#: git-gui.sh:2101
+#, fuzzy
+msgid "File type change staged, file missing"
+msgstr "Filtype endret, køet"
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Usporet, ikke køet"
 
-#: git-gui.sh:1834
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Fraværende"
 
-#: git-gui.sh:1835
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Køet for fjerning"
 
-#: git-gui.sh:1836
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Køet for fjerning, fortsatt tilstede"
 
-#: git-gui.sh:1838 git-gui.sh:1839 git-gui.sh:1840 git-gui.sh:1841
-#: git-gui.sh:1842 git-gui.sh:1843
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Sammenslåingen krever konflikthåndtering"
 
-#: git-gui.sh:1878
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Starter gitk... Vennligst vent..."
 
-#: git-gui.sh:1887
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Kunne ikke finne gitk i PATH"
 
-#: git-gui.sh:2280 lib/choose_repository.tcl:36
+#: git-gui.sh:2223
+#, fuzzy
+msgid "Couldn't find git gui in PATH"
+msgstr "Kunne ikke finne gitk i PATH"
+
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Arkiv"
 
-#: git-gui.sh:2281
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Redigere"
 
-#: git-gui.sh:2283 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Gren"
 
-#: git-gui.sh:2286 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Innsjekking"
 
-#: git-gui.sh:2289 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Sammenslåing"
 
-#: git-gui.sh:2290 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Fjernarkiv"
 
-#: git-gui.sh:2293
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Verktøy"
 
-#: git-gui.sh:2302
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Utforsk arbeidskopien"
 
-#: git-gui.sh:2307
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Utforsk denne grens filer"
 
-#: git-gui.sh:2311
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Bla igjennom filer på gren..."
 
-#: git-gui.sh:2316
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Visualiser denne grens historikk"
 
-#: git-gui.sh:2320
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Visualiser alle greners historikk"
 
-#: git-gui.sh:2327
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Bla i filene til %s"
 
-#: git-gui.sh:2329
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Visualiser historien til %s"
 
-#: git-gui.sh:2334 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Databasestatistikk"
 
-#: git-gui.sh:2337 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Kompress databasen"
 
-#: git-gui.sh:2340
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Verifiser databasen"
 
-#: git-gui.sh:2347 git-gui.sh:2351 git-gui.sh:2355 lib/shortcut.tcl:7
-#: lib/shortcut.tcl:39 lib/shortcut.tcl:71
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Lag skrivebordsikon"
 
-#: git-gui.sh:2363 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Avslutt"
 
-#: git-gui.sh:2371
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Angre"
 
-#: git-gui.sh:2374
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Gjør om"
 
-#: git-gui.sh:2378 git-gui.sh:2923
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: git-gui.sh:2381 git-gui.sh:2926 git-gui.sh:3000 git-gui.sh:3082
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Kopier"
 
-#: git-gui.sh:2384 git-gui.sh:2929
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Lim inn"
 
-#: git-gui.sh:2387 git-gui.sh:2932 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Slett"
 
-#: git-gui.sh:2391 git-gui.sh:2936 git-gui.sh:3086 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Velg alle"
 
-#: git-gui.sh:2400
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Opprett..."
 
-#: git-gui.sh:2406
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Sjekk ut..."
 
-#: git-gui.sh:2412
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Endre navn..."
 
-#: git-gui.sh:2417
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Slett..."
 
-#: git-gui.sh:2422
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Tilbakestill..."
 
-#: git-gui.sh:2432
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Ferdig"
 
-#: git-gui.sh:2434
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Sjekk inn"
 
-#: git-gui.sh:2443 git-gui.sh:2864
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Ny innsjekking"
 
-#: git-gui.sh:2451 git-gui.sh:2871
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Legg til forrige innsjekking"
 
-#: git-gui.sh:2461 git-gui.sh:2825 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Søk på ny"
 
-#: git-gui.sh:2467
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Legg til i innsjekkingskøen"
 
-#: git-gui.sh:2473
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Legg til endrede filer i innsjekkingskøen"
 
-#: git-gui.sh:2479
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Fjern fra innsjekkingskøen"
 
-#: git-gui.sh:2484 lib/index.tcl:410
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Tilbakestill endringer"
 
-#: git-gui.sh:2491 git-gui.sh:3069
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Vis mindre innhold"
 
-#: git-gui.sh:2495 git-gui.sh:3073
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Vis mer innhold"
 
-#: git-gui.sh:2502 git-gui.sh:2838 git-gui.sh:2947
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Signér"
 
-#: git-gui.sh:2518
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Lokal sammenslåing..."
 
-#: git-gui.sh:2523
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Avbryt sammenslåing..."
 
-#: git-gui.sh:2535 git-gui.sh:2575
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Legg til..."
 
-#: git-gui.sh:2539
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Send..."
 
-#: git-gui.sh:2543
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Fjern gren..."
 
-#: git-gui.sh:2553 git-gui.sh:2589 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2944 git-gui.sh:3577
+msgid "Options..."
+msgstr "Alternativer..."
+
+#: git-gui.sh:2955
+msgid "Remove..."
+msgstr "Fjern..."
+
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
+msgid "Help"
+msgstr "Hjelp"
+
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Om %s"
 
-#: git-gui.sh:2557
-msgid "Preferences..."
-msgstr "Innstillinger..."
-
-#: git-gui.sh:2565 git-gui.sh:3115
-msgid "Options..."
-msgstr "Alternativer..."
-
-#: git-gui.sh:2576
-msgid "Remove..."
-msgstr "Fjern..."
-
-#: git-gui.sh:2585 lib/choose_repository.tcl:50
-msgid "Help"
-msgstr "Hjelp"
-
-#: git-gui.sh:2611
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Online dokumentasjon"
 
-#: git-gui.sh:2614 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Vis SSH-nøkkel"
 
-#: git-gui.sh:2707
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "feil"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "kritisk: kunne ikke finne status for sti %s: Ingen slik fil eller katalog"
 
-#: git-gui.sh:2740
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Nåværende gren:"
 
-#: git-gui.sh:2761
-msgid "Staged Changes (Will Commit)"
-msgstr "Køede endringer (til innsjekking)"
-
-#: git-gui.sh:2781
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Ukøede endringer"
 
-#: git-gui.sh:2831
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Køede endringer (til innsjekking)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Kø endret"
 
-#: git-gui.sh:2850 lib/transport.tcl:93 lib/transport.tcl:182
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Send"
 
-#: git-gui.sh:2885
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Innledende innsjekkingsmelding:"
 
-#: git-gui.sh:2886
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Utdypt innsjekkingsmelding"
 
-#: git-gui.sh:2887
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Utdypt innledende innsjekkingsmelding:"
 
-#: git-gui.sh:2888
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Utdypt innsjekkingsmelding for sammenslåing:"
 
-#: git-gui.sh:2889
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Revisjonsmelding for sammenslåing:"
 
-#: git-gui.sh:2890
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Revisjonsmelding:"
 
-#: git-gui.sh:2939 git-gui.sh:3090 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Kopier alle"
 
-#: git-gui.sh:2963 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Fil:"
 
-#: git-gui.sh:3078
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Oppdater"
 
-#: git-gui.sh:3099
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Gjør teksten mindre"
 
-#: git-gui.sh:3103
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Gjør teksten større"
 
-#: git-gui.sh:3111 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Tekstkoding"
 
-#: git-gui.sh:3122
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Bruk/tilbakestill del"
 
-#: git-gui.sh:3127
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Bruk/tilbakestill linje"
 
-#: git-gui.sh:3137
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Start sammenslåingsprosess"
 
-#: git-gui.sh:3142
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Bruk versjon fra fjernarkiv"
 
-#: git-gui.sh:3146
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Bruk lokal versjon"
 
-#: git-gui.sh:3150
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Tilbakestill til baseversjonen"
 
-#: git-gui.sh:3169
+#: git-gui.sh:3639
+msgid "Visualize These Changes In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3643
+#, fuzzy
+msgid "Visualize Current Branch History In The Submodule"
+msgstr "Visualiser denne grens historikk"
+
+#: git-gui.sh:3647
+#, fuzzy
+msgid "Visualize All Branch History In The Submodule"
+msgstr "Visualiser alle greners historikk"
+
+#: git-gui.sh:3652
+msgid "Start git gui In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Fjern delen fra innsjekkingskøen"
 
-#: git-gui.sh:3170
+#: git-gui.sh:3689
+#, fuzzy
+msgid "Unstage Lines From Commit"
+msgstr "Fjern linjen fra innsjekkingskøen"
+
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Fjern linjen fra innsjekkingskøen"
 
-#: git-gui.sh:3172
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Legg del i innsjekkingskøen"
 
-#: git-gui.sh:3173
+#: git-gui.sh:3696
+#, fuzzy
+msgid "Stage Lines For Commit"
+msgstr "Legg til linje i innsjekkingskøen"
+
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Legg til linje i innsjekkingskøen"
 
-#: git-gui.sh:3196
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Initsialiserer..."
 
-#: git-gui.sh:3301
+#: git-gui.sh:3868
 #, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 
-#: git-gui.sh:3331
+#: git-gui.sh:3897
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 
-#: git-gui.sh:3336
+#: git-gui.sh:3902
 #, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - Et grafisk brukergrensesnitt for Git."
-
-#: lib/blame.tcl:72
-msgid "File Viewer"
-msgstr "Filviser"
-
-#: lib/blame.tcl:78
-msgid "Commit:"
-msgstr "Innsjekking:"
-
-#: lib/blame.tcl:271
-msgid "Copy Commit"
-msgstr "Kopier innsjekking"
-
-#: lib/blame.tcl:275
-msgid "Find Text..."
-msgstr "Søk etter tekst..."
-
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr "Gjennomfør full deteksjon av kopieringer"
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr "Vis historikkens innhold"
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
 
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Leser %s..."
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
 
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr ""
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Jobber... Vennligst vent..."
 
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr ""
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Lukk"
 
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr ""
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Suksess"
 
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr "Opptatt"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Feil: Kommandoen feilet"
 
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr ""
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr "Kjører kopidetektering..."
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr ""
-
-#: lib/blame.tcl:964
-msgid "Author:"
-msgstr "Forfatter:"
-
-#: lib/blame.tcl:968
-msgid "Committer:"
-msgstr "Innsjekker:"
-
-#: lib/blame.tcl:973
-msgid "Original File:"
-msgstr "Opprinnelig fil:"
-
-#: lib/blame.tcl:1021
-msgid "Cannot find HEAD commit:"
-msgstr "Finner ikke HEAD's innsjekking:"
-
-#: lib/blame.tcl:1076
-msgid "Cannot find parent commit:"
-msgstr "Kan ikke finne innsjekkingens forelder:"
-
-#: lib/blame.tcl:1091
-msgid "Unable to display parent"
-msgstr "Kan ikke vise forelder"
-
-#: lib/blame.tcl:1092 lib/diff.tcl:297
-msgid "Error loading diff:"
-msgstr "Feil ved innlasting av forskjell:"
-
-#: lib/blame.tcl:1232
-msgid "Originally By:"
-msgstr "Opprinnelig av:"
-
-#: lib/blame.tcl:1238
-msgid "In File:"
-msgstr "I fil:"
-
-#: lib/blame.tcl:1243
-msgid "Copied Or Moved Here By:"
-msgstr "Kopiert eller flyttet hit av:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Sjekk ut gren"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Utsjekking"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:544 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:97
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr "Revisjon"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr "Valg"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Hent sporet gren"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Koble bort lokal gren"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Opprett gren"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Opprett ny gren"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:377
-msgid "Create"
-msgstr "Opprett"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Navn på gren"
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr "Navn:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Bruk navn på sporet gren"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Starter revisjon"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Oppdater eksisterende gren:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Nei"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Kun hurtigfremspoling"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:536
-msgid "Reset"
-msgstr "Tilbakestill"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Sjekk ut etter oppretting"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Velg en gren som skal følges."
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "Den fulgte grenen %s er ikke en gren i fjernarkivet."
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Angi et navn for grenen."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "'%s' kan ikke brukes som navn på en gren."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Fjern gren"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Fjern lokal gren"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Lokale grener"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Fjern kun ved sammenslåing"
-
-#: lib/branch_delete.tcl:54
-msgid "Always (Do not perform merge test.)"
-msgstr "Alltid (Ikke utfør sammenslåingstest.)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Følgende grener er ikke fullstendig slått sammen med %s:"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-"Kunne ikke fjerne grener:\n"
-"%s"
-
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Gi gren nytt navn"
-
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Endre navn"
-
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Gren:"
-
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Nytt navn:"
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Vennligst velg grenen du vil endre navn på."
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:201
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "Grenen '%s' eksisterer allerede."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Kunne ikke endre navnet '%s'."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Starter..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "Utforsker"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Laster %s..."
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[Opp til forelder]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "Bla igjennom grenens filer"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:394
-#: lib/choose_repository.tcl:480 lib/choose_repository.tcl:491
-#: lib/choose_repository.tcl:995
-msgid "Browse"
-msgstr "Bla igjennom"
-
-#: lib/checkout_op.tcl:84
+#: lib/checkout_op.tcl:85
 #, tcl-format
 msgid "Fetching %s from %s"
 msgstr "Henter %s fra %s"
 
-#: lib/checkout_op.tcl:132
+#: lib/checkout_op.tcl:133
 #, tcl-format
 msgid "fatal: Cannot resolve %s"
 msgstr "kritisk: Kan ikke åpne %s"
 
-#: lib/checkout_op.tcl:145 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr "Lukk"
-
-#: lib/checkout_op.tcl:174
+#: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
 msgstr "Grenen '%s' eksisterer ikke."
 
-#: lib/checkout_op.tcl:193
+#: lib/checkout_op.tcl:194
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Kunne ikke konfigurere forenklet git-pull for '%s'."
 
-#: lib/checkout_op.tcl:228
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "Grenen '%s' eksisterer allerede."
+
+#: lib/checkout_op.tcl:229
 #, tcl-format
 msgid ""
 "Branch '%s' already exists.\n"
@@ -865,824 +659,324 @@ msgstr ""
 "Den kan ikke hurtigfremspoles til %s.\n"
 "En sammenslåing er påkrevd."
 
-#: lib/checkout_op.tcl:242
+#: lib/checkout_op.tcl:243
 #, tcl-format
 msgid "Merge strategy '%s' not supported."
 msgstr "Sammenslåingsstrategien '%s' er ikke støttet."
 
-#: lib/checkout_op.tcl:261
+#: lib/checkout_op.tcl:262
 #, tcl-format
 msgid "Failed to update '%s'."
 msgstr "Kunne ikke oppdatere '%s'."
 
-#: lib/checkout_op.tcl:273
+#: lib/checkout_op.tcl:274
 msgid "Staging area (index) is already locked."
 msgstr "Køområdet (index) er allerede låst."
 
-#: lib/checkout_op.tcl:288
+#: lib/checkout_op.tcl:289
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 
-#: lib/checkout_op.tcl:344
+#: lib/checkout_op.tcl:345
 #, tcl-format
 msgid "Updating working directory to '%s'..."
 msgstr "Oppdaterer arbeidskatalogen til '%s'..."
 
-#: lib/checkout_op.tcl:345
+#: lib/checkout_op.tcl:346
 msgid "files checked out"
 msgstr "filer sjekket ut"
 
-#: lib/checkout_op.tcl:375
+#: lib/checkout_op.tcl:376
 #, tcl-format
 msgid "Aborted checkout of '%s' (file level merging is required)."
 msgstr "Avbrøt utsjekkingen av '%s' (sammenslåing på filnivå kreves)."
 
-#: lib/checkout_op.tcl:376
+#: lib/checkout_op.tcl:377
 msgid "File level merge required."
 msgstr "Sammenslåing på filnivå kreves"
 
-#: lib/checkout_op.tcl:380
+#: lib/checkout_op.tcl:381
 #, tcl-format
 msgid "Staying on branch '%s'."
 msgstr "Blir stående på grenen '%s'."
 
-#: lib/checkout_op.tcl:451
+#: lib/checkout_op.tcl:452
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
 
-#: lib/checkout_op.tcl:468 lib/checkout_op.tcl:472
+#: lib/checkout_op.tcl:503 lib/checkout_op.tcl:507
 #, tcl-format
 msgid "Checked out '%s'."
 msgstr "Sjekket ut '%s'."
 
-#: lib/checkout_op.tcl:500
+#: lib/checkout_op.tcl:535
 #, tcl-format
 msgid "Resetting '%s' to '%s' will lose the following commits:"
 msgstr ""
 "Tilbakestilling av '%s' til '%s' vil medføre tap av følgende innsjekkinger:"
 
-#: lib/checkout_op.tcl:522
+#: lib/checkout_op.tcl:557
 msgid "Recovering lost commits may not be easy."
 msgstr ""
 "Det vil kanskje ikke være så enkelt å gjenopprette en tapt innsjekking."
 
-#: lib/checkout_op.tcl:527
+#: lib/checkout_op.tcl:562
 #, tcl-format
 msgid "Reset '%s'?"
 msgstr "Tilbakestill '%s'?"
 
-#: lib/checkout_op.tcl:532 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Visualiser"
 
-#: lib/checkout_op.tcl:600
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Tilbakestill"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: lib/checkout_op.tcl:635
 #, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Velg"
-
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Skrifttype-familie"
-
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Skriftstørrelse"
-
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Skrifteksempel"
-
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
-msgstr ""
-"Dette er en eksempeltekst.\n"
-"Hvis du liker hvordan teksten ser ut, kan du velge dette som din skrifttype."
-
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
-
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:382
-msgid "Create New Repository"
-msgstr "Opprett nytt arkiv"
-
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr "Ny..."
-
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:465
-msgid "Clone Existing Repository"
-msgstr "Klon eksistererende arkiv"
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr "Klon..."
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:983
-msgid "Open Existing Repository"
-msgstr "Åpne eksistererende arkiv"
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr "Åpne..."
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr "Nylig brukte arkiv"
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr "Åpne nylig brukt arkiv:"
-
-#: lib/choose_repository.tcl:302 lib/choose_repository.tcl:309
-#: lib/choose_repository.tcl:316
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
 #, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Kunne ikke opprette arkivet %s:"
+msgid "fetch %s"
+msgstr "hent %s"
 
-#: lib/choose_repository.tcl:387
-msgid "Directory:"
-msgstr "Mappe:"
-
-#: lib/choose_repository.tcl:417 lib/choose_repository.tcl:544
-#: lib/choose_repository.tcl:1017
-msgid "Git Repository"
-msgstr "Git arkiv"
-
-#: lib/choose_repository.tcl:442
+#: lib/transport.tcl:7
 #, tcl-format
-msgid "Directory %s already exists."
-msgstr "Mappen %s eksisterer allerede."
+msgid "Fetching new changes from %s"
+msgstr "Henter nye endringer fra %s"
 
-#: lib/choose_repository.tcl:446
+#: lib/transport.tcl:18
 #, tcl-format
-msgid "File %s already exists."
-msgstr "Filen %s eksisterer allerede."
+msgid "remote prune %s"
+msgstr "slett fjernarkiv %s"
 
-#: lib/choose_repository.tcl:460
-msgid "Clone"
-msgstr "Klon"
-
-#: lib/choose_repository.tcl:473
-msgid "Source Location:"
-msgstr "Kildeplassering:"
-
-#: lib/choose_repository.tcl:484
-msgid "Target Directory:"
-msgstr "Destinasjonsmappe:"
-
-#: lib/choose_repository.tcl:496
-msgid "Clone Type:"
-msgstr "Klontype:"
-
-#: lib/choose_repository.tcl:502
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Standard (rask, delvis redundant, hardlinker)"
-
-#: lib/choose_repository.tcl:508
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Full kopi (tregere, redundant sikkerhetskopi)"
-
-#: lib/choose_repository.tcl:514
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Delt (raskest, ikke anbefalt, ingen sikkerhetskopiering)"
-
-#: lib/choose_repository.tcl:550 lib/choose_repository.tcl:597
-#: lib/choose_repository.tcl:743 lib/choose_repository.tcl:813
-#: lib/choose_repository.tcl:1023 lib/choose_repository.tcl:1031
+#: lib/transport.tcl:19
 #, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Ikke et Git-arkiv: %s"
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Fjrner sporing av grener slettet fra %s"
 
-#: lib/choose_repository.tcl:586
-msgid "Standard only available for local repository."
-msgstr "Standard er kun tilgjengelig for lokalt arkiv."
-
-#: lib/choose_repository.tcl:590
-msgid "Shared only available for local repository."
-msgstr "Delt er kun tilgjengelig for lokalt arkiv."
-
-#: lib/choose_repository.tcl:611
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "Stedet %s eksisterer allerede."
-
-#: lib/choose_repository.tcl:622
-msgid "Failed to configure origin"
-msgstr "Kunne ikke konfigurere kildeoppføring"
-
-#: lib/choose_repository.tcl:634
-msgid "Counting objects"
-msgstr "Teller objekter"
-
-#: lib/choose_repository.tcl:635
-msgid "buckets"
-msgstr "bøtter"
-
-#: lib/choose_repository.tcl:659
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Kunne ikke kopiere objekter/informasjon/alternativt: %s"
-
-#: lib/choose_repository.tcl:695
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Ingenting å klone fra %s."
-
-#: lib/choose_repository.tcl:697 lib/choose_repository.tcl:911
-#: lib/choose_repository.tcl:923
-msgid "The 'master' branch has not been initialized."
-msgstr "Grenen 'master' har ikke blitt initsialisert."
-
-#: lib/choose_repository.tcl:710
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Harde linker er utilgjengelig. Går tilbake til kopiering."
-
-#: lib/choose_repository.tcl:722
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Kloner fra %s"
-
-#: lib/choose_repository.tcl:753
-msgid "Copying objects"
-msgstr "Kopierer objekter"
-
-#: lib/choose_repository.tcl:754
-msgid "KiB"
-msgstr "kB"
-
-#: lib/choose_repository.tcl:778
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Kunne ikke kopiere objekt: %s"
-
-#: lib/choose_repository.tcl:788
-msgid "Linking objects"
-msgstr "Lenker objekter"
-
-#: lib/choose_repository.tcl:789
-msgid "objects"
-msgstr "objekter"
-
-#: lib/choose_repository.tcl:797
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Kunne ikke opprette hardlink med objektet: %s"
-
-#: lib/choose_repository.tcl:852
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr "Kunne ikke hente grener og objekter. Se utdata i konsoll for detaljer."
-
-#: lib/choose_repository.tcl:863
-msgid "Cannot fetch tags.  See console output for details."
-msgstr "Kunne ikke hente tagger. Se utdata i konsoll for detaljer."
-
-#: lib/choose_repository.tcl:887
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr "Kan ikke bestemme HEAD. Se utdata i konsoll for detaljer."
-
-#: lib/choose_repository.tcl:896
-#, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Kunne ikke rydde opp %s"
-
-#: lib/choose_repository.tcl:902
-msgid "Clone failed."
-msgstr "Kloning feilet."
-
-#: lib/choose_repository.tcl:909
-msgid "No default branch obtained."
-msgstr "Ingen standardgren hentet."
-
-#: lib/choose_repository.tcl:920
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Kan ikke finne %s som en innsjekking."
-
-#: lib/choose_repository.tcl:932
-msgid "Creating working directory"
-msgstr "Oppretter arbeidskatalog"
-
-#: lib/choose_repository.tcl:933 lib/index.tcl:65 lib/index.tcl:128
-#: lib/index.tcl:196
-msgid "files"
-msgstr "filer"
-
-#: lib/choose_repository.tcl:962
-msgid "Initial file checkout failed."
-msgstr "Initsialiserende utsjekking feilet."
-
-#: lib/choose_repository.tcl:978
-msgid "Open"
-msgstr "Åpne"
-
-#: lib/choose_repository.tcl:988
-msgid "Repository:"
-msgstr "Arkiv:"
-
-#: lib/choose_repository.tcl:1037
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Kunne ikke åpne arkivet %s:"
-
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "Denne frakoblede utsjekkingen"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Revisjonsuttrykk:"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Lokal gren"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Sporet gren"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Tag"
-
-#: lib/choose_rev.tcl:317
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Ugyldig revisjon: %s"
-
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Ingen revisjoner valgt."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "Revisjonsuttrykk er tomt."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Oppdatert"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"Det er ingenting å legge til.\n"
-"\n"
-"Du er i ferd med å lage den initsialiserende revisjonen. Det er ingen "
-"tidligere revisjoner å tilføye.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Kan ikke tilføye under sammenslåing.\n"
-"\n"
-"Du er for øyeblikket under en pågående sammenslåing som ikke er fullført. Du "
-"kan ikke tilføye en tidligere revisjon med mindre du først avbryter denne "
-"sammenslåingen.\n"
-
-#: lib/commit.tcl:49
-msgid "Error loading commit data for amend:"
-msgstr "Feil ved innhenting av revisjonsdata for tilføying:"
-
-#: lib/commit.tcl:76
-msgid "Unable to obtain your identity:"
-msgstr "Kunne ikke avgjøre din identitet:"
-
-#: lib/commit.tcl:81
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Ugyldig GIT_COMMITTER_IDENT:"
-
-#: lib/commit.tcl:133
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
 
-#: lib/commit.tcl:156
+#: lib/transport.tcl:26
+#, fuzzy
+msgid "Fetching new changes from all remotes"
+msgstr "Henter nye endringer fra %s"
+
+#: lib/transport.tcl:40
+#, fuzzy
+msgid "remote prune all remotes"
+msgstr "slett fjernarkiv %s"
+
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Fjrner sporing av grener slettet fra %s"
+
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
+msgid "push %s"
+msgstr "send %s"
+
+#: lib/transport.tcl:55
+#, tcl-format
+msgid "Pushing changes to %s"
+msgstr "Sender endringer til %s"
+
+#: lib/transport.tcl:93
+#, fuzzy, tcl-format
+msgid "Mirroring to %s"
+msgstr "Slå sammen inn i %s"
+
+#: lib/transport.tcl:111
+#, tcl-format
+msgid "Pushing %s %s to %s"
+msgstr "Sender %s %s til %s"
+
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Send grener"
+
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Kildegrener"
+
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Destinasjonsarkiv"
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Fjernarkiv:"
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Vilkårlig lokasjon:"
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Overføringsalternativer"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr "Tving overskrivning av eksisterende gren (kan forkaste endringer)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Bruk tynne pakker (for tregere nettverkstilkoblinger)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Inkluder tagger"
+
+#: lib/transport.tcl:229
+#, tcl-format
+msgid "%s (%s): Push"
 msgstr ""
 
-#: lib/commit.tcl:164
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "Legg til fjernarkiv"
+
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Legg til nytt fjernarkiv"
+
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Legg til"
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Detaljer for fjernarkiv"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Navn:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Lokasjon:"
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Videre handling"
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Hent umiddelbart"
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Initsialiser og send til fjernarkiv"
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr "Ikke gjør mer nå"
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Vennligst angi et navn for fjernarkivet."
+
+#: lib/remote_add.tcl:113
 #, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Ukjent filstatus %s er funnet.\n"
-"\n"
-"Filen %s kan ikke sjekkes inn av dette programmet.\n"
+msgid "'%s' is not an acceptable remote name."
+msgstr "'%s' er ikke et tillatt navn for et fjernarkiv."
 
-#: lib/commit.tcl:172
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Ingen endringer å sjekke inn.\n"
-"\n"
-"Du må køe minst en fil før du kan sjekke inn noe.\n"
-
-#: lib/commit.tcl:187
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Vennligst angi en revisjonsmelding.\n"
-"\n"
-"En god melding har følgende format:\n"
-"\n"
-"- Første linje: En beskrivelse av hva du har gjort i én setning.\n"
-"- Andre linje: Blank\n"
-"- Resterende linjer: Forklar hvorfor denne endringen er bra.\n"
-
-#: lib/commit.tcl:211
+#: lib/remote_add.tcl:124
 #, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "advarsel: Tcl støtter ikke denne tegnkodingen '%s'."
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Kunne ikke legge til fjernarkivet '%s' på '%s'."
 
-#: lib/commit.tcl:227
-msgid "Calling pre-commit hook..."
-msgstr ""
-
-#: lib/commit.tcl:242
-msgid "Commit declined by pre-commit hook."
-msgstr ""
-
-#: lib/commit.tcl:265
-msgid "Calling commit-msg hook..."
-msgstr ""
-
-#: lib/commit.tcl:280
-msgid "Commit declined by commit-msg hook."
-msgstr ""
-
-#: lib/commit.tcl:293
-msgid "Committing changes..."
-msgstr "Sjekker inn endringer..."
-
-#: lib/commit.tcl:309
-msgid "write-tree failed:"
-msgstr "Skriving til tre feilet:"
-
-#: lib/commit.tcl:310 lib/commit.tcl:354 lib/commit.tcl:374
-msgid "Commit failed."
-msgstr "Innsjekking feilet."
-
-#: lib/commit.tcl:327
+#: lib/remote_add.tcl:133
 #, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Revisjon %s ser ut til å være korrupt"
+msgid "Fetching the %s"
+msgstr "Henter %s"
 
-#: lib/commit.tcl:332
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Ingen endringer til innsjekking.\n"
-"\n"
-"Ingen filer ble endret av denne revisjonen, og det var ikke en revisjon fra "
-"en sammenslåing.\n"
-"\n"
-"Et nytt søk vil bli startet automatisk.\n"
-
-#: lib/commit.tcl:339
-msgid "No changes to commit."
-msgstr "Ingen endringer til innsekking."
-
-#: lib/commit.tcl:353
-msgid "commit-tree failed:"
-msgstr "commit-tree feilet:"
-
-#: lib/commit.tcl:373
-msgid "update-ref failed:"
-msgstr "update-ref feilet:"
-
-#: lib/commit.tcl:461
+#: lib/remote_add.tcl:156
 #, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Opprettet innsjekking %s: %s"
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "Vet ikke hvordan arkiv på '%s' skal opprettes."
 
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Jobber... Vennligst vent..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Suksess"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Feil: Kommandoen feilet"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Antall løse objekter"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Diskplass brukt av løse objekter"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Antall pakkede objekter"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Antall pakker"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "Diskplass brukt av pakkede objekter"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Pakkede objekter som avventer fjerning"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "Avfallsfiler"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Komprimerer objektdatabasen"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Verifiserer objektdatabasen med fsck-objects"
-
-#: lib/database.tcl:108
+#: lib/remote_add.tcl:163
 #, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database when more than %i loose objects exist.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Dette arkivet inneholder omtrent %i 'løse' objekter.\n"
-"\n"
-"For å sikre en optimal ytelse er det sterkt anbefalt at du komprimerer "
-"databasen når det er flere enn %i 'løse' objekter i den.\n"
-"\n"
-"Komprimere databasen nå?"
+msgid "Setting up the %s (at %s)"
+msgstr "Initsialiserer %s (på %s)"
 
-#: lib/date.tcl:25
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Starter..."
+
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Utforsker"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
 #, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Ugyldig dato fra Git: %s"
+msgid "Loading %s..."
+msgstr "Laster %s..."
 
-#: lib/diff.tcl:59
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Ingen forandringer funnet.\n"
-"\n"
-"%s har ingen endringer.\n"
-"\n"
-"Tidsstempelet for endring på denne filen ble oppdatert av en annen "
-" applikasjon, men innholdet er uendret.\n"
-"\n"
-"En gjennomsøking vil nå starte automatisk for å se om andre filer har "
-"status."
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Opp til forelder]"
 
-#: lib/diff.tcl:99
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Laster inn forskjellene av %s..."
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Bla igjennom grenens filer"
 
-#: lib/diff.tcl:120
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr "LOKAL: slettet\n"
-"FJERN:\n"
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Bla igjennom grenens filer"
 
-#: lib/diff.tcl:125
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr "FJERN: slettet\n"
-"LOKAL:\n"
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Bla igjennom"
 
-#: lib/diff.tcl:132
-msgid "LOCAL:\n"
-msgstr "LOKAL:\n"
-
-#: lib/diff.tcl:135
-msgid "REMOTE:\n"
-msgstr "FJERN:\n"
-
-#: lib/diff.tcl:197 lib/diff.tcl:296
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Kan ikke vise %s"
-
-#: lib/diff.tcl:198
-msgid "Error loading file:"
-msgstr "Feil ved lesing av fil: %s"
-
-#: lib/diff.tcl:205
-msgid "Git Repository (subproject)"
-msgstr "Git-arkiv (underprosjekt)"
-
-#: lib/diff.tcl:217
-msgid "* Binary file (not showing content)."
-msgstr "* Binærfil (viser ikke innhold)"
-
-#: lib/diff.tcl:222
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* Usporet fil er %d bytes.\n"
-"* Viser bare %d første bytes.\n"
-
-#: lib/diff.tcl:228
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-"\n"
-"* Usporede filer klippet her av %s.\n"
-"* For å se hele filen, bruk et eksternt redigeringsverktøy.\n"
-
-#: lib/diff.tcl:436
-msgid "Failed to unstage selected hunk."
-msgstr "Kunne ikke fjerne den valgte delen fra innsjekkingskøen."
-
-#: lib/diff.tcl:443
-msgid "Failed to stage selected hunk."
-msgstr "Kunne ikke legge til den valgte delen i innsjekkingskøen."
-
-#: lib/diff.tcl:509
-msgid "Failed to unstage selected line."
-msgstr "Kunne ikke fjerne den valgte linjen fra innsjekkingskøen."
-
-#: lib/diff.tcl:517
-msgid "Failed to stage selected line."
-msgstr "Kunne ikke legge til den valgte linjen i innsjekkingskøen."
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Standard"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Systemets (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Andre"
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "feil"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "advarsel"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr "Du må rette de ovenstående feilene før innsjekking."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Kunne ikke låse opp indexen."
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Feil på index"
-
-#: lib/index.tcl:21
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"Oppdatering av Git's index mislyktes. Et nytt søk vil bli startet for å "
-"resynkronisere git-gui."
-
-#: lib/index.tcl:27
-msgid "Continue"
-msgstr "Fortsett"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Lås opp index"
-
-#: lib/index.tcl:287
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Fjerner %s fra innsjekkingskøen"
-
-#: lib/index.tcl:326
-msgid "Ready to commit."
-msgstr "Klar til innsjekking."
-
-#: lib/index.tcl:339
-#, tcl-format
-msgid "Adding %s"
-msgstr "Legger til %s"
-
-#: lib/index.tcl:396
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Reverter endringene i filen %s?"
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Reverter endringene i disse %i filene?"
-
-#: lib/index.tcl:406
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr "Endringer som ikke ligger i innsjekkingskøen vil bli tapt av denne "
-"reverteringen"
-
-#: lib/index.tcl:409
-msgid "Do Nothing"
-msgstr "Ikke gjør noe"
-
-#: lib/index.tcl:427
-msgid "Reverting selected files"
-msgstr "Reverterer valgte filer"
-
-#: lib/index.tcl:431
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Reverterer %s"
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Revisjon"
 
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Kunne ikke slå sammen under utvidelse.\n"
 "\n"
@@ -1691,94 +985,103 @@ msgstr ""
 
 #: lib/merge.tcl:27
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 
 #: lib/merge.tcl:45
 #, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 
 #: lib/merge.tcl:55
 #, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 
-#: lib/merge.tcl:107
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s av %s"
 
-#: lib/merge.tcl:120
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Slår sammen %s og %s"
 
-#: lib/merge.tcl:131
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "Vellykket sammenslåing fullført."
 
-#: lib/merge.tcl:133
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "Sammenslåing feilet. Håndtering av konflikten kreves."
 
-#: lib/merge.tcl:158
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Slå sammen inn i %s"
 
-#: lib/merge.tcl:177
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Revisjon til sammenslåing"
 
-#: lib/merge.tcl:212
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "Kan ikke avbryte under utvidelse av revisjon.\n"
 "\n"
 "Du må fullføre utvidelsen av denne revisjonen.\n"
 
-#: lib/merge.tcl:222
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Avbryt sammenslåing?\n"
 "\n"
-"Avbryting av pågående sammenslåing vil føre til at *alle* endringer som ikke "
-" er sjekket inn, vil gå tapt.\n"
+"Avbryting av pågående sammenslåing vil føre til at *alle* endringer som "
+"ikke  er sjekket inn, vil gå tapt.\n"
 "\n"
 "Fortsette med å avbryte den pågående sammenslåingen?"
 
-#: lib/merge.tcl:228
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Nullstill endringer?\n"
@@ -1788,425 +1091,81 @@ msgstr ""
 "\n"
 "Fortsette med nullstilling av endringer?"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Avbryter"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "filer tilbakestilt"
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "Avbryting feilet."
 
-#: lib/merge.tcl:269
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "Avbryting fullført. Klar."
 
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Tving håndtering til opprinnelig versjon?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Tving håndtering i denne grenen?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Tving håndtering i den andre grenen?"
-
-#: lib/mergetool.tcl:14
+#: lib/tools.tcl:76
 #, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Merk deg at endringsvisningen kun viser motstridende endringer.\n"
-"\n"
-"%s vil bli overskrevet.\n"
-"\n"
-"Denne operasjonen kan kun bli angret ved å starte sammenslåingen på ny."
+msgid "Running %s requires a selected file."
+msgstr "Å kjøre %s krever at en fil er valgt"
 
-#: lib/mergetool.tcl:45
+#: lib/tools.tcl:92
+#, fuzzy, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Er du sikker på at du vil kjøre %s?"
+
+#: lib/tools.tcl:96
 #, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr "Filen %s ser ut til å ha uløste konflikter, skal filen likevel køes?"
+msgid "Are you sure you want to run %s?"
+msgstr "Er du sikker på at du vil kjøre %s?"
 
-#: lib/mergetool.tcl:60
+#: lib/tools.tcl:118
 #, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Legger til løsninge på konflikt for %s"
+msgid "Tool: %s"
+msgstr "Verktøy: %s"
 
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "Konfliktfil eksisterer ikke"
-
-#: lib/mergetool.tcl:264
+#: lib/tools.tcl:119
 #, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr ""
+msgid "Running: %s"
+msgstr "Kjører: %s"
 
-#: lib/mergetool.tcl:268
+#: lib/tools.tcl:158
 #, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr ""
+msgid "Tool completed successfully: %s"
+msgstr "Verktøyet ble fullført med suksess: %s"
 
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr ""
-
-#: lib/mergetool.tcl:323
+#: lib/tools.tcl:160
 #, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Kunne ikke hente versjoner:\n"
-"%s"
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr ""
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr ""
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr ""
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr ""
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr "Gjennopprett standardverdier"
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr "Lagre"
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr "%s arkiv"
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr "Globalt (alle arkiv)"
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr "Navn"
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr "Epost-adresse"
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr "Oppsummer innsjekkinger fra sammenslåinger"
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr "Detaljenivå på sammenslåing"
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr "Vis endringsstatistikk etter sammenslåing"
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr "Bruk sammenslåingsverktøy"
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr "Stol på filers tid for endring"
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr ""
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr ""
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr ""
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr ""
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr ""
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr "Antall linjer sammenhengende endringer"
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr "Tekstbredde for vindu til innsjekkingsmeldinger"
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr "Mal for navn på nye grener"
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr "Standard tekstenkoding for innhold i filer"
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr "Endre"
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr "Stavebokordlister:"
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr "Endre skrifttype"
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr "Velg %s"
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr "pt."
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr "Egenskaper"
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr "Kunne ikke lagre alternativ:"
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr "Fjern fjernarkiv"
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr "Fjern fra"
-
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr "Hent fra"
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr "Send til"
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
-msgstr "Legg til fjernarkiv"
-
-#: lib/remote_add.tcl:24
-msgid "Add New Remote"
-msgstr "Legg til nytt fjernarkiv"
-
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
-msgid "Add"
-msgstr "Legg til"
-
-#: lib/remote_add.tcl:37
-msgid "Remote Details"
-msgstr "Detaljer for fjernarkiv"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Lokasjon:"
-
-#: lib/remote_add.tcl:62
-msgid "Further Action"
-msgstr "Videre handling"
-
-#: lib/remote_add.tcl:65
-msgid "Fetch Immediately"
-msgstr "Hent umiddelbart"
-
-#: lib/remote_add.tcl:71
-msgid "Initialize Remote Repository and Push"
-msgstr "Initsialiser og send til fjernarkiv"
-
-#: lib/remote_add.tcl:77
-msgid "Do Nothing Else Now"
-msgstr "Ikke gjør mer nå"
-
-#: lib/remote_add.tcl:101
-msgid "Please supply a remote name."
-msgstr "Vennligst angi et navn for fjernarkivet."
-
-#: lib/remote_add.tcl:114
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "'%s' er ikke et tillatt navn for et fjernarkiv."
-
-#: lib/remote_add.tcl:125
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Kunne ikke legge til fjernarkivet '%s' på '%s'."
-
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "hent %s"
-
-#: lib/remote_add.tcl:134
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "Henter %s"
-
-#: lib/remote_add.tcl:157
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Vet ikke hvordan arkiv på '%s' skal opprettes."
-
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:71
-#, tcl-format
-msgid "push %s"
-msgstr "send %s"
-
-#: lib/remote_add.tcl:164
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "Initsialiserer %s (på %s)"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Fjern gren fra fjernarkiv"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "Fra arkiv"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:123
-msgid "Remote:"
-msgstr "Fjernarkiv:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:138
-msgid "Arbitrary Location:"
-msgstr "Vilkårlig lokasjon:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Grener"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Slett kun hvis"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Slått sammen i:"
-
-#: lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Alltid (Ikke utfør sammenslåingskontroll)"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "En gren kreves for 'sammenslåing i'."
-
-#: lib/remote_branch_delete.tcl:184
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-"Følgende grener er ikke fullestendig sammenslått med %s:\n"
-"\n"
-" - %s"
-
-#: lib/remote_branch_delete.tcl:189
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-"En eller flere av testene som blir kjørt under sammenslåing feilet fordi du"
-"ikke har hentet inn de nødvendige innsjekkingene. Prøv å hent disse fra %s"
-"først"
-
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Velg en eller flere grener som skal fjernes."
-
-#: lib/remote_branch_delete.tcl:216
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr ""
-"Gjenoppretting av fjernede grener er vanskelig.\n"
-"\n"
-"Fjern den merkede grenen?"
-
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Fjerner grenene fra %s"
-
-#: lib/remote_branch_delete.tcl:286
-msgid "No repository selected."
-msgstr "Ingen arkiv valgt."
-
-#: lib/remote_branch_delete.tcl:291
-#, tcl-format
-msgid "Scanning %s..."
-msgstr "Søker %s..."
-
-#: lib/search.tcl:21
-msgid "Find:"
-msgstr "Finn:"
-
-#: lib/search.tcl:23
-msgid "Next"
-msgstr "Neste"
-
-#: lib/search.tcl:24
-msgid "Prev"
-msgstr "Forrige"
-
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
-msgstr "Skiller på store og små bokstaver"
-
-#: lib/shortcut.tcl:20 lib/shortcut.tcl:61
-msgid "Cannot write shortcut:"
-msgstr "Kan ikke opprette snarvei:"
-
-#: lib/shortcut.tcl:136
-msgid "Cannot write icon:"
-msgstr "Kan ikke opprette ikon:"
+msgid "Tool failed: %s"
+msgstr "Verktøy feilet: %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Sjekk ut gren"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Sjekk ut gren"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Utsjekking"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Valg"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Hent sporet gren"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Koble bort lokal gren"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -2245,6 +1204,1004 @@ msgstr "Uventet slutt på filen fra stavekontrollen"
 msgid "Spell Checker Failed"
 msgstr "Stavekontroll mislyktes"
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s ... %*i av %*i %s (%3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Ingen forandringer funnet.\n"
+"\n"
+"%s har ingen endringer.\n"
+"\n"
+"Tidsstempelet for endring på denne filen ble oppdatert av en annen  "
+"applikasjon, men innholdet er uendret.\n"
+"\n"
+"En gjennomsøking vil nå starte automatisk for å se om andre filer har status."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Laster inn forskjellene av %s..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"LOKAL: slettet\n"
+"FJERN:\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"FJERN: slettet\n"
+"LOKAL:\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "LOKAL:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "FJERN:\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Kan ikke vise %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Feil ved lesing av fil: %s"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Git-arkiv (underprosjekt)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Binærfil (viser ikke innhold)"
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* Usporede filer klippet her av %s.\n"
+"* For å se hele filen, bruk et eksternt redigeringsverktøy.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Feil ved innlasting av forskjell:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Kunne ikke fjerne den valgte delen fra innsjekkingskøen."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Kunne ikke legge til den valgte delen i innsjekkingskøen."
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Kunne ikke fjerne den valgte linjen fra innsjekkingskøen."
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Kunne ikke legge til den valgte linjen i innsjekkingskøen."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Send til"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Fjern fjernarkiv"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Fjern fra"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Hent fra"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Velg"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Skrifttype-familie"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Skriftstørrelse"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Skrifteksempel"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Dette er en eksempeltekst.\n"
+"Hvis du liker hvordan teksten ser ut, kan du velge dette som din skrifttype."
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr ""
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr ""
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Gjennopprett standardverdier"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Lagre"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "%s arkiv"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Globalt (alle arkiv)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Navn"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Epost-adresse"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "Oppsummer innsjekkinger fra sammenslåinger"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Detaljenivå på sammenslåing"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Vis endringsstatistikk etter sammenslåing"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr "Bruk sammenslåingsverktøy"
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "Stol på filers tid for endring"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr ""
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr ""
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr ""
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Nylig brukte arkiv"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr ""
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr ""
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Antall linjer sammenhengende endringer"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Tekstbredde for vindu til innsjekkingsmeldinger"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Mal for navn på nye grener"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr "Standard tekstenkoding for innhold i filer"
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr "Endre"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Stavebokordlister:"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Endre skrifttype"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "Velg %s"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "pt."
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Egenskaper"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "Kunne ikke lagre alternativ:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Tving håndtering til opprinnelig versjon?"
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Tving håndtering i denne grenen?"
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Tving håndtering i den andre grenen?"
+
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"Merk deg at endringsvisningen kun viser motstridende endringer.\n"
+"\n"
+"%s vil bli overskrevet.\n"
+"\n"
+"Denne operasjonen kan kun bli angret ved å starte sammenslåingen på ny."
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr "Filen %s ser ut til å ha uløste konflikter, skal filen likevel køes?"
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr "Legger til løsninge på konflikt for %s"
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "Konfliktfil eksisterer ikke"
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr ""
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr ""
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr ""
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Kunne ikke hente versjoner:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr ""
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr ""
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "Legg til verktøy"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "Legg til ny verktøykommando"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "Legg til globalt"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "Verktøydetaljer"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "Bruk '/'-separator for å lage undermenyer:"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "Kommando:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "Vis en dialog før start"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr "Spør brukeren om å velge en revisjon (setter $REVISION)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "Spør brukeren for ytterligere paramtere (setter $ARGS)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "Ikke vis kommandoens utdata i vinduet"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "Kjør kun om forskjellene er markert ($FILENAME er ikke tom)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "Vennligst angi et navn for dette verktøyet."
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "Verktøyet '%s' eksisterer allerede."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+"Kunne ikke legge til verktøyet:\n"
+"%s"
+
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "Fjern verktøyet"
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "Fjern verktøyskommandoen"
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "Fjern"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(Blue angir lokale verktøy til arkivet)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Systemets (%s)"
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "Kjør kommando: %s"
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "Argumenter"
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "OK"
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Finn:"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Neste"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Forrige"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Lag skrivebordsikon"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Kan ikke opprette snarvei:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Kan ikke opprette ikon:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Gi gren nytt navn"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Gi gren nytt navn"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Endre navn"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Gren:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Nytt navn:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Vennligst velg grenen du vil endre navn på."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Angi et navn for grenen."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "'%s' kan ikke brukes som navn på en gren."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Kunne ikke endre navnet '%s'."
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Fjern gren fra fjernarkiv"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Fjern gren fra fjernarkiv"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Fra arkiv"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Grener"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Slett kun hvis"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Slått sammen i:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Alltid (Ikke utfør sammenslåingskontroll)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "En gren kreves for 'sammenslåing i'."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"Følgende grener er ikke fullestendig sammenslått med %s:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"En eller flere av testene som blir kjørt under sammenslåing feilet fordi "
+"duikke har hentet inn de nødvendige innsjekkingene. Prøv å hent disse fra "
+"%sførst"
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Velg en eller flere grener som skal fjernes."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Gjenoppretting av fjernede grener er vanskelig.\n"
+"\n"
+"Fjern den merkede grenen?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Fjerner grenene fra %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Ingen arkiv valgt."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Søker %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Opprett nytt arkiv"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Ny..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Klon eksistererende arkiv"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Klon..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Åpne eksistererende arkiv"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Åpne..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Nylig brukte arkiv"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Åpne nylig brukt arkiv:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Kunne ikke opprette arkivet %s:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Opprett"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Mappe:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Git arkiv"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "Mappen %s eksisterer allerede."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Filen %s eksisterer allerede."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Klon"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Kildeplassering:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Destinasjonsmappe:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Klontype:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Standard (rask, delvis redundant, hardlinker)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Full kopi (tregere, redundant sikkerhetskopi)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Delt (raskest, ikke anbefalt, ingen sikkerhetskopiering)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Ikke et Git-arkiv: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Standard er kun tilgjengelig for lokalt arkiv."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "Delt er kun tilgjengelig for lokalt arkiv."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "Stedet %s eksisterer allerede."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Kunne ikke konfigurere kildeoppføring"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Teller objekter"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "bøtter"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Kunne ikke kopiere objekter/informasjon/alternativt: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Ingenting å klone fra %s."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "Grenen 'master' har ikke blitt initsialisert."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Harde linker er utilgjengelig. Går tilbake til kopiering."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Kloner fra %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Kopierer objekter"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "kB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Kunne ikke kopiere objekt: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Lenker objekter"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "objekter"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Kunne ikke opprette hardlink med objektet: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr "Kunne ikke hente grener og objekter. Se utdata i konsoll for detaljer."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr "Kunne ikke hente tagger. Se utdata i konsoll for detaljer."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr "Kan ikke bestemme HEAD. Se utdata i konsoll for detaljer."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Kunne ikke rydde opp %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Kloning feilet."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Ingen standardgren hentet."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Kan ikke finne %s som en innsjekking."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Oppretter arbeidskatalog"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "filer"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Kloner fra %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Initsialiserende utsjekking feilet."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Åpne"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Arkiv:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Kunne ikke åpne arkivet %s:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - Et grafisk brukergrensesnitt for Git."
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Filviser"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Innsjekking:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Kopier innsjekking"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Søk etter tekst..."
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Klon..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Gjennomfør full deteksjon av kopieringer"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Vis historikkens innhold"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr ""
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Leser %s..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr ""
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr ""
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr ""
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr ""
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Opptatt"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr ""
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Kjører kopidetektering..."
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr ""
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Forfatter:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Innsjekker:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Opprinnelig fil:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Finner ikke HEAD's innsjekking:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Kan ikke finne innsjekkingens forelder:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Kan ikke vise forelder"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Opprinnelig av:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "I fil:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Kopiert eller flyttet hit av:"
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr "Ingen nøkler funnet."
@@ -2258,19 +2215,19 @@ msgstr "Funnet en offentlig nøkkel i: %s"
 msgid "Generate Key"
 msgstr "Generer nøkkel"
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "Kopier til utklippstavlen"
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "Din offentlige OpenSSH-nøkkel"
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Genererer..."
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2281,194 +2238,543 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr "Generering feilet."
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr "Generering vellykket, men ingen nøkler er funnet."
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "Nøkkelen din ligger i: %s"
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Opprett gren"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Opprett ny gren"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Navn på gren"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Bruk navn på sporet gren"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Starter revisjon"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Oppdater eksisterende gren:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Nei"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Kun hurtigfremspoling"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Sjekk ut etter oppretting"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Velg en gren som skal følges."
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s ... %*i av %*i %s (%3i%%)"
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "Den fulgte grenen %s er ikke en gren i fjernarkivet."
 
-#: lib/tools.tcl:75
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Det er ingenting å legge til.\n"
+"\n"
+"Du er i ferd med å lage den initsialiserende revisjonen. Det er ingen "
+"tidligere revisjoner å tilføye.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Kan ikke tilføye under sammenslåing.\n"
+"\n"
+"Du er for øyeblikket under en pågående sammenslåing som ikke er fullført. Du "
+"kan ikke tilføye en tidligere revisjon med mindre du først avbryter denne "
+"sammenslåingen.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Feil ved innhenting av revisjonsdata for tilføying:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Kunne ikke avgjøre din identitet:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Ugyldig GIT_COMMITTER_IDENT:"
+
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "Å kjøre %s krever at en fil er valgt"
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "advarsel: Tcl støtter ikke denne tegnkodingen '%s'."
 
-#: lib/tools.tcl:90
-#, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Er du sikker på at du vil kjøre %s?"
+#: lib/commit.tcl:152
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
 
-#: lib/tools.tcl:110
-#, tcl-format
-msgid "Tool: %s"
-msgstr "Verktøy: %s"
-
-#: lib/tools.tcl:111
-#, tcl-format
-msgid "Running: %s"
-msgstr "Kjører: %s"
-
-#: lib/tools.tcl:149
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Verktøyet ble fullført med suksess: %s"
-
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "Verktøy feilet: %s"
-
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "Legg til verktøy"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "Legg til ny verktøykommando"
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr "Legg til globalt"
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr "Verktøydetaljer"
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "Bruk '/'-separator for å lage undermenyer:"
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr "Kommando:"
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr "Vis en dialog før start"
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr "Spør brukeren om å velge en revisjon (setter $REVISION)"
-
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "Spør brukeren for ytterligere paramtere (setter $ARGS)"
-
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr "Ikke vis kommandoens utdata i vinduet"
-
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "Kjør kun om forskjellene er markert ($FILENAME er ikke tom)"
-
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr "Vennligst angi et navn for dette verktøyet."
-
-#: lib/tools_dlg.tcl:129
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "Verktøyet '%s' eksisterer allerede."
-
-#: lib/tools_dlg.tcl:151
+#: lib/commit.tcl:176
 #, tcl-format
 msgid ""
-"Could not add tool:\n"
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Ukjent filstatus %s er funnet.\n"
+"\n"
+"Filen %s kan ikke sjekkes inn av dette programmet.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Ingen endringer å sjekke inn.\n"
+"\n"
+"Du må køe minst en fil før du kan sjekke inn noe.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Vennligst angi en revisjonsmelding.\n"
+"\n"
+"En god melding har følgende format:\n"
+"\n"
+"- Første linje: En beskrivelse av hva du har gjort i én setning.\n"
+"- Andre linje: Blank\n"
+"- Resterende linjer: Forklar hvorfor denne endringen er bra.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr ""
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr ""
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr ""
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr ""
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Sjekker inn endringer..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "Skriving til tre feilet:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Innsjekking feilet."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "Revisjon %s ser ut til å være korrupt"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Ingen endringer til innsjekking.\n"
+"\n"
+"Ingen filer ble endret av denne revisjonen, og det var ikke en revisjon fra "
+"en sammenslåing.\n"
+"\n"
+"Et nytt søk vil bli startet automatisk.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Ingen endringer til innsekking."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree feilet:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref feilet:"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "Opprettet innsjekking %s: %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Fjern gren"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Fjern lokal gren"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Lokale grener"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Fjern kun ved sammenslåing"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "Følgende grener er ikke fullstendig slått sammen med %s:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
 "%s"
 msgstr ""
-"Kunne ikke legge til verktøyet:\n"
+"Kunne ikke fjerne grener:\n"
 "%s"
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
-msgstr "Fjern verktøyet"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Kunne ikke låse opp indexen."
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
-msgstr "Fjern verktøyskommandoen"
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Feil på index"
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
-msgstr "Fjern"
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Oppdatering av Git's index mislyktes. Et nytt søk vil bli startet for å "
+"resynkronisere git-gui."
 
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
-msgstr "(Blue angir lokale verktøy til arkivet)"
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Fortsett"
 
-#: lib/tools_dlg.tcl:297
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Lås opp index"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Fjerner %s fra innsjekkingskøen"
+
+#: lib/index.tcl:298
 #, tcl-format
-msgid "Run Command: %s"
-msgstr "Kjør kommando: %s"
+msgid "Unstaging %s from commit"
+msgstr "Fjerner %s fra innsjekkingskøen"
 
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
-msgstr "Argumenter"
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Klar til innsjekking."
 
-#: lib/tools_dlg.tcl:348
-msgid "OK"
-msgstr "OK"
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Reverterer valgte filer"
 
-#: lib/transport.tcl:7
+#: lib/index.tcl:350
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Henter nye endringer fra %s"
+msgid "Adding %s"
+msgstr "Legger til %s"
 
-#: lib/transport.tcl:18
+#: lib/index.tcl:380
 #, tcl-format
-msgid "remote prune %s"
-msgstr "slett fjernarkiv %s"
+msgid "Stage %d untracked files?"
+msgstr ""
 
-#: lib/transport.tcl:19
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Fjrner sporing av grener slettet fra %s"
+msgid "Revert changes in file %s?"
+msgstr "Reverter endringene i filen %s?"
 
-#: lib/transport.tcl:26
+#: lib/index.tcl:442
 #, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Sender endringer til %s"
+msgid "Revert changes in these %i files?"
+msgstr "Reverter endringene i disse %i filene?"
 
-#: lib/transport.tcl:72
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Endringer som ikke ligger i innsjekkingskøen vil bli tapt av denne "
+"reverteringen"
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Ikke gjør noe"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Fjerner grenene fra %s"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Reverter endringene i disse %i filene?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Slett"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Reverterer valgte filer"
+
+#: lib/index.tcl:532
 #, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Sender %s %s til %s"
+msgid "Reverting %s"
+msgstr "Reverterer %s"
 
-#: lib/transport.tcl:89
-msgid "Push Branches"
-msgstr "Send grener"
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Standard"
 
-#: lib/transport.tcl:103
-msgid "Source Branches"
-msgstr "Kildegrener"
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr "Systemets (%s)"
 
-#: lib/transport.tcl:120
-msgid "Destination Repository"
-msgstr "Destinasjonsarkiv"
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Andre"
 
-#: lib/transport.tcl:158
-msgid "Transfer Options"
-msgstr "Overføringsalternativer"
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Ugyldig dato fra Git: %s"
 
-#: lib/transport.tcl:160
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr "Tving overskrivning av eksisterende gren (kan forkaste endringer)"
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Denne frakoblede utsjekkingen"
 
-#: lib/transport.tcl:164
-msgid "Use thin pack (for slow network connections)"
-msgstr "Bruk tynne pakker (for tregere nettverkstilkoblinger)"
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Revisjonsuttrykk:"
 
-#: lib/transport.tcl:168
-msgid "Include tags"
-msgstr "Inkluder tagger"
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Lokal gren"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Sporet gren"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Tag"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Ugyldig revisjon: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Ingen revisjoner valgt."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "Revisjonsuttrykk er tomt."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Oppdatert"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Antall løse objekter"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Diskplass brukt av løse objekter"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Antall pakkede objekter"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Antall pakker"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Diskplass brukt av pakkede objekter"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Pakkede objekter som avventer fjerning"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Avfallsfiler"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Databasestatistikk"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Komprimerer objektdatabasen"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Verifiserer objektdatabasen med fsck-objects"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Dette arkivet inneholder omtrent %i 'løse' objekter.\n"
+"\n"
+"For å sikre en optimal ytelse er det sterkt anbefalt at du komprimerer "
+"databasen når det er flere enn %i 'løse' objekter i den.\n"
+"\n"
+"Komprimere databasen nå?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "feil"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "advarsel"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "Verktøy feilet: %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Du må rette de ovenstående feilene før innsjekking."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Preferences..."
+#~ msgstr "Innstillinger..."
+
+#~ msgid "Always (Do not perform merge test.)"
+#~ msgstr "Alltid (Ikke utfør sammenslåingstest.)"
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Usporet fil er %d bytes.\n"
+#~ "* Viser bare %d første bytes.\n"
+
+#~ msgid "Case-Sensitive"
+#~ msgstr "Skiller på store og små bokstaver"

--- a/po/pt_br.po
+++ b/po/pt_br.po
@@ -1,56 +1,57 @@
 # Translation of git-gui to Brazilian Portuguese
 # Copyright (C) 2007 Shawn Pearce, et al.
 # This file is distributed under the same license as the git-gui package.
-#
+# 
 # Alexandre Erwin Ittner <alexandre@ittner.com.br>, 2010.
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-01-26 15:47-0800\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2010-09-18 11:09-0300\n"
 "Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
 "Language-Team: Brazilian Portuguese <>\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:41 git-gui.sh:793 git-gui.sh:807 git-gui.sh:820 git-gui.sh:903
-#: git-gui.sh:922
-msgid "git-gui: fatal error"
-msgstr "git-gui: erro fatal"
-
-#: git-gui.sh:743
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Fonte inválida indicada em %s:"
 
-#: git-gui.sh:779
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Fonte principal"
 
-#: git-gui.sh:780
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Fonte para o diff/console"
 
-#: git-gui.sh:794
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: erro fatal"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Impossível encontrar o git no \"PATH\""
 
-#: git-gui.sh:821
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Impossível interpretar a versão do git:"
 
-#: git-gui.sh:839
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Não foi possível determinar a versão do git:\n"
 "\n"
@@ -60,483 +61,515 @@ msgstr ""
 "\n"
 "Assumir que '%s' é a versão 1.5.0?\n"
 
-#: git-gui.sh:1128
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Diretório do Git não encontrado:"
 
-#: git-gui.sh:1146
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Impossível mover para o início do diretório de trabalho:"
 
-#: git-gui.sh:1154
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Impossível usar repositório puro:"
 
-#: git-gui.sh:1162
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Sem diretório de trabalho"
 
-#: git-gui.sh:1334 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Atualizando estado dos arquivos..."
 
-#: git-gui.sh:1390
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Procurando por arquivos modificados ..."
 
-#: git-gui.sh:1454
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "Executando hook \"prepare-commit-msg\"..."
 
-#: git-gui.sh:1471
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "O script \"prepare-commit-msg\" negou a criação de uma nova revisão"
 
-#: git-gui.sh:1629 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Pronto."
 
-#: git-gui.sh:1787
+#: git-gui.sh:1966
 #, tcl-format
-msgid "Displaying only %s of %s files."
-msgstr "Exibindo apenas %s de %s arquivos."
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
 
-#: git-gui.sh:1913
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Não modificado"
 
-#: git-gui.sh:1915
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Modificado, não marcado"
 
-#: git-gui.sh:1916 git-gui.sh:1924
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Marcado para uma nova revisão"
 
-#: git-gui.sh:1917 git-gui.sh:1925
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Trechos marcados para revisão"
 
-#: git-gui.sh:1918 git-gui.sh:1926
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Marcado para revisão, faltando"
 
-#: git-gui.sh:1920
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Tipo do arquivo modificado, não marcado"
 
-#: git-gui.sh:1921
+#: git-gui.sh:2097 git-gui.sh:2098
+#, fuzzy
+msgid "File type changed, old type staged for commit"
+msgstr "Tipo do arquivo modificado, não marcado"
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Tipo do arquivo modificado, marcado"
 
-#: git-gui.sh:1923
+#: git-gui.sh:2100
+#, fuzzy
+msgid "File type change staged, modification not staged"
+msgstr "Tipo do arquivo modificado, não marcado"
+
+#: git-gui.sh:2101
+#, fuzzy
+msgid "File type change staged, file missing"
+msgstr "Tipo do arquivo modificado, marcado"
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Não monitorado, não marcado"
 
-#: git-gui.sh:1928
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Faltando"
 
-#: git-gui.sh:1929
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Marcado para remoção"
 
-#: git-gui.sh:1930
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Marcado para remoção, ainda presente"
 
-#: git-gui.sh:1932 git-gui.sh:1933 git-gui.sh:1934 git-gui.sh:1935
-#: git-gui.sh:1936 git-gui.sh:1937
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Requer resolução de conflitos"
 
-#: git-gui.sh:1972
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Iniciando gitk... Aguarde..."
 
-#: git-gui.sh:1984
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Impossível encontrar o gitk no PATH"
 
-#: git-gui.sh:2043
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "Impossível encontrar o \"git gui\" no PATH"
 
-#: git-gui.sh:2455 lib/choose_repository.tcl:36
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Repositório"
 
-#: git-gui.sh:2456
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Editar"
 
-#: git-gui.sh:2458 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Ramo"
 
-#: git-gui.sh:2461 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Revisão"
 
-#: git-gui.sh:2464 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Mesclar"
 
-#: git-gui.sh:2465 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Remoto"
 
-#: git-gui.sh:2468
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: git-gui.sh:2477
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Explorar cópia de trabalho"
 
-#: git-gui.sh:2483
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Explorar arquivos do ramo atual"
 
-#: git-gui.sh:2487
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Explorar arquivos do ramo..."
 
-#: git-gui.sh:2492
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Visualizar histórico do ramo atual"
 
-#: git-gui.sh:2496
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Visualizar histórico de todos os ramos"
 
-#: git-gui.sh:2503
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Explorar arquivos de %s"
 
-#: git-gui.sh:2505
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Visualizar histórico de %s"
 
-#: git-gui.sh:2510 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Estatísticas do banco de dados"
 
-#: git-gui.sh:2513 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Compactar banco de dados"
 
-#: git-gui.sh:2516
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Verificar banco de dados"
 
-#: git-gui.sh:2523 git-gui.sh:2527 git-gui.sh:2531 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Criar ícone na área de trabalho"
 
-#: git-gui.sh:2539 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Sair"
 
-#: git-gui.sh:2547
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Desfazer"
 
-#: git-gui.sh:2550
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Refazer"
 
-#: git-gui.sh:2554 git-gui.sh:3109
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Recortar"
 
-#: git-gui.sh:2557 git-gui.sh:3112 git-gui.sh:3186 git-gui.sh:3259
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Copiar"
 
-#: git-gui.sh:2560 git-gui.sh:3115
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Colar"
 
-#: git-gui.sh:2563 git-gui.sh:3118 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Apagar"
 
-#: git-gui.sh:2567 git-gui.sh:3122 git-gui.sh:3263 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Selecionar tudo"
 
-#: git-gui.sh:2576
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Criar..."
 
-#: git-gui.sh:2582
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Checkout..."
 
-#: git-gui.sh:2588
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: git-gui.sh:2593
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Apagar..."
 
-#: git-gui.sh:2598
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Redefinir..."
 
-#: git-gui.sh:2608
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Pronto"
 
-#: git-gui.sh:2610
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Salvar revisão"
 
-#: git-gui.sh:2619 git-gui.sh:3050
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Nova revisão"
 
-#: git-gui.sh:2627 git-gui.sh:3057
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Corrigir última revisão"
 
-#: git-gui.sh:2637 git-gui.sh:3011 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Atualizar"
 
-#: git-gui.sh:2643
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Marcar para revisão"
 
-#: git-gui.sh:2649
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Marcar arquivos modificados"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Desmarcar"
 
-#: git-gui.sh:2661 lib/index.tcl:412
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Reverter mudanças"
 
-#: git-gui.sh:2669 git-gui.sh:3310 git-gui.sh:3341
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Mostrar menos contexto"
 
-#: git-gui.sh:2673 git-gui.sh:3314 git-gui.sh:3345
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Mostrar mais contexto"
 
-#: git-gui.sh:2680 git-gui.sh:3024 git-gui.sh:3133
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Assinar embaixo"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Mesclar localmente..."
 
-#: git-gui.sh:2701
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Abortar mesclagem..."
 
-#: git-gui.sh:2713 git-gui.sh:2741
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Adicionar..."
 
-#: git-gui.sh:2717
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Enviar..."
 
-#: git-gui.sh:2721
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Apagar ramo..."
 
-#: git-gui.sh:2731 git-gui.sh:3292
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Opções..."
 
-#: git-gui.sh:2742
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Remover..."
 
-#: git-gui.sh:2751 lib/choose_repository.tcl:50
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Ajuda"
 
-#: git-gui.sh:2755 git-gui.sh:2759 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Sobre o %s"
 
-#: git-gui.sh:2783
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Ajuda online"
 
-#: git-gui.sh:2786 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Mostrar chave SSH"
 
-#: git-gui.sh:2893
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "Erro"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "erro fatal: impossível executar \"stat\" em  %s: Arquivo ou diretório não "
 "encontrado"
 
-#: git-gui.sh:2926
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Ramo atual:"
 
-#: git-gui.sh:2947
-msgid "Staged Changes (Will Commit)"
-msgstr "Mudanças marcadas"
-
-#: git-gui.sh:2967
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Mudanças não marcadas"
 
-#: git-gui.sh:3017
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Mudanças marcadas"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Marcar alterados"
 
-#: git-gui.sh:3036 lib/transport.tcl:104 lib/transport.tcl:193
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Enviar"
 
-#: git-gui.sh:3071
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Descrição da revisão inicial:"
 
-#: git-gui.sh:3072
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Descrição da revisão corrigida:"
 
-#: git-gui.sh:3073
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Descrição da revisão inicial corrigida:"
 
-#: git-gui.sh:3074
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Descrição da revisão de mescla corrigida:"
 
-#: git-gui.sh:3075
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Descrição da revisão de mescla:"
 
-#: git-gui.sh:3076
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Descrição da revisão:"
 
-#: git-gui.sh:3125 git-gui.sh:3267 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Copiar todos"
 
-#: git-gui.sh:3149 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Arquivo:"
 
-#: git-gui.sh:3255
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Reduzir tamanho da fonte"
 
-#: git-gui.sh:3280
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Aumentar tamanho da fonte"
 
-#: git-gui.sh:3288 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Codificação"
 
-#: git-gui.sh:3299
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Aplicar/reverter trecho"
 
-#: git-gui.sh:3304
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Aplicar/reverter linha"
 
-#: git-gui.sh:3323
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Executar ferramenta de mescla"
 
-#: git-gui.sh:3328
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Usar versão remota"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Usar versão local"
 
-#: git-gui.sh:3336
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Reverter para a versão-base"
 
-#: git-gui.sh:3354
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Visualizar estas mudanças no sub-módulo"
 
-#: git-gui.sh:3358
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Visualizar histórico do ramo atual no sub-módulo"
 
-#: git-gui.sh:3362
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Visualizar histórico de todos os camos no sub-módulo"
 
-#: git-gui.sh:3367
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Iniciar \"git gui\" no sub-módulo"
 
-#: git-gui.sh:3389
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Desmarcar trecho para revisão"
 
-#: git-gui.sh:3391
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Desmarcar linhas para revisão"
 
-#: git-gui.sh:3393
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Desmarcar linha para revisão"
 
-#: git-gui.sh:3396
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Marcar trecho para revisão"
 
-#: git-gui.sh:3398
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Marcar linhas para revisão"
 
-#: git-gui.sh:3400
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Marcar linha para revisão"
 
-#: git-gui.sh:3424
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Iniciando..."
 
-#: git-gui.sh:3541
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Possíveis problemas com as variáveis de ambiente.\n"
 "\n"
@@ -544,25 +577,26 @@ msgstr ""
 "ignoradas por qualquer sub-processo do Git executado por\n"
 "%s:\n"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Isto se deve a um problema conhecido com os binários da Tcl \n"
 "distribuídos com o Cygwin"
 
-#: git-gui.sh:3575
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -570,314 +604,30 @@ msgstr ""
 "é colocar os valores para o nome de usuário e e-mail\n"
 "no seu arquivo \"~/.gitconfig\"\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - uma interface gráfica para o Git"
-
-#: lib/blame.tcl:72
-msgid "File Viewer"
-msgstr "Visualizador de arquivos"
-
-#: lib/blame.tcl:78
-msgid "Commit:"
-msgstr "Revisão:"
-
-#: lib/blame.tcl:271
-msgid "Copy Commit"
-msgstr "Copiar revisão"
-
-#: lib/blame.tcl:275
-msgid "Find Text..."
-msgstr "Procurar texto..."
-
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr "Executar detecção completa de cópias"
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr "Mostrar contexto do histórico"
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
-msgstr "Anotar revisão anterior"
-
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Lendo %s..."
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
-msgstr "Carregando anotações de cópia/movimentação..."
-
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr "linhas anotadas"
-
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr "Carregando anotações originais..."
-
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr "Anotação completa."
-
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr "Ocupado"
-
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr "O processo de anotação já está em execução"
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr "Executando detecção de cópia..."
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr "Carregando anotações..."
-
-#: lib/blame.tcl:963
-msgid "Author:"
-msgstr "Autor:"
-
-#: lib/blame.tcl:967
-msgid "Committer:"
-msgstr "Revisor:"
-
-#: lib/blame.tcl:972
-msgid "Original File:"
-msgstr "Arquivo original:"
-
-#: lib/blame.tcl:1020
-msgid "Cannot find HEAD commit:"
-msgstr "Impossível encontrar revisão HEAD:"
-
-#: lib/blame.tcl:1075
-msgid "Cannot find parent commit:"
-msgstr "Impossível encontrar revisão anterior:"
-
-#: lib/blame.tcl:1090
-msgid "Unable to display parent"
-msgstr "Impossível exibir revisão anterior"
-
-#: lib/blame.tcl:1091 lib/diff.tcl:320
-msgid "Error loading diff:"
-msgstr "Erro ao carregar as diferenças:"
-
-#: lib/blame.tcl:1231
-msgid "Originally By:"
-msgstr "Originalmente por:"
-
-#: lib/blame.tcl:1237
-msgid "In File:"
-msgstr "No arquivo:"
-
-#: lib/blame.tcl:1242
-msgid "Copied Or Moved Here By:"
-msgstr "Copiado ou movido para cá por:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Efetuar checkout do ramo"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Checkout"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:579 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:108
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr "Revisão"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr "Opções"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Obter ramo de rastreamento"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Separar do ramo local"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Criar ramo"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Criar novo ramo"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:381
-msgid "Create"
-msgstr "Criar"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Nome do ramo"
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr "Nome:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Coincidir nome do ramo de rastreamento"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Revisão inicial"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Atualizar ramo existente:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Não"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Somente se for um avanço rápido"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr "Redefinir"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Efetuar checkout após a criação"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Selecione um ramo de rastreamento."
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "O ramo de rastreamento %s não é um ramo do repositório remoto."
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Indique um nome para o ramo."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "\"%s\" não é um nome de ramo válido"
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Apagar ramo"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Apagar ramo local"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Ramos locais"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Apagar somente se mesclado em"
-
-#: lib/branch_delete.tcl:54 lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Forçar exclusão (não verificar se o ramo foi mesclado)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Os ramos seguintes não foram completamente mesclados em %s:"
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:217
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
-"Recuperar ramos apagados é difícil.\n"
-"\n"
-"Apagar os ramos selecionados?"
 
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
-"Erro ao apagar ramos:\n"
-"%s"
 
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Renomear ramo"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Trabalhando... aguarde..."
 
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Renomear"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Fechar"
 
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Ramo:"
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Sucesso"
 
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Novo nome:"
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Selecione um ramo para renomear."
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "O ramo \"%s\" já existe."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Erro ao renomear \"%s\"."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Inciando..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "Navegador de arquivos"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Carregando %s..."
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[Subir]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "Explorar arquivos do ramo"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:398
-#: lib/choose_repository.tcl:486 lib/choose_repository.tcl:497
-#: lib/choose_repository.tcl:1028
-msgid "Browse"
-msgstr "Explorar"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Erro: o comando falhou"
 
 #: lib/checkout_op.tcl:85
 #, tcl-format
@@ -889,11 +639,6 @@ msgstr "Obtendo %s de %s"
 msgid "fatal: Cannot resolve %s"
 msgstr "Erro fatal: impossível resolver %s"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr "Fechar"
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -903,6 +648,11 @@ msgstr "O ramo \"%s\" não existe."
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Erro ao configurar git-pull simplificado para \"%s\"."
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "O ramo \"%s\" já existe."
 
 #: lib/checkout_op.tcl:229
 #, tcl-format
@@ -932,13 +682,14 @@ msgid "Staging area (index) is already locked."
 msgstr "A área de marcação (staging area, index) já está bloqueada."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "O último estado lido não confere com o estado atual.\n"
 "\n"
@@ -971,9 +722,10 @@ msgid "Staying on branch '%s'."
 msgstr "Permanecendo no ramo \"%s\"."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -1000,18 +752,31 @@ msgstr "Recuperar revisões perdidas pode não ser fácil."
 msgid "Reset '%s'?"
 msgstr "Redefinir \"%s\"?"
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Visualizar"
 
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Redefinir"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Cancelar"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Erro ao definir o ramo atual.\n"
@@ -1021,762 +786,234 @@ msgstr ""
 "\n"
 "Isto não deveria ter acontecido, %s terminará agora."
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Selecionar"
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "receber %s"
 
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Tipo da fonte"
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "Recebendo novas mudanças de %s"
 
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Tamanho da fonte"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "Limpar %s"
 
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Exemplo"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Limpando ramos excluídos de %s"
 
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
-"Este é um texto de exemplo.\n"
-"Se você gostar deste texto, esta pode ser sua fonte."
 
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
+#: lib/transport.tcl:26
+#, fuzzy
+msgid "Fetching new changes from all remotes"
+msgstr "Recebendo novas mudanças de %s"
 
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:386
-msgid "Create New Repository"
-msgstr "Criar novo repositório"
+#: lib/transport.tcl:40
+#, fuzzy
+msgid "remote prune all remotes"
+msgstr "Limpar %s"
 
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr "Novo..."
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Limpando ramos excluídos de %s"
 
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:471
-msgid "Clone Existing Repository"
-msgstr "Clonar repositório existente"
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr "Clonar..."
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:1016
-msgid "Open Existing Repository"
-msgstr "Abrir repositório existente"
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr "Abrir..."
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr "Repositórios recentes"
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr "Abrir repositório recente:"
-
-#: lib/choose_repository.tcl:306 lib/choose_repository.tcl:313
-#: lib/choose_repository.tcl:320
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Erro ao criar repositório %s:"
+msgid "push %s"
+msgstr "enviar %s"
 
-#: lib/choose_repository.tcl:391
-msgid "Directory:"
-msgstr "Diretório:"
-
-#: lib/choose_repository.tcl:423 lib/choose_repository.tcl:550
-#: lib/choose_repository.tcl:1052
-msgid "Git Repository"
-msgstr "Repositório Git"
-
-#: lib/choose_repository.tcl:448
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Directory %s already exists."
-msgstr "O diretório %s já existe."
+msgid "Pushing changes to %s"
+msgstr "Enviando mudanças para %s"
 
-#: lib/choose_repository.tcl:452
+#: lib/transport.tcl:93
 #, tcl-format
-msgid "File %s already exists."
-msgstr "O arquivo %s já existe."
+msgid "Mirroring to %s"
+msgstr "Duplicando para %s"
 
-#: lib/choose_repository.tcl:466
-msgid "Clone"
-msgstr "Clonar"
-
-#: lib/choose_repository.tcl:479
-msgid "Source Location:"
-msgstr "Origem:"
-
-#: lib/choose_repository.tcl:490
-msgid "Target Directory:"
-msgstr "Diretório de destino:"
-
-#: lib/choose_repository.tcl:502
-msgid "Clone Type:"
-msgstr "Tipo de clonagem:"
-
-#: lib/choose_repository.tcl:508
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Padrão (rápida, semi-redundante, com hardlinks)"
-
-#: lib/choose_repository.tcl:514
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Cópia completa (mais lenta, backup redundante)"
-
-#: lib/choose_repository.tcl:520
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Compartilhada (A mais rápida, não recomendada, sem backup)"
-
-#: lib/choose_repository.tcl:556 lib/choose_repository.tcl:603
-#: lib/choose_repository.tcl:749 lib/choose_repository.tcl:819
-#: lib/choose_repository.tcl:1058 lib/choose_repository.tcl:1066
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Este não é um repositório do Git: %s"
+msgid "Pushing %s %s to %s"
+msgstr "Enviando %s %s para %s"
 
-#: lib/choose_repository.tcl:592
-msgid "Standard only available for local repository."
-msgstr "Clonagens padrões só são possíveis em repositórios locais."
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Enviar ramos"
 
-#: lib/choose_repository.tcl:596
-msgid "Shared only available for local repository."
-msgstr "Clonagens parciais só são possíveis em repositórios locais."
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Ramos de origem"
 
-#: lib/choose_repository.tcl:617
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Repositório de destino"
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Remoto:"
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Outro local:"
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Opções de transferência"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr "Sobrescrever ramos existentes (pode descartar mudanças)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Usar compactação minimalista (para redes lentas)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Incluir etiquetas"
+
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Location %s already exists."
-msgstr "O local %s já existe."
-
-#: lib/choose_repository.tcl:628
-msgid "Failed to configure origin"
-msgstr "Erro ao configurar origem"
-
-#: lib/choose_repository.tcl:640
-msgid "Counting objects"
-msgstr "Contando objetos"
-
-#: lib/choose_repository.tcl:641
-msgid "buckets"
-msgstr "buckets"
-
-#: lib/choose_repository.tcl:665
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Erro ao copiar objetos ou informações adicionais: %s"
-
-#: lib/choose_repository.tcl:701
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Não há nada para clonar em %s."
-
-#: lib/choose_repository.tcl:703 lib/choose_repository.tcl:917
-#: lib/choose_repository.tcl:929
-msgid "The 'master' branch has not been initialized."
-msgstr "O ramo \"master\" não foi inicializado."
-
-#: lib/choose_repository.tcl:716
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Não foi possível criar hardlinks, usando cópias convencionais."
-
-#: lib/choose_repository.tcl:728
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Clonando de %s"
-
-#: lib/choose_repository.tcl:759
-msgid "Copying objects"
-msgstr "Copiando objetos"
-
-#: lib/choose_repository.tcl:760
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:784
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Não foi possível copiar o objeto: %s"
-
-#: lib/choose_repository.tcl:794
-msgid "Linking objects"
-msgstr "Ligando objetos"
-
-#: lib/choose_repository.tcl:795
-msgid "objects"
-msgstr "objetos"
-
-#: lib/choose_repository.tcl:803
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Não foi possível ligar o objeto: %s"
-
-#: lib/choose_repository.tcl:858
-msgid "Cannot fetch branches and objects.  See console output for details."
+msgid "%s (%s): Push"
 msgstr ""
-"Não foi possível receber ramos ou objetos. Veja a saída do console para "
-"detalhes."
 
-#: lib/choose_repository.tcl:869
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-"Não foi possível receber as etiquetas. Veja a saída do console para detalhes."
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "Adicionar repositório remoto"
 
-#: lib/choose_repository.tcl:893
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-"Não foi possível determinar a etiqueta HEAD. Veja a saída do console para "
-"detalhes."
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Adicionar novo repositório remoto"
 
-#: lib/choose_repository.tcl:902
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Adicionar"
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Detalhes do repositório remoto"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Nome:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Local:"
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Ações adicionais"
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Receber imediatamente"
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Inicializar repositório remoto e enviar"
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr "Não fazer nada agora"
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Por favor, indique um nome para o repositório remoto."
+
+#: lib/remote_add.tcl:113
 #, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Não foi possível limpar %s"
+msgid "'%s' is not an acceptable remote name."
+msgstr "\"%s\" não é um nome válido para um repositório remoto."
 
-#: lib/choose_repository.tcl:908
-msgid "Clone failed."
-msgstr "A clonagem falhou."
-
-#: lib/choose_repository.tcl:915
-msgid "No default branch obtained."
-msgstr "O ramo padrão não foi recebido."
-
-#: lib/choose_repository.tcl:926
+#: lib/remote_add.tcl:124
 #, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Não foi possível resolver %s como uma revisão."
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Erro ao adicionar repositório remoto \"%s\" do local \"%s\":"
 
-#: lib/choose_repository.tcl:938
-msgid "Creating working directory"
-msgstr "Criando diretório de trabalho."
-
-#: lib/choose_repository.tcl:939 lib/index.tcl:67 lib/index.tcl:130
-#: lib/index.tcl:198
-msgid "files"
-msgstr "arquivos"
-
-#: lib/choose_repository.tcl:968
-msgid "Initial file checkout failed."
-msgstr "Erro ao efetuar checkout inicial."
-
-#: lib/choose_repository.tcl:1011
-msgid "Open"
-msgstr "Abrir"
-
-#: lib/choose_repository.tcl:1021
-msgid "Repository:"
-msgstr "Repositório:"
-
-#: lib/choose_repository.tcl:1072
+#: lib/remote_add.tcl:133
 #, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Erro ao abrir o repositório %s:"
+msgid "Fetching the %s"
+msgstr "Recebendo o %s"
 
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "Este checkout"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Expressão de revisão:"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Ramo local"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Ramo de rastreamento"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Etiqueta"
-
-#: lib/choose_rev.tcl:317
+#: lib/remote_add.tcl:156
 #, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Revisão inválida: %s"
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "Não sabe como inicializar o repositório remoto em \"%s\"."
 
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Nenhuma revisão selecionada."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "A expressão de revisão está vazia."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Atualizado"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"Não há nada para corrigir.\n"
-"\n"
-"Você está prestes a criar uma revisão inicial. Não há revisão anterior para "
-"corrigir.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Não é possível corrigir durante uma mesclagem.\n"
-"\n"
-"Você está em meio a uma operação de mesclagem que não foi completada. Não é "
-"possível corrigir a revisão anterior a menos que você aborte a mescla atual "
-"antes.\n"
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Erro ao carregar dados da revisão para corrigir:"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Não foi possível obter a sua identidade:"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Variável \"GIT_COMMITTER_IDENT\" inválida:"
-
-#: lib/commit.tcl:129
+#: lib/remote_add.tcl:163
 #, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "aviso: O Tcl não suporta a codificação \"%s\"."
+msgid "Setting up the %s (at %s)"
+msgstr "Configurando %s (em %s)"
 
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"O último estado lido não confere com o estado atual.\n"
-"\n"
-"Outro programa do Git modificou o repositório desde a última leitura. Uma "
-"atualização deve ser executada antes de criar outra revisão.\n"
-"\n"
-"A atualização começará automaticamente agora.\n"
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Inciando..."
 
-#: lib/commit.tcl:172
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Navegador de arquivos"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
 #, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"Não é possível salvar revisões para arquivos não mesclados.\n"
-"\n"
-"O arquivo %s possui conflitos de mesclagem. Você deve resolvê-los e marcar o "
-"arquivo antes de salvar a revisão.\n"
-
-#: lib/commit.tcl:180
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Estado desconhecido detectado para o arquivo %s.\n"
-"\n"
-"Este programa não pode salvar uma revisão para o arquivo %s.\n"
-
-#: lib/commit.tcl:188
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Não há mudanças para salvar.\n"
-"\n"
-"Você deve marcar ao menos um arquivo antes de salvar a revisão.\n"
-
-#: lib/commit.tcl:203
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Por favor, indique uma descrição para a revisão.\n"
-"\n"
-"Uma boa descrição tem o seguinte formato:\n"
-"\n"
-"- Primeira linha: descreve, em uma única frase, o que você fez.\n"
-"- Segunda linha: em branco.\n"
-"- Demais linhas: Descreve detalhadamente a revisão.\n"
-
-#: lib/commit.tcl:234
-msgid "Calling pre-commit hook..."
-msgstr "Executando script \"pre-commit\"..."
-
-#: lib/commit.tcl:249
-msgid "Commit declined by pre-commit hook."
-msgstr "A revisão foi bloqueada pelo script \"pre-commit\"."
-
-#: lib/commit.tcl:272
-msgid "Calling commit-msg hook..."
-msgstr "Executando script \"commit-msg\"..."
-
-#: lib/commit.tcl:287
-msgid "Commit declined by commit-msg hook."
-msgstr "Revisão bloqueada pelo script \"commit-msg\"."
-
-#: lib/commit.tcl:300
-msgid "Committing changes..."
-msgstr "Salvando revisão..."
-
-#: lib/commit.tcl:316
-msgid "write-tree failed:"
-msgstr "write-tree falhou:"
-
-#: lib/commit.tcl:317 lib/commit.tcl:361 lib/commit.tcl:382
-msgid "Commit failed."
-msgstr "A revisão falhou."
-
-#: lib/commit.tcl:334
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "A revisão %s parece estar corrompida."
-
-#: lib/commit.tcl:339
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Não há alterações para salvar.\n"
-"\n"
-"Nenhum arquivo foi modificado e esta não é uma revisão de mesclagem.\n"
-"\n"
-"Uma atualização será executada automaticamente agora.\n"
-
-#: lib/commit.tcl:346
-msgid "No changes to commit."
-msgstr "Não há alterações para salvar."
-
-#: lib/commit.tcl:360
-msgid "commit-tree failed:"
-msgstr "commit-tree falhou:"
-
-#: lib/commit.tcl:381
-msgid "update-ref failed:"
-msgstr "update-ref falhou:"
-
-#: lib/commit.tcl:469
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Revisão %s criada: %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Trabalhando... aguarde..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Sucesso"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Erro: o comando falhou"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Número de objetos soltos"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Espaço ocupado pelos objetos soltos"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Número de objetos compactados"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Número de pacotes"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "Espaço ocupado pelos objetos compactados"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Objetos compactados aguardando eliminação"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "Arquivos de lixo"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Compactando banco de dados de objetos"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Verificando banco de dados de objetos com fsck-objects"
-
-#: lib/database.tcl:107
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Este repositório possui aproximadamente %i objetos soltos.\n"
-"\n"
-"Para manter o desempenho ótimo é altamente recomendado que você compacte o "
-"banco de dados.\n"
-"\n"
-"Compactar o banco de dados agora?"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Data inválida recebida do Git: %s"
-
-#: lib/diff.tcl:64
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Nenhuma diferença foi detectada.\n"
-"\n"
-"%s não possui mudanças.\n"
-"\n"
-"A data de modificação deste arquivo foi atualizada por outro aplicativo, mas "
-"o conteúdo do arquivo não foi alterado.\n"
-"\n"
-"Uma atualização ser executada para encontrar outros arquivos que possam ter "
-"o mesmo estado."
-
-#: lib/diff.tcl:104
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Carregando diferenças de %s..."
-
-#: lib/diff.tcl:125
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-"Local: apagado\n"
-"Remoto:\n"
-
-#: lib/diff.tcl:130
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-"Remoto: apagado\n"
-"Local:\n"
-
-#: lib/diff.tcl:137
-msgid "LOCAL:\n"
-msgstr "Local:\n"
-
-#: lib/diff.tcl:140
-msgid "REMOTE:\n"
-msgstr "Remoto:\n"
-
-#: lib/diff.tcl:202 lib/diff.tcl:319
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Impossível exibir %s"
-
-#: lib/diff.tcl:203
-msgid "Error loading file:"
-msgstr "Erro ao carregar o arquivo:"
-
-#: lib/diff.tcl:210
-msgid "Git Repository (subproject)"
-msgstr "Repositório Git (sub-projeto)"
-
-#: lib/diff.tcl:222
-msgid "* Binary file (not showing content)."
-msgstr "* Arquivo binário (conteúdo não exibido)."
-
-#: lib/diff.tcl:227
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* O arquivo não rastreado possui %d bytes.\n"
-"* Exibindo apenas os primeiros %d bytes.\n"
-
-#: lib/diff.tcl:233
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-"\n"
-"* O arquivo não rastreado foi cortado aqui por %s.\n"
-"* Para ver o arquivo completo, use um editor externo.\n"
-
-#: lib/diff.tcl:482
-msgid "Failed to unstage selected hunk."
-msgstr "Erro ao desmarcar o trecho selecionado."
-
-#: lib/diff.tcl:489
-msgid "Failed to stage selected hunk."
-msgstr "Erro ao marcar o trecho selecionado."
-
-#: lib/diff.tcl:568
-msgid "Failed to unstage selected line."
-msgstr "Erro ao desmarcar a linha selecionada."
-
-#: lib/diff.tcl:576
-msgid "Failed to stage selected line."
-msgstr "Erro ao marcar a linha selecionada."
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Padrão"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Sistema (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Outro"
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "Erro"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "aviso"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr "Você precisa corrigir os erros acima antes de salvar a revisão."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Impossível desbloquear o índice."
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Erro no índice"
-
-#: lib/index.tcl:17
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"A atualização do índice do Git falhou. Uma atualização será executada "
-"automaticamente para ressincronizar o Git GUI"
-
-#: lib/index.tcl:28
-msgid "Continue"
-msgstr "Continuar"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Desbloquear índice"
-
-#: lib/index.tcl:289
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Desmarcando %s para revisão"
-
-#: lib/index.tcl:328
-msgid "Ready to commit."
-msgstr "Pronto para salvar a revisão."
-
-#: lib/index.tcl:341
-#, tcl-format
-msgid "Adding %s"
-msgstr "Adicionando %s"
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Reverter as alterações no arquivo %s?"
-
-#: lib/index.tcl:400
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Reverter as alterações nestes %i arquivos?"
-
-#: lib/index.tcl:408
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Qualquer alteração não marcada será permanentemente perdida na reversão."
-
-#: lib/index.tcl:411
-msgid "Do Nothing"
-msgstr "Não fazer nada"
-
-#: lib/index.tcl:429
-msgid "Reverting selected files"
-msgstr "Revertendo os arquivos selecionados"
-
-#: lib/index.tcl:433
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Revertendo %s"
+msgid "Loading %s..."
+msgstr "Carregando %s..."
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Subir]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Explorar arquivos do ramo"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Explorar arquivos do ramo"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Explorar"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Revisão"
 
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Não é possível mesclar durante uma correção.\n"
 "\n"
 "Você deve concluir a correção antes de começar qualquer mesclagem.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "O último estado lido não confere com o estado atual.\n"
 "\n"
@@ -1786,14 +1023,14 @@ msgstr ""
 "A atualização começará automaticamente agora.\n"
 
 #: lib/merge.tcl:45
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "Há uma mesclagem com conflitos em progresso.\n"
 "\n"
@@ -1803,14 +1040,14 @@ msgstr ""
 "mesclagem atual. Só então você poderá começar outra.\n"
 
 #: lib/merge.tcl:55
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "Você está em meio a uma mudança.\n"
 "\n"
@@ -1819,49 +1056,57 @@ msgstr ""
 "Você deve completar e salvar a revisão atual antes de começar uma mesclagem. "
 "Ao fazê-lo, você poderá abortar a mesclagem caso haja algum erro.\n"
 
-#: lib/merge.tcl:107
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s de %s"
 
-#: lib/merge.tcl:120
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Mesclando %s e %s..."
 
-#: lib/merge.tcl:131
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "Mesclagem completada com sucesso."
 
-#: lib/merge.tcl:133
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "A mesclagem falhou. É necessário resolver conflitos."
 
-#: lib/merge.tcl:158
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Mesclar em %s"
 
-#: lib/merge.tcl:177
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Revisão para mesclar"
 
-#: lib/merge.tcl:212
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "Não é possível abortar durante uma correção.\n"
 "\n"
 "Você precisa finalizar a correção desta revisão.\n"
 
-#: lib/merge.tcl:222
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Abortar mesclagem?\n"
@@ -1871,12 +1116,13 @@ msgstr ""
 "\n"
 "Abortar a mesclagem atual?"
 
-#: lib/merge.tcl:228
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Descartar as mudanças?\n"
@@ -1885,417 +1131,81 @@ msgstr ""
 "\n"
 "Continuar e descartar as mudanças atuais?"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Abortando"
 
-#: lib/merge.tcl:239
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "arquivos redefindos"
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "A tentativa de abortar a operação falhou"
 
-#: lib/merge.tcl:269
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "Operação abortada com sucesso. Pronto."
 
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Forçar a resolução para a versão base?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Forçar resolução para este ramo?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Forçar resolução para o outro ramo?"
-
-#: lib/mergetool.tcl:14
+#: lib/tools.tcl:76
 #, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Note que o diff mostra apenas as mudanças conflitantes.\n"
-"\n"
-"%s será sobrescrito.\n"
-"\n"
-"Caso necessário, será preciso reiniciar a mesclagem para desfazer esta "
-"operação."
+msgid "Running %s requires a selected file."
+msgstr "É preciso selecionar um arquivo para executar %s."
 
-#: lib/mergetool.tcl:45
+#: lib/tools.tcl:92
+#, fuzzy, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Você tem certeza que deseja executar %s?"
+
+#: lib/tools.tcl:96
 #, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr "O arquivo %s parece ter conflitos não resolvidos. Marcar mesmo assim?"
+msgid "Are you sure you want to run %s?"
+msgstr "Você tem certeza que deseja executar %s?"
 
-#: lib/mergetool.tcl:60
+#: lib/tools.tcl:118
 #, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Adicionando resolução para %s"
+msgid "Tool: %s"
+msgstr "Ferramenta: %s"
 
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-"Impossível resolver conflitos envolvendo exclusão ou links de arquivos com "
-"esta ferramenta."
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "O arquivo conflitante não existe"
-
-#: lib/mergetool.tcl:264
+#: lib/tools.tcl:119
 #, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "Não é uma ferramenta de mesclagem gráfica: \"%s\""
+msgid "Running: %s"
+msgstr "Executando: %s"
 
-#: lib/mergetool.tcl:268
+#: lib/tools.tcl:158
 #, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "Ferramenta de mesclagem não suportada \"%s\""
+msgid "Tool completed successfully: %s"
+msgstr "Execução completada com sucesso: %s"
 
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr "A ferramenta de mesclagem já está em execução. Finalizar?"
-
-#: lib/mergetool.tcl:323
+#: lib/tools.tcl:160
 #, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Erro ao obter as versões:\n"
-"%s"
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-"Não foi possível iniciar a ferramenta de mesclagem:\n"
-"\n"
-"%s"
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr "Executando ferramenta de mesclagem..."
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr "Ferramenta de mesclagem falhou."
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr "Codificação global inválida \"%s\""
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr "Codificação do repositório inválida \"%s\""
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr "Restaurar padrões"
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr "Salvar"
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr "Repositório %s"
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr "Global (todos os repositórios)"
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr "Nome do usuário"
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr "Endereço de e-mail"
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr "Exibir sumário das revisões de mesclagem"
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr "Nível de detalhamento da mesclagem"
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr "Exibir estatísticas após mesclagens"
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr "Usar ferramenta de mesclagem"
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr "Confiar nas datas de modificação dos arquivos"
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr "Eliminar ramos de rastreamento ao receber"
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr "Coincidir ramos de rastreamento"
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr "Detectar cópias somente em arquivos modificados"
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr "Número mínimo de letras para detectar cópias"
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr "Extensão do contexto de detecção (em dias)"
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr "Número de linhas para o diff contextual"
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr "Largura do texto da descrição da revisão"
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr "Modelo de nome para novos ramos"
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr "Codificação padrão dos arquivos"
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr "Alterar"
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr "Dicionário para o verificador ortográfico:"
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr "Mudar fonte"
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr "Escolher %s"
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr "pt."
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr "Preferências"
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr "Houve um erro ao salvar as opções:"
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr "Excluir"
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr "Limpar de"
-
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr "Receber de"
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr "Enviar para"
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
-msgstr "Adicionar repositório remoto"
-
-#: lib/remote_add.tcl:24
-msgid "Add New Remote"
-msgstr "Adicionar novo repositório remoto"
-
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
-msgid "Add"
-msgstr "Adicionar"
-
-#: lib/remote_add.tcl:37
-msgid "Remote Details"
-msgstr "Detalhes do repositório remoto"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Local:"
-
-#: lib/remote_add.tcl:62
-msgid "Further Action"
-msgstr "Ações adicionais"
-
-#: lib/remote_add.tcl:65
-msgid "Fetch Immediately"
-msgstr "Receber imediatamente"
-
-#: lib/remote_add.tcl:71
-msgid "Initialize Remote Repository and Push"
-msgstr "Inicializar repositório remoto e enviar"
-
-#: lib/remote_add.tcl:77
-msgid "Do Nothing Else Now"
-msgstr "Não fazer nada agora"
-
-#: lib/remote_add.tcl:101
-msgid "Please supply a remote name."
-msgstr "Por favor, indique um nome para o repositório remoto."
-
-#: lib/remote_add.tcl:114
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "\"%s\" não é um nome válido para um repositório remoto."
-
-#: lib/remote_add.tcl:125
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Erro ao adicionar repositório remoto \"%s\" do local \"%s\":"
-
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "receber %s"
-
-#: lib/remote_add.tcl:134
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "Recebendo o %s"
-
-#: lib/remote_add.tcl:157
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Não sabe como inicializar o repositório remoto em \"%s\"."
-
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:63
-#: lib/transport.tcl:81
-#, tcl-format
-msgid "push %s"
-msgstr "enviar %s"
-
-#: lib/remote_add.tcl:164
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "Configurando %s (em %s)"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Apagar ramo remoto"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "Do repositório"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:134
-msgid "Remote:"
-msgstr "Remoto:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:149
-msgid "Arbitrary Location:"
-msgstr "Outro local:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Ramos"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Apagar somente se"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Mesclado em:"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "É preciso indicar um ramo para \"Mesclado em\"."
-
-#: lib/remote_branch_delete.tcl:184
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-"Os seguintes ramos não estão inteiramente mesclados em %s:\n"
-"\n"
-" - %s"
-
-#: lib/remote_branch_delete.tcl:189
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-"Um ou mais testes de mesclagem falharam porque você não possui as revisões "
-"necessárias. Tente receber revisões de %s primeiro."
-
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Por favor selecione um ou mais ramos para apagar."
-
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Apagar ramos de %s"
-
-#: lib/remote_branch_delete.tcl:292
-msgid "No repository selected."
-msgstr "Nenhum repositório foi selecionado."
-
-#: lib/remote_branch_delete.tcl:297
-#, tcl-format
-msgid "Scanning %s..."
-msgstr "Atualizando %s..."
-
-#: lib/search.tcl:21
-msgid "Find:"
-msgstr "Encontrar:"
-
-#: lib/search.tcl:23
-msgid "Next"
-msgstr "Próximo"
-
-#: lib/search.tcl:24
-msgid "Prev"
-msgstr "Anterior"
-
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
-msgstr "Sensível a maiúsculas/minúsculas"
-
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "Não foi possível gravar o atalho:"
-
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "Não foi possível gravar o ícone:"
+msgid "Tool failed: %s"
+msgstr "Ferramenta falhou: %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Efetuar checkout do ramo"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Efetuar checkout do ramo"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Checkout"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Opções"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Obter ramo de rastreamento"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Separar do ramo local"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -2334,6 +1244,1015 @@ msgstr "Final de arquivo inesperado recebido do verificador ortográfico"
 msgid "Spell Checker Failed"
 msgstr "A verificação ortográfica falhou"
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s ... %*i de %*i %s (%3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Nenhuma diferença foi detectada.\n"
+"\n"
+"%s não possui mudanças.\n"
+"\n"
+"A data de modificação deste arquivo foi atualizada por outro aplicativo, mas "
+"o conteúdo do arquivo não foi alterado.\n"
+"\n"
+"Uma atualização ser executada para encontrar outros arquivos que possam ter "
+"o mesmo estado."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Carregando diferenças de %s..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"Local: apagado\n"
+"Remoto:\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"Remoto: apagado\n"
+"Local:\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "Local:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "Remoto:\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Impossível exibir %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Erro ao carregar o arquivo:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Repositório Git (sub-projeto)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Arquivo binário (conteúdo não exibido)."
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* O arquivo não rastreado foi cortado aqui por %s.\n"
+"* Para ver o arquivo completo, use um editor externo.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Erro ao carregar as diferenças:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Erro ao desmarcar o trecho selecionado."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Erro ao marcar o trecho selecionado."
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Erro ao desmarcar a linha selecionada."
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Erro ao marcar a linha selecionada."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Enviar para"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Excluir"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Limpar de"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Receber de"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Selecionar"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Tipo da fonte"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Tamanho da fonte"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Exemplo"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Este é um texto de exemplo.\n"
+"Se você gostar deste texto, esta pode ser sua fonte."
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr "Codificação global inválida \"%s\""
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr "Codificação do repositório inválida \"%s\""
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Restaurar padrões"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Salvar"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "Repositório %s"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Global (todos os repositórios)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Nome do usuário"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Endereço de e-mail"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "Exibir sumário das revisões de mesclagem"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Nível de detalhamento da mesclagem"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Exibir estatísticas após mesclagens"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr "Usar ferramenta de mesclagem"
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "Confiar nas datas de modificação dos arquivos"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr "Eliminar ramos de rastreamento ao receber"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "Coincidir ramos de rastreamento"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr "Detectar cópias somente em arquivos modificados"
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Repositórios recentes"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr "Número mínimo de letras para detectar cópias"
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr "Extensão do contexto de detecção (em dias)"
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Número de linhas para o diff contextual"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Largura do texto da descrição da revisão"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Modelo de nome para novos ramos"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr "Codificação padrão dos arquivos"
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr "Alterar"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Dicionário para o verificador ortográfico:"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Mudar fonte"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "Escolher %s"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "pt."
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Preferências"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "Houve um erro ao salvar as opções:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Forçar a resolução para a versão base?"
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Forçar resolução para este ramo?"
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Forçar resolução para o outro ramo?"
+
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"Note que o diff mostra apenas as mudanças conflitantes.\n"
+"\n"
+"%s será sobrescrito.\n"
+"\n"
+"Caso necessário, será preciso reiniciar a mesclagem para desfazer esta "
+"operação."
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr "O arquivo %s parece ter conflitos não resolvidos. Marcar mesmo assim?"
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr "Adicionando resolução para %s"
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+"Impossível resolver conflitos envolvendo exclusão ou links de arquivos com "
+"esta ferramenta."
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "O arquivo conflitante não existe"
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "Não é uma ferramenta de mesclagem gráfica: \"%s\""
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr "Ferramenta de mesclagem não suportada \"%s\""
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "A ferramenta de mesclagem já está em execução. Finalizar?"
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Erro ao obter as versões:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+"Não foi possível iniciar a ferramenta de mesclagem:\n"
+"\n"
+"%s"
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "Executando ferramenta de mesclagem..."
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "Ferramenta de mesclagem falhou."
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "Adicionar ferramenta"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "Adicionar novo comando de ferramenta"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "Adicionar globalmente"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "Detalhes da ferramenta"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "Use o separador \"/\" para criar uma árvore de sub-menus:"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "Comando:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "Exibir uma caixa de diálogo antes de executar"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr "Solicitar a seleção de uma revisão (a variável $REVISION)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "Solicitar argumentos adicionais (define a variável $ARGS)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "Não exibir a janela de saída do comando"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "Executar apenas se houver um diff selecionado ($FILENAME não-vazio)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "Por favor, indique um nome para a ferramenta."
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "A ferramenta \"%s\" já existe."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+"Não foi possível adicionar a ferramenta:\n"
+"%s"
+
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "Excluir ferramenta"
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "Excluir comando de ferramenta"
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "Excluir"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(Azul indica ferramentas do repositório local)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Sistema (%s)"
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "Executar comando: %s"
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "Argumentos"
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "OK"
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Encontrar:"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Próximo"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Anterior"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Criar ícone na área de trabalho"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Não foi possível gravar o atalho:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Não foi possível gravar o ícone:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Renomear ramo"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Renomear ramo"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Renomear"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Ramo:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Novo nome:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Selecione um ramo para renomear."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Indique um nome para o ramo."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "\"%s\" não é um nome de ramo válido"
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Erro ao renomear \"%s\"."
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Apagar ramo remoto"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Apagar ramo remoto"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Do repositório"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Ramos"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Apagar somente se"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Mesclado em:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Forçar exclusão (não verificar se o ramo foi mesclado)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "É preciso indicar um ramo para \"Mesclado em\"."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"Os seguintes ramos não estão inteiramente mesclados em %s:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Um ou mais testes de mesclagem falharam porque você não possui as revisões "
+"necessárias. Tente receber revisões de %s primeiro."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Por favor selecione um ou mais ramos para apagar."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Recuperar ramos apagados é difícil.\n"
+"\n"
+"Apagar os ramos selecionados?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Apagar ramos de %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Nenhum repositório foi selecionado."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Atualizando %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Criar novo repositório"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Novo..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Clonar repositório existente"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Clonar..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Abrir repositório existente"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Abrir..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Repositórios recentes"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Abrir repositório recente:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Erro ao criar repositório %s:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Criar"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Diretório:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Repositório Git"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "O diretório %s já existe."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "O arquivo %s já existe."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Clonar"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Origem:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Diretório de destino:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Tipo de clonagem:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Padrão (rápida, semi-redundante, com hardlinks)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Cópia completa (mais lenta, backup redundante)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Compartilhada (A mais rápida, não recomendada, sem backup)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Este não é um repositório do Git: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Clonagens padrões só são possíveis em repositórios locais."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "Clonagens parciais só são possíveis em repositórios locais."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "O local %s já existe."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Erro ao configurar origem"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Contando objetos"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "buckets"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Erro ao copiar objetos ou informações adicionais: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Não há nada para clonar em %s."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "O ramo \"master\" não foi inicializado."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Não foi possível criar hardlinks, usando cópias convencionais."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Clonando de %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Copiando objetos"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Não foi possível copiar o objeto: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Ligando objetos"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "objetos"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Não foi possível ligar o objeto: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Não foi possível receber ramos ou objetos. Veja a saída do console para "
+"detalhes."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+"Não foi possível receber as etiquetas. Veja a saída do console para detalhes."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+"Não foi possível determinar a etiqueta HEAD. Veja a saída do console para "
+"detalhes."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Não foi possível limpar %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "A clonagem falhou."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "O ramo padrão não foi recebido."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Não foi possível resolver %s como uma revisão."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Criando diretório de trabalho."
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "arquivos"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Clonando de %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Erro ao efetuar checkout inicial."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Abrir"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Repositório:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Erro ao abrir o repositório %s:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - uma interface gráfica para o Git"
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Visualizador de arquivos"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Revisão:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Copiar revisão"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Procurar texto..."
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Clonar..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Executar detecção completa de cópias"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Mostrar contexto do histórico"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Anotar revisão anterior"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Lendo %s..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Carregando anotações de cópia/movimentação..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "linhas anotadas"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Carregando anotações originais..."
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Anotação completa."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Ocupado"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "O processo de anotação já está em execução"
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Executando detecção de cópia..."
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Carregando anotações..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Autor:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Revisor:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Arquivo original:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Impossível encontrar revisão HEAD:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Impossível encontrar revisão anterior:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Impossível exibir revisão anterior"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Originalmente por:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "No arquivo:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Copiado ou movido para cá por:"
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr "Nenhuma chave encontrada"
@@ -2347,19 +2266,19 @@ msgstr "Chave pública encontrada em: %s"
 msgid "Generate Key"
 msgstr "Gerar chave"
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "Copiar para a área de transferência"
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "Sua chave pública OpenSSH"
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Gerando..."
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2370,199 +2289,549 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr "A geração da chave falhou."
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr "A geração da chave foi bem-sucedida, mas nenhuma chave foi encontrada."
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "Sua chave em: %s"
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Criar ramo"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Criar novo ramo"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Nome do ramo"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Coincidir nome do ramo de rastreamento"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Revisão inicial"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Atualizar ramo existente:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Não"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Somente se for um avanço rápido"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Efetuar checkout após a criação"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Selecione um ramo de rastreamento."
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s ... %*i de %*i %s (%3i%%)"
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "O ramo de rastreamento %s não é um ramo do repositório remoto."
 
-#: lib/tools.tcl:75
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Não há nada para corrigir.\n"
+"\n"
+"Você está prestes a criar uma revisão inicial. Não há revisão anterior para "
+"corrigir.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Não é possível corrigir durante uma mesclagem.\n"
+"\n"
+"Você está em meio a uma operação de mesclagem que não foi completada. Não é "
+"possível corrigir a revisão anterior a menos que você aborte a mescla atual "
+"antes.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Erro ao carregar dados da revisão para corrigir:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Não foi possível obter a sua identidade:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Variável \"GIT_COMMITTER_IDENT\" inválida:"
+
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "É preciso selecionar um arquivo para executar %s."
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "aviso: O Tcl não suporta a codificação \"%s\"."
 
-#: lib/tools.tcl:90
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"O último estado lido não confere com o estado atual.\n"
+"\n"
+"Outro programa do Git modificou o repositório desde a última leitura. Uma "
+"atualização deve ser executada antes de criar outra revisão.\n"
+"\n"
+"A atualização começará automaticamente agora.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Não é possível salvar revisões para arquivos não mesclados.\n"
+"\n"
+"O arquivo %s possui conflitos de mesclagem. Você deve resolvê-los e marcar o "
+"arquivo antes de salvar a revisão.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Estado desconhecido detectado para o arquivo %s.\n"
+"\n"
+"Este programa não pode salvar uma revisão para o arquivo %s.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Não há mudanças para salvar.\n"
+"\n"
+"Você deve marcar ao menos um arquivo antes de salvar a revisão.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Por favor, indique uma descrição para a revisão.\n"
+"\n"
+"Uma boa descrição tem o seguinte formato:\n"
+"\n"
+"- Primeira linha: descreve, em uma única frase, o que você fez.\n"
+"- Segunda linha: em branco.\n"
+"- Demais linhas: Descreve detalhadamente a revisão.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Executando script \"pre-commit\"..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "A revisão foi bloqueada pelo script \"pre-commit\"."
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Executando script \"commit-msg\"..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Revisão bloqueada pelo script \"commit-msg\"."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Salvando revisão..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "write-tree falhou:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "A revisão falhou."
+
+#: lib/commit.tcl:356
 #, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Você tem certeza que deseja executar %s?"
+msgid "Commit %s appears to be corrupt"
+msgstr "A revisão %s parece estar corrompida."
 
-#: lib/tools.tcl:110
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Não há alterações para salvar.\n"
+"\n"
+"Nenhum arquivo foi modificado e esta não é uma revisão de mesclagem.\n"
+"\n"
+"Uma atualização será executada automaticamente agora.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Não há alterações para salvar."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree falhou:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref falhou:"
+
+#: lib/commit.tcl:508
 #, tcl-format
-msgid "Tool: %s"
-msgstr "Ferramenta: %s"
+msgid "Created commit %s: %s"
+msgstr "Revisão %s criada: %s"
 
-#: lib/tools.tcl:111
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Apagar ramo"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Apagar ramo local"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Ramos locais"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Apagar somente se mesclado em"
+
+#: lib/branch_delete.tcl:103
 #, tcl-format
-msgid "Running: %s"
-msgstr "Executando: %s"
+msgid "The following branches are not completely merged into %s:"
+msgstr "Os ramos seguintes não foram completamente mesclados em %s:"
 
-#: lib/tools.tcl:149
+#: lib/branch_delete.tcl:131
 #, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Execução completada com sucesso: %s"
+msgid " - %s:"
+msgstr ""
 
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "Ferramenta falhou: %s"
-
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "Adicionar ferramenta"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "Adicionar novo comando de ferramenta"
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr "Adicionar globalmente"
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr "Detalhes da ferramenta"
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "Use o separador \"/\" para criar uma árvore de sub-menus:"
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr "Comando:"
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr "Exibir uma caixa de diálogo antes de executar"
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr "Solicitar a seleção de uma revisão (a variável $REVISION)"
-
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "Solicitar argumentos adicionais (define a variável $ARGS)"
-
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr "Não exibir a janela de saída do comando"
-
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "Executar apenas se houver um diff selecionado ($FILENAME não-vazio)"
-
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr "Por favor, indique um nome para a ferramenta."
-
-#: lib/tools_dlg.tcl:129
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "A ferramenta \"%s\" já existe."
-
-#: lib/tools_dlg.tcl:151
+#: lib/branch_delete.tcl:141
 #, tcl-format
 msgid ""
-"Could not add tool:\n"
+"Failed to delete branches:\n"
 "%s"
 msgstr ""
-"Não foi possível adicionar a ferramenta:\n"
+"Erro ao apagar ramos:\n"
 "%s"
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
-msgstr "Excluir ferramenta"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Impossível desbloquear o índice."
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
-msgstr "Excluir comando de ferramenta"
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Erro no índice"
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
-msgstr "Excluir"
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"A atualização do índice do Git falhou. Uma atualização será executada "
+"automaticamente para ressincronizar o Git GUI"
 
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
-msgstr "(Azul indica ferramentas do repositório local)"
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Continuar"
 
-#: lib/tools_dlg.tcl:297
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Desbloquear índice"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Desmarcando %s para revisão"
+
+#: lib/index.tcl:298
 #, tcl-format
-msgid "Run Command: %s"
-msgstr "Executar comando: %s"
+msgid "Unstaging %s from commit"
+msgstr "Desmarcando %s para revisão"
 
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
-msgstr "Argumentos"
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Pronto para salvar a revisão."
 
-#: lib/tools_dlg.tcl:348
-msgid "OK"
-msgstr "OK"
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Revertendo os arquivos selecionados"
 
-#: lib/transport.tcl:7
+#: lib/index.tcl:350
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Recebendo novas mudanças de %s"
+msgid "Adding %s"
+msgstr "Adicionando %s"
 
-#: lib/transport.tcl:18
+#: lib/index.tcl:380
 #, tcl-format
-msgid "remote prune %s"
-msgstr "Limpar %s"
+msgid "Stage %d untracked files?"
+msgstr ""
 
-#: lib/transport.tcl:19
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Limpando ramos excluídos de %s"
+msgid "Revert changes in file %s?"
+msgstr "Reverter as alterações no arquivo %s?"
 
-#: lib/transport.tcl:26
+#: lib/index.tcl:442
 #, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Enviando mudanças para %s"
+msgid "Revert changes in these %i files?"
+msgstr "Reverter as alterações nestes %i arquivos?"
 
-#: lib/transport.tcl:64
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Qualquer alteração não marcada será permanentemente perdida na reversão."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Não fazer nada"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Apagar ramos de %s"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Reverter as alterações nestes %i arquivos?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Apagar"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Revertendo os arquivos selecionados"
+
+#: lib/index.tcl:532
 #, tcl-format
-msgid "Mirroring to %s"
-msgstr "Duplicando para %s"
+msgid "Reverting %s"
+msgstr "Revertendo %s"
 
-#: lib/transport.tcl:82
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Padrão"
+
+#: lib/encoding.tcl:448
 #, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Enviando %s %s para %s"
+msgid "System (%s)"
+msgstr "Sistema (%s)"
 
-#: lib/transport.tcl:100
-msgid "Push Branches"
-msgstr "Enviar ramos"
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Outro"
 
-#: lib/transport.tcl:114
-msgid "Source Branches"
-msgstr "Ramos de origem"
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Data inválida recebida do Git: %s"
 
-#: lib/transport.tcl:131
-msgid "Destination Repository"
-msgstr "Repositório de destino"
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Este checkout"
 
-#: lib/transport.tcl:169
-msgid "Transfer Options"
-msgstr "Opções de transferência"
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Expressão de revisão:"
 
-#: lib/transport.tcl:171
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr "Sobrescrever ramos existentes (pode descartar mudanças)"
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Ramo local"
 
-#: lib/transport.tcl:175
-msgid "Use thin pack (for slow network connections)"
-msgstr "Usar compactação minimalista (para redes lentas)"
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Ramo de rastreamento"
 
-#: lib/transport.tcl:179
-msgid "Include tags"
-msgstr "Incluir etiquetas"
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Etiqueta"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Revisão inválida: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Nenhuma revisão selecionada."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "A expressão de revisão está vazia."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Atualizado"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Número de objetos soltos"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Espaço ocupado pelos objetos soltos"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Número de objetos compactados"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Número de pacotes"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Espaço ocupado pelos objetos compactados"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Objetos compactados aguardando eliminação"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Arquivos de lixo"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Estatísticas do banco de dados"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Compactando banco de dados de objetos"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Verificando banco de dados de objetos com fsck-objects"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Este repositório possui aproximadamente %i objetos soltos.\n"
+"\n"
+"Para manter o desempenho ótimo é altamente recomendado que você compacte o "
+"banco de dados.\n"
+"\n"
+"Compactar o banco de dados agora?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "Erro"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "aviso"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "Ferramenta falhou: %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Você precisa corrigir os erros acima antes de salvar a revisão."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Displaying only %s of %s files."
+#~ msgstr "Exibindo apenas %s de %s arquivos."
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* O arquivo não rastreado possui %d bytes.\n"
+#~ "* Exibindo apenas os primeiros %d bytes.\n"
+
+#~ msgid "Case-Sensitive"
+#~ msgstr "Sensível a maiúsculas/minúsculas"

--- a/po/pt_pt.po
+++ b/po/pt_pt.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git-gui\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-06 09:36+0000\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2016-05-06 13:09+0000\n"
 "Last-Translator: Vasco Almeida <vascomalmeida@sapo.pt>\n"
 "Language-Team: Portuguese\n"
@@ -17,42 +17,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: git-gui.sh:861
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Tipo de letra inválido especificado em %s:"
 
-#: git-gui.sh:915
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Tipo de letra principal"
 
-#: git-gui.sh:916
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Tipo de letra Diferenças/Consola"
 
-#: git-gui.sh:931 git-gui.sh:945 git-gui.sh:958 git-gui.sh:1048
-#: git-gui.sh:1067 git-gui.sh:3125
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
 msgid "git-gui: fatal error"
 msgstr "git-gui: erro fatal"
 
-#: git-gui.sh:932
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Não é possível encontrar o git em PATH."
 
-#: git-gui.sh:959
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Não é possível analisar a versão do Git:"
 
-#: git-gui.sh:984
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "A versão do Git não pôde ser determinada.\n"
 "\n"
@@ -62,46 +62,46 @@ msgstr ""
 "\n"
 "Assumir que '%s' está na versão 1.5.0?\n"
 
-#: git-gui.sh:1281
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Diretório Git não encontrado:"
 
-#: git-gui.sh:1315
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Não é possível mover para o topo do diretório de trabalho:"
 
-#: git-gui.sh:1323
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Não é possível usar repositório nu:"
 
-#: git-gui.sh:1331
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Nenhum diretório de trabalho"
 
-#: git-gui.sh:1503 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "A atualizar estado do ficheiro..."
 
-#: git-gui.sh:1563
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "A procurar por ficheiros modificados..."
 
-#: git-gui.sh:1639
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr ""
 "A invocar gancho preparar-mensagem-de-commit (prepare-commit-msg hook)..."
 
-#: git-gui.sh:1656
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr ""
 "Commit recusado pelo gancho preparar-mensagem-de-commit (prepare-commit-msg "
 "hook)."
 
-#: git-gui.sh:1814 lib/browser.tcl:252
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Pronto."
 
-#: git-gui.sh:1978
+#: git-gui.sh:1966
 #, tcl-format
 msgid ""
 "Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
@@ -109,466 +109,470 @@ msgstr ""
 "Limite de visualização (gui.maxfilesdisplayed = %s) atingido, não são "
 "mostrados todos os %s ficheiros."
 
-#: git-gui.sh:2101
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Não modificado"
 
-#: git-gui.sh:2103
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Modificado, não preparado"
 
-#: git-gui.sh:2104 git-gui.sh:2116
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Preparado para commit"
 
-#: git-gui.sh:2105 git-gui.sh:2117
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Porções preparadas para commit"
 
-#: git-gui.sh:2106 git-gui.sh:2118
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Preparado para commit, em falta"
 
-#: git-gui.sh:2108
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Tipo de ficheiro modificado, não preparado"
 
-#: git-gui.sh:2109 git-gui.sh:2110
+#: git-gui.sh:2097 git-gui.sh:2098
 msgid "File type changed, old type staged for commit"
 msgstr "Tipo de ficheiro modificado, tipo antigo preparado para commit"
 
-#: git-gui.sh:2111
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Tipo de ficheiro modificado, preparado"
 
-#: git-gui.sh:2112
+#: git-gui.sh:2100
 msgid "File type change staged, modification not staged"
 msgstr "Tipo de ficheiro modificado, modificação não preparada"
 
-#: git-gui.sh:2113
+#: git-gui.sh:2101
 msgid "File type change staged, file missing"
 msgstr "Tipo de ficheiro modificado, ficheiro em falta"
 
-#: git-gui.sh:2115
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Não controlado, não preparado"
 
-#: git-gui.sh:2120
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Em falta"
 
-#: git-gui.sh:2121
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Preparado para remoção"
 
-#: git-gui.sh:2122
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Preparado para remoção, ainda presente"
 
-#: git-gui.sh:2124 git-gui.sh:2125 git-gui.sh:2126 git-gui.sh:2127
-#: git-gui.sh:2128 git-gui.sh:2129
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Requer resolução de integração"
 
-#: git-gui.sh:2164
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "A iniciar gitk... aguarde..."
 
-#: git-gui.sh:2176
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Não foi possível encontrar gitk em PATH"
 
-#: git-gui.sh:2235
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "Não foi possível encontrar git gui em PATH"
 
-#: git-gui.sh:2654 lib/choose_repository.tcl:41
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Repositório"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Editar"
 
-#: git-gui.sh:2657 lib/choose_rev.tcl:567
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Ramo"
 
-#: git-gui.sh:2660 lib/choose_rev.tcl:554
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Commit"
 
-#: git-gui.sh:2663 lib/merge.tcl:123 lib/merge.tcl:152 lib/merge.tcl:170
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Integrar"
 
-#: git-gui.sh:2664 lib/choose_rev.tcl:563
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Remoto"
 
-#: git-gui.sh:2667
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: git-gui.sh:2676
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Explorar cópia de trabalho"
 
-#: git-gui.sh:2682
+#: git-gui.sh:2686
 msgid "Git Bash"
 msgstr "Git Bash"
 
-#: git-gui.sh:2692
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Navegar pelos ficheiro do ramo atual"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Navegar pelos ficheiros do ramo..."
 
-#: git-gui.sh:2701
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Visualizar histórico do ramo atual"
 
-#: git-gui.sh:2705
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Visualizar histórico de todos os ramos"
 
-#: git-gui.sh:2712
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Navegar pelos ficheiro de %s"
 
-#: git-gui.sh:2714
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Visualizar histórico de %s"
 
-#: git-gui.sh:2719 lib/database.tcl:40 lib/database.tcl:66
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Estatísticas da base de dados"
 
-#: git-gui.sh:2722 lib/database.tcl:33
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Comprimir base de dados"
 
-#: git-gui.sh:2725
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Verificar base de dados"
 
-#: git-gui.sh:2732 git-gui.sh:2736 git-gui.sh:2740 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Criar ícone no ambiente de trabalho"
 
-#: git-gui.sh:2748 lib/choose_repository.tcl:193 lib/choose_repository.tcl:201
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Sair"
 
-#: git-gui.sh:2756
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Desfazer"
 
-#: git-gui.sh:2759
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Refazer"
 
-#: git-gui.sh:2763 git-gui.sh:3368
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Cortar"
 
-#: git-gui.sh:2766 git-gui.sh:3371 git-gui.sh:3445 git-gui.sh:3530
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Copiar"
 
-#: git-gui.sh:2769 git-gui.sh:3374
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Colar"
 
-#: git-gui.sh:2772 git-gui.sh:3377 lib/remote_branch_delete.tcl:39
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
 #: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Eliminar"
 
-#: git-gui.sh:2776 git-gui.sh:3381 git-gui.sh:3534 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Selecionar tudo"
 
-#: git-gui.sh:2785
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Criar..."
 
-#: git-gui.sh:2791
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Extrair..."
 
-#: git-gui.sh:2797
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Mudar nome..."
 
-#: git-gui.sh:2802
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Eliminar..."
 
-#: git-gui.sh:2807
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Repor..."
 
-#: git-gui.sh:2817
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Concluído"
 
-#: git-gui.sh:2819
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Submeter"
 
-#: git-gui.sh:2828 git-gui.sh:3309
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Novo commit"
 
-#: git-gui.sh:2836 git-gui.sh:3316
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Emendar último commit"
 
-#: git-gui.sh:2846 git-gui.sh:3270 lib/remote_branch_delete.tcl:101
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Reanalisar"
 
-#: git-gui.sh:2852
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Preparar para commit"
 
-#: git-gui.sh:2858
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Preparar ficheiros modificados para commit"
 
-#: git-gui.sh:2864
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Retirar do commit"
 
-#: git-gui.sh:2870 lib/index.tcl:442
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Reverter alterações"
 
-#: git-gui.sh:2878 git-gui.sh:3581 git-gui.sh:3612
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Mostrar menos contexto"
 
-#: git-gui.sh:2882 git-gui.sh:3585 git-gui.sh:3616
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Mostrar mais contexto"
 
-#: git-gui.sh:2889 git-gui.sh:3283 git-gui.sh:3392
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Assinar por baixo"
 
-#: git-gui.sh:2905
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Integração local..."
 
-#: git-gui.sh:2910
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Abortar integração..."
 
-#: git-gui.sh:2922 git-gui.sh:2950
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Adicionar..."
 
-#: git-gui.sh:2926
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Publicar..."
 
-#: git-gui.sh:2930
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Eliminar ramo..."
 
-#: git-gui.sh:2940 git-gui.sh:3563
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Opções..."
 
-#: git-gui.sh:2951
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Remover..."
 
-#: git-gui.sh:2960 lib/choose_repository.tcl:55
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Ajuda"
 
-#: git-gui.sh:2964 git-gui.sh:2968 lib/choose_repository.tcl:49
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
 #: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Sobre %s"
 
-#: git-gui.sh:2992
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Documentação online"
 
-#: git-gui.sh:2995 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Mostrar chave SSH"
 
 #: git-gui.sh:3014 git-gui.sh:3146
+#, fuzzy
+msgid "usage:"
+msgstr "Utilização"
+
+#: git-gui.sh:3018 git-gui.sh:3150
 msgid "Usage"
 msgstr "Utilização"
 
-#: git-gui.sh:3095 lib/blame.tcl:573
+#: git-gui.sh:3099 lib/blame.tcl:573
 msgid "Error"
 msgstr "Erro"
 
-#: git-gui.sh:3126
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "fatal: não é possível obter estado do caminho %s: Ficheiro ou diretório "
 "inexistente"
 
-#: git-gui.sh:3159
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Ramo atual:"
 
-#: git-gui.sh:3185
-msgid "Staged Changes (Will Commit)"
-msgstr "Alterações preparadas (para commit)"
-
-#: git-gui.sh:3205
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Alterações não preparadas"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Alterações preparadas (para commit)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Preparar modificados"
 
-#: git-gui.sh:3295 lib/transport.tcl:137 lib/transport.tcl:229
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Publicar"
 
-#: git-gui.sh:3330
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Mensagem de commit inicial:"
 
-#: git-gui.sh:3331
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Mensagem de commit emendada:"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Mensagem de commit inicial emendada:"
 
-#: git-gui.sh:3333
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Mensagem de commit de integração emendada:"
 
-#: git-gui.sh:3334
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Mensagem de commit de integração:"
 
-#: git-gui.sh:3335
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Mensagem de commit:"
 
-#: git-gui.sh:3384 git-gui.sh:3538 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Copiar tudo"
 
-#: git-gui.sh:3408 lib/blame.tcl:105
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Ficheiro:"
 
-#: git-gui.sh:3526
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: git-gui.sh:3547
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Diminuir tamanho de letra"
 
-#: git-gui.sh:3551
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Aumentar tamanho de letra"
 
-#: git-gui.sh:3559 lib/blame.tcl:294
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Codificação"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Aplicar/Reverter excerto"
 
-#: git-gui.sh:3575
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Aplicar/Reverter linha"
 
-#: git-gui.sh:3594
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Executar ferramenta de integração"
 
-#: git-gui.sh:3599
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Usar a versão remota"
 
-#: git-gui.sh:3603
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Usar a versão local"
 
-#: git-gui.sh:3607
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Reverter para a base"
 
-#: git-gui.sh:3625
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Visualizar estas alterações no submódulo"
 
-#: git-gui.sh:3629
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Visualizar histórico do ramo atual no submódulo"
 
-#: git-gui.sh:3633
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Visualizar histórico de todos os ramos no submódulo"
 
-#: git-gui.sh:3638
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Iniciar git gui no submódulo"
 
-#: git-gui.sh:3673
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Retirar excerto do commit"
 
-#: git-gui.sh:3675
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Retirar linhas do commit"
 
-#: git-gui.sh:3677
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Retirar linha do commit"
 
-#: git-gui.sh:3680
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Preparar excerto para commit"
 
-#: git-gui.sh:3682
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Preparar linhas para commit"
 
-#: git-gui.sh:3684
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Preparar linha para commit"
 
-#: git-gui.sh:3709
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "A inicializar..."
 
-#: git-gui.sh:3852
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Existem possíveis erros de ambiente.\n"
 "\n"
@@ -577,25 +581,26 @@ msgstr ""
 "por %s:\n"
 "\n"
 
-#: git-gui.sh:3881
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Devido a um problema conhecido com o\n"
 "binário Tcl distribuído pelo Cygwin."
 
-#: git-gui.sh:3886
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -681,13 +686,14 @@ msgid "Staging area (index) is already locked."
 msgstr "A área de estágio (índice) já está bloqueada."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "O último estado analisado não corresponde ao estado do repositório.\n"
 "\n"
@@ -721,9 +727,10 @@ msgid "Staying on branch '%s'."
 msgstr "Permanecer no ramo '%s'."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -750,7 +757,7 @@ msgstr "Recuperar commits perdidos pode não ser fácil."
 msgid "Reset '%s'?"
 msgstr "Repor '%s'?"
 
-#: lib/checkout_op.tcl:567 lib/tools_dlg.tcl:336 lib/merge.tcl:166
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Visualizar"
 
@@ -759,22 +766,22 @@ msgid "Reset"
 msgstr "Repor"
 
 #: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
-#: lib/browser.tcl:292 lib/branch_checkout.tcl:30 lib/choose_font.tcl:45
-#: lib/option.tcl:127 lib/tools_dlg.tcl:41 lib/tools_dlg.tcl:202
-#: lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
 #: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
-#: lib/branch_delete.tcl:34 lib/merge.tcl:174
+#: lib/branch_delete.tcl:34
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Falha ao definir ramo atual.\n"
@@ -878,8 +885,14 @@ msgstr "Usar pacote fino (para conexões de rede lentas)"
 msgid "Include tags"
 msgstr "Incluir tags"
 
+#: lib/transport.tcl:229
+#, tcl-format
+msgid "%s (%s): Push"
+msgstr ""
+
 #: lib/remote_add.tcl:20
-msgid "Add Remote"
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
 msgstr "Adicionar remoto"
 
 #: lib/remote_add.tcl:25
@@ -952,7 +965,8 @@ msgid "Starting..."
 msgstr "A iniciar..."
 
 #: lib/browser.tcl:27
-msgid "File Browser"
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
 msgstr "Navegador de ficheiros"
 
 #: lib/browser.tcl:132 lib/browser.tcl:149
@@ -964,13 +978,18 @@ msgstr "A carregar %s..."
 msgid "[Up To Parent]"
 msgstr "[Subir]"
 
-#: lib/browser.tcl:275 lib/browser.tcl:282
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Navegar pelos ficheiros do ramo"
+
+#: lib/browser.tcl:282
 msgid "Browse Branch Files"
 msgstr "Navegar pelos ficheiros do ramo"
 
-#: lib/browser.tcl:288 lib/choose_repository.tcl:422
-#: lib/choose_repository.tcl:509 lib/choose_repository.tcl:518
-#: lib/choose_repository.tcl:1074
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
 msgid "Browse"
 msgstr "Navegar"
 
@@ -978,42 +997,201 @@ msgstr "Navegar"
 msgid "Revision"
 msgstr "Revisão"
 
-#: lib/tools.tcl:75
+#: lib/merge.tcl:13
+#, fuzzy
+msgid ""
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
+msgstr ""
+"Não possível integrar ao mesmo tempo que se emenda.\n"
+"\n"
+"Deve acabar de emendar este commit antes de iniciar qualquer tipo de "
+"integração.\n"
+
+#: lib/merge.tcl:27
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"O último estado analisado não corresponde ao estado do repositório.\n"
+"\n"
+"Outro programa Git modificou este repositório deste a última análise. Deve-"
+"se reanalisar antes de se poder integrar.\n"
+"\n"
+"Irá-se reanalisar agora automaticamente.\n"
+
+#: lib/merge.tcl:45
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
+"You must resolve them, stage the file, and commit to complete the current "
+"merge.  Only then can you begin another merge.\r\n"
+msgstr ""
+"Integração com conflitos em curso.\n"
+"\n"
+"O ficheiro %s tem conflitos de integração.\n"
+"\n"
+"Deve resolvê-los, preparar o ficheiro e submeter para concluir a integração "
+"atual. Só então pode iniciar outra integração.\n"
+
+#: lib/merge.tcl:55
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
+"You should complete the current commit before starting a merge.  Doing so "
+"will help you abort a failed merge, should the need arise.\r\n"
+msgstr ""
+"Tem alterações presentes.\n"
+"\n"
+"O ficheiro %s foi modificado.\n"
+"\n"
+"Deve concluir o commit atual antes de iniciar uma integração. Assim, ajuda-o "
+"a abortar uma integração falhada, caso necessário.\n"
+
+#: lib/merge.tcl:108
+#, tcl-format
+msgid "%s of %s"
+msgstr "%s de %s"
+
+#: lib/merge.tcl:126
+#, tcl-format
+msgid "Merging %s and %s..."
+msgstr "A integrar %s e %s..."
+
+#: lib/merge.tcl:137
+msgid "Merge completed successfully."
+msgstr "Integração concluída com sucesso."
+
+#: lib/merge.tcl:139
+msgid "Merge failed.  Conflict resolution is required."
+msgstr "Integração falhada. É necessário resolver conflitos."
+
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
+#, tcl-format
+msgid "Merge Into %s"
+msgstr "Integrar em %s"
+
+#: lib/merge.tcl:183
+msgid "Revision To Merge"
+msgstr "Revisão a integrar"
+
+#: lib/merge.tcl:218
+#, fuzzy
+msgid ""
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
+msgstr ""
+"Não é possível abortar enquanto se emenda.\n"
+"\n"
+"Deve acabar de emendar este commit.\n"
+
+#: lib/merge.tcl:228
+#, fuzzy
+msgid ""
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
+"Continue with aborting the current merge?"
+msgstr ""
+"Abortar integração?\n"
+"\n"
+"Ao abortar a integração atual perderá *TODAS* as alteração que não foram "
+"submetidas.\n"
+"\n"
+"Continuar a abortar a integração atual?"
+
+#: lib/merge.tcl:234
+#, fuzzy
+msgid ""
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
+"Continue with resetting the current changes?"
+msgstr ""
+"Repor alterações?\n"
+"\n"
+"Ao repor as alterações perderá *TODAS* as alterações não submetidas.\n"
+"\n"
+"Continuar a repor as alterações atuais?"
+
+#: lib/merge.tcl:245
+msgid "Aborting"
+msgstr "A abortar"
+
+#: lib/merge.tcl:245
+msgid "files reset"
+msgstr "ficheiros repostos"
+
+#: lib/merge.tcl:273
+msgid "Abort failed."
+msgstr "Falha ao abortar."
+
+#: lib/merge.tcl:275
+msgid "Abort completed.  Ready."
+msgstr "Aborto concluído. Pronto."
+
+#: lib/tools.tcl:76
 #, tcl-format
 msgid "Running %s requires a selected file."
 msgstr "Deve selecionar um ficheiro para executar %s."
 
-#: lib/tools.tcl:91
+#: lib/tools.tcl:92
 #, tcl-format
 msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
 msgstr "Tem a certeza que pretende executar %1$s sobre o ficheiro \"%2$s\"?"
 
-#: lib/tools.tcl:95
+#: lib/tools.tcl:96
 #, tcl-format
 msgid "Are you sure you want to run %s?"
 msgstr "Tem a certeza que pretende executar %s?"
 
-#: lib/tools.tcl:116
+#: lib/tools.tcl:118
 #, tcl-format
 msgid "Tool: %s"
 msgstr "Ferramenta: %s"
 
-#: lib/tools.tcl:117
+#: lib/tools.tcl:119
 #, tcl-format
 msgid "Running: %s"
 msgstr "A executar: %s"
 
-#: lib/tools.tcl:155
+#: lib/tools.tcl:158
 #, tcl-format
 msgid "Tool completed successfully: %s"
 msgstr "A ferramenta concluí com sucesso: %s"
 
-#: lib/tools.tcl:157
+#: lib/tools.tcl:160
 #, tcl-format
 msgid "Tool failed: %s"
 msgstr "A ferramenta falhou: %s"
 
-#: lib/branch_checkout.tcl:16 lib/branch_checkout.tcl:21
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Extrair ramo"
+
+#: lib/branch_checkout.tcl:21
 msgid "Checkout Branch"
 msgstr "Extrair ramo"
 
@@ -1076,15 +1254,15 @@ msgid "%s ... %*i of %*i %s (%3i%%)"
 msgstr "%s ... %*i de %*i %s (%3i%%)"
 
 #: lib/diff.tcl:77
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
 "The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
+"the content within the file was not changed.\r\n"
+"\r\n"
 "A rescan will be automatically started to find other files which may have "
 "the same state."
 msgstr ""
@@ -1103,7 +1281,7 @@ msgstr ""
 msgid "Loading diff of %s..."
 msgstr "A carregar diferenças de %s..."
 
-#: lib/diff.tcl:140
+#: lib/diff.tcl:143
 msgid ""
 "LOCAL: deleted\n"
 "REMOTE:\n"
@@ -1111,7 +1289,7 @@ msgstr ""
 "LOCAL: eliminado\n"
 "REMOTO:\n"
 
-#: lib/diff.tcl:145
+#: lib/diff.tcl:148
 msgid ""
 "REMOTE: deleted\n"
 "LOCAL:\n"
@@ -1119,68 +1297,63 @@ msgstr ""
 "REMOTO: eliminado\n"
 "LOCAL:\n"
 
-#: lib/diff.tcl:152
+#: lib/diff.tcl:155
 msgid "LOCAL:\n"
 msgstr "LOCAL:\n"
 
-#: lib/diff.tcl:155
+#: lib/diff.tcl:158
 msgid "REMOTE:\n"
 msgstr "REMOTO:\n"
 
-#: lib/diff.tcl:217 lib/diff.tcl:355
+#: lib/diff.tcl:220 lib/diff.tcl:357
 #, tcl-format
 msgid "Unable to display %s"
 msgstr "Não é possível mostrar %s"
 
-#: lib/diff.tcl:218
+#: lib/diff.tcl:221
 msgid "Error loading file:"
 msgstr "Erro ao carregar ficheiro:"
 
-#: lib/diff.tcl:225
+#: lib/diff.tcl:227
 msgid "Git Repository (subproject)"
 msgstr "Repositório Git (subprojeto)"
 
-#: lib/diff.tcl:237
+#: lib/diff.tcl:239
 msgid "* Binary file (not showing content)."
 msgstr "* Ficheiro binário (conteúdo não exibido)."
 
-#: lib/diff.tcl:242
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
+#: lib/diff.tcl:243
+msgid "\r"
 msgstr ""
-"* O ficheiro não controlado tem %d bytes.\n"
-"* Exibido apenas os primeiros %d bytes.\n"
 
-#: lib/diff.tcl:248
-#, tcl-format
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
 msgstr ""
 "\n"
 "* Ficheiro não controlado recortado aqui por %s.\n"
 "* Para ver o ficheiro inteiro, use um editor externo.\n"
 
-#: lib/diff.tcl:356 lib/blame.tcl:1128
+#: lib/diff.tcl:358 lib/blame.tcl:1128
 msgid "Error loading diff:"
 msgstr "Erro ao carregar diferenças:"
 
-#: lib/diff.tcl:578
+#: lib/diff.tcl:580
 msgid "Failed to unstage selected hunk."
 msgstr "Falha ao retirar excerto selecionado do índice."
 
-#: lib/diff.tcl:585
+#: lib/diff.tcl:587
 msgid "Failed to stage selected hunk."
 msgstr "Falha ao preparar excerto selecionado."
 
-#: lib/diff.tcl:664
+#: lib/diff.tcl:666
 msgid "Failed to unstage selected line."
 msgstr "Falha ao retirar linha selecionada do índice."
 
-#: lib/diff.tcl:672
+#: lib/diff.tcl:674
 msgid "Failed to stage selected line."
 msgstr "Falha ao preparar linha selecionada."
 
@@ -1199,6 +1372,10 @@ msgstr "Podar de"
 #: lib/remote.tcl:228
 msgid "Fetch from"
 msgstr "Obter de"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
 
 #: lib/choose_font.tcl:41
 msgid "Select"
@@ -1343,6 +1520,12 @@ msgstr "Mostrar ficheiros não controlados"
 msgid "Tab spacing"
 msgstr "Espaçamento da tabulação"
 
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
 #: lib/option.tcl:210
 msgid "Change"
 msgstr "Alterar"
@@ -1385,12 +1568,12 @@ msgid "Force resolution to the other branch?"
 msgstr "Forçar resolução para o outro ramo?"
 
 #: lib/mergetool.tcl:14
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
 "This operation can be undone only by restarting the merge."
 msgstr ""
 "Note que as diferenças mostram apenas alterações em conflito.\n"
@@ -1463,7 +1646,8 @@ msgid "Merge tool failed."
 msgstr "A ferramenta de integração falhou."
 
 #: lib/tools_dlg.tcl:22
-msgid "Add Tool"
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
 msgstr "Adicionar ferramenta"
 
 #: lib/tools_dlg.tcl:28
@@ -1525,7 +1709,8 @@ msgstr ""
 "%s"
 
 #: lib/tools_dlg.tcl:187
-msgid "Remove Tool"
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
 msgstr "Remover ferramenta"
 
 #: lib/tools_dlg.tcl:193
@@ -1539,6 +1724,11 @@ msgstr "Remover"
 #: lib/tools_dlg.tcl:231
 msgid "(Blue denotes repository-local tools)"
 msgstr "(Azul denota ferramentas locais do repositório)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Sistema (%s)"
 
 #: lib/tools_dlg.tcl:292
 #, tcl-format
@@ -1573,15 +1763,25 @@ msgstr "ExpReg"
 msgid "Case"
 msgstr "Maiúsculas"
 
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Criar ícone no ambiente de trabalho"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
 msgid "Cannot write shortcut:"
 msgstr "Não é possível escrever atalho:"
 
-#: lib/shortcut.tcl:137
+#: lib/shortcut.tcl:140
 msgid "Cannot write icon:"
 msgstr "Não é possível escrever ícone:"
 
-#: lib/branch_rename.tcl:15 lib/branch_rename.tcl:23
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Mudar nome de ramo"
+
+#: lib/branch_rename.tcl:23
 msgid "Rename Branch"
 msgstr "Mudar nome de ramo"
 
@@ -1615,7 +1815,12 @@ msgstr "'%s' não pode ser aceite como nome de ramo."
 msgid "Failed to rename '%s'."
 msgstr "Falha ao mudar o nome de '%s'."
 
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Remover ramo remotamente"
+
+#: lib/remote_branch_delete.tcl:34
 msgid "Delete Branch Remotely"
 msgstr "Remover ramo remotamente"
 
@@ -1644,10 +1849,10 @@ msgid "A branch is required for 'Merged Into'."
 msgstr "É necessário um ramo em 'Integrar em'."
 
 #: lib/remote_branch_delete.tcl:185
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
 " - %s"
 msgstr ""
 "Os seguintes ramos não foram completamente integrados em %s:\n"
@@ -1695,7 +1900,7 @@ msgstr "A analisar %s..."
 msgid "Git Gui"
 msgstr "Git Gui"
 
-#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:412
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
 msgid "Create New Repository"
 msgstr "Criar novo repositório"
 
@@ -1703,7 +1908,7 @@ msgstr "Criar novo repositório"
 msgid "New..."
 msgstr "Novo..."
 
-#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:496
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
 msgid "Clone Existing Repository"
 msgstr "Clonar repositório existente"
 
@@ -1711,7 +1916,7 @@ msgstr "Clonar repositório existente"
 msgid "Clone..."
 msgstr "Clonar..."
 
-#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1064
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
 msgid "Open Existing Repository"
 msgstr "Abrir repositório existente"
 
@@ -1723,214 +1928,214 @@ msgstr "Abrir..."
 msgid "Recent Repositories"
 msgstr "Repositórios recentes"
 
-#: lib/choose_repository.tcl:148
+#: lib/choose_repository.tcl:152
 msgid "Open Recent Repository:"
 msgstr "Abrir repositório recente:"
 
-#: lib/choose_repository.tcl:316 lib/choose_repository.tcl:323
-#: lib/choose_repository.tcl:330
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
 #, tcl-format
 msgid "Failed to create repository %s:"
 msgstr "Falha ao criar o repositório %s:"
 
-#: lib/choose_repository.tcl:407 lib/branch_create.tcl:33
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
 msgid "Create"
 msgstr "Criar"
 
-#: lib/choose_repository.tcl:417
+#: lib/choose_repository.tcl:420
 msgid "Directory:"
 msgstr "Diretório:"
 
-#: lib/choose_repository.tcl:447 lib/choose_repository.tcl:573
-#: lib/choose_repository.tcl:1098
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
 msgid "Git Repository"
 msgstr "Repositório Git"
 
-#: lib/choose_repository.tcl:472
+#: lib/choose_repository.tcl:475
 #, tcl-format
 msgid "Directory %s already exists."
 msgstr "O diretório %s já existe."
 
-#: lib/choose_repository.tcl:476
+#: lib/choose_repository.tcl:479
 #, tcl-format
 msgid "File %s already exists."
 msgstr "O ficheiro %s já existe."
 
-#: lib/choose_repository.tcl:491
+#: lib/choose_repository.tcl:494
 msgid "Clone"
 msgstr "Clonar"
 
-#: lib/choose_repository.tcl:504
+#: lib/choose_repository.tcl:507
 msgid "Source Location:"
 msgstr "Localização de origem:"
 
-#: lib/choose_repository.tcl:513
+#: lib/choose_repository.tcl:516
 msgid "Target Directory:"
 msgstr "Diretório de destino:"
 
-#: lib/choose_repository.tcl:523
+#: lib/choose_repository.tcl:526
 msgid "Clone Type:"
 msgstr "Tipo de clone:"
 
-#: lib/choose_repository.tcl:528
+#: lib/choose_repository.tcl:531
 msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
 msgstr "Padrão (rápido, semi-redundante, ligações fixas)"
 
-#: lib/choose_repository.tcl:533
+#: lib/choose_repository.tcl:536
 msgid "Full Copy (Slower, Redundant Backup)"
 msgstr "Cópia Total (lento, cópia de segurança redundante)"
 
-#: lib/choose_repository.tcl:538
+#: lib/choose_repository.tcl:541
 msgid "Shared (Fastest, Not Recommended, No Backup)"
 msgstr "Partilhado (mais rápido, não recomendado, sem cópia)"
 
-#: lib/choose_repository.tcl:545
+#: lib/choose_repository.tcl:548
 msgid "Recursively clone submodules too"
 msgstr "Clonar recursivamente submódulos também"
 
-#: lib/choose_repository.tcl:579 lib/choose_repository.tcl:626
-#: lib/choose_repository.tcl:772 lib/choose_repository.tcl:842
-#: lib/choose_repository.tcl:1104 lib/choose_repository.tcl:1112
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
 #, tcl-format
 msgid "Not a Git repository: %s"
 msgstr "Não é um repositório Git: %s"
 
-#: lib/choose_repository.tcl:615
+#: lib/choose_repository.tcl:618
 msgid "Standard only available for local repository."
 msgstr "Padrão só disponível em repositórios locais."
 
-#: lib/choose_repository.tcl:619
+#: lib/choose_repository.tcl:622
 msgid "Shared only available for local repository."
 msgstr "Partilhado só disponível em repositórios locais."
 
-#: lib/choose_repository.tcl:640
+#: lib/choose_repository.tcl:643
 #, tcl-format
 msgid "Location %s already exists."
 msgstr "A localização %s já existe."
 
-#: lib/choose_repository.tcl:651
+#: lib/choose_repository.tcl:654
 msgid "Failed to configure origin"
 msgstr "Falha ao configurar origem"
 
-#: lib/choose_repository.tcl:663
+#: lib/choose_repository.tcl:666
 msgid "Counting objects"
 msgstr "A contar objetos"
 
-#: lib/choose_repository.tcl:664
+#: lib/choose_repository.tcl:667
 msgid "buckets"
 msgstr "baldes"
 
-#: lib/choose_repository.tcl:688
+#: lib/choose_repository.tcl:691
 #, tcl-format
 msgid "Unable to copy objects/info/alternates: %s"
 msgstr "Não é possível copiar objects/info/alternates: %s"
 
-#: lib/choose_repository.tcl:724
+#: lib/choose_repository.tcl:727
 #, tcl-format
 msgid "Nothing to clone from %s."
 msgstr "Nada para clonar de %s."
 
-#: lib/choose_repository.tcl:726 lib/choose_repository.tcl:940
-#: lib/choose_repository.tcl:952
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
 msgid "The 'master' branch has not been initialized."
 msgstr "O ramo 'master' não foi inicializado."
 
-#: lib/choose_repository.tcl:739
+#: lib/choose_repository.tcl:742
 msgid "Hardlinks are unavailable.  Falling back to copying."
 msgstr "Ligações fixas indisponíveis. A recorrer a cópia."
 
-#: lib/choose_repository.tcl:751
+#: lib/choose_repository.tcl:754
 #, tcl-format
 msgid "Cloning from %s"
 msgstr "A clonar de %s"
 
-#: lib/choose_repository.tcl:782
+#: lib/choose_repository.tcl:785
 msgid "Copying objects"
 msgstr "A copiar objetos"
 
-#: lib/choose_repository.tcl:783
+#: lib/choose_repository.tcl:786
 msgid "KiB"
 msgstr "KiB"
 
-#: lib/choose_repository.tcl:807
+#: lib/choose_repository.tcl:810
 #, tcl-format
 msgid "Unable to copy object: %s"
 msgstr "Não é possível copiar objeto: %s"
 
-#: lib/choose_repository.tcl:817
+#: lib/choose_repository.tcl:820
 msgid "Linking objects"
 msgstr "A ligar objetos"
 
-#: lib/choose_repository.tcl:818
+#: lib/choose_repository.tcl:821
 msgid "objects"
 msgstr "objetos"
 
-#: lib/choose_repository.tcl:826
+#: lib/choose_repository.tcl:829
 #, tcl-format
 msgid "Unable to hardlink object: %s"
 msgstr "Não é possível criar ligação fixa de objeto: %s"
 
-#: lib/choose_repository.tcl:881
+#: lib/choose_repository.tcl:884
 msgid "Cannot fetch branches and objects.  See console output for details."
 msgstr ""
 "Não é possível obter ramos e objetos. Ver saída na consola para detalhes."
 
-#: lib/choose_repository.tcl:892
+#: lib/choose_repository.tcl:895
 msgid "Cannot fetch tags.  See console output for details."
 msgstr "Não é possível obter tags. Ver saída na consola para detalhes."
 
-#: lib/choose_repository.tcl:916
+#: lib/choose_repository.tcl:919
 msgid "Cannot determine HEAD.  See console output for details."
 msgstr "Não é possível determinar HEAD. Ver saída na consola para detalhes."
 
-#: lib/choose_repository.tcl:925
+#: lib/choose_repository.tcl:928
 #, tcl-format
 msgid "Unable to cleanup %s"
 msgstr "Não foi possível limpar %s"
 
-#: lib/choose_repository.tcl:931
+#: lib/choose_repository.tcl:934
 msgid "Clone failed."
 msgstr "Falha ao clonar."
 
-#: lib/choose_repository.tcl:938
+#: lib/choose_repository.tcl:941
 msgid "No default branch obtained."
 msgstr "Não foi obtido nenhum ramo predefinido."
 
-#: lib/choose_repository.tcl:949
+#: lib/choose_repository.tcl:952
 #, tcl-format
 msgid "Cannot resolve %s as a commit."
 msgstr "Não é possível resolver %s como um commit."
 
-#: lib/choose_repository.tcl:961
+#: lib/choose_repository.tcl:964
 msgid "Creating working directory"
 msgstr "A criar diretório de trabalho"
 
-#: lib/choose_repository.tcl:962 lib/index.tcl:70 lib/index.tcl:136
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
 #: lib/index.tcl:207
 msgid "files"
 msgstr "ficheiros"
 
-#: lib/choose_repository.tcl:981
+#: lib/choose_repository.tcl:984
 msgid "Cannot clone submodules."
 msgstr "Não é possível clonar submódulos."
 
-#: lib/choose_repository.tcl:990
+#: lib/choose_repository.tcl:993
 msgid "Cloning submodules"
 msgstr "A clonar submódulos"
 
-#: lib/choose_repository.tcl:1015
+#: lib/choose_repository.tcl:1018
 msgid "Initial file checkout failed."
 msgstr "Falha de extração inicial de ficheiro."
 
-#: lib/choose_repository.tcl:1059
+#: lib/choose_repository.tcl:1062
 msgid "Open"
 msgstr "Abrir"
 
-#: lib/choose_repository.tcl:1069
+#: lib/choose_repository.tcl:1072
 msgid "Repository:"
 msgstr "Repositório:"
 
-#: lib/choose_repository.tcl:1118
+#: lib/choose_repository.tcl:1121
 #, tcl-format
 msgid "Failed to open repository %s:"
 msgstr "Falha ao abrir o repositório %s:"
@@ -1940,7 +2145,8 @@ msgid "git-gui - a graphical user interface for Git."
 msgstr "git-gui - uma interface gráfica do Git."
 
 #: lib/blame.tcl:73
-msgid "File Viewer"
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
 msgstr "Visualizador de ficheiros"
 
 #: lib/blame.tcl:79
@@ -2094,7 +2300,8 @@ msgid "Your key is in: %s"
 msgstr "A sua chave encontra-se em: %s"
 
 #: lib/branch_create.tcl:23
-msgid "Create Branch"
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
 msgstr "Criar ramo"
 
 #: lib/branch_create.tcl:28
@@ -2139,11 +2346,12 @@ msgid "Tracking branch %s is not a branch in the remote repository."
 msgstr "O ramo de monitorização %s não é um ramo no repositório remoto."
 
 #: lib/commit.tcl:9
+#, fuzzy
 msgid ""
-"There is nothing to amend.\n"
-"\n"
+"There is nothing to amend.\r\n"
+"\r\n"
 "You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
+"to amend.\r\n"
 msgstr ""
 "Não há nada para emendar.\n"
 "\n"
@@ -2151,43 +2359,45 @@ msgstr ""
 "emendar.\n"
 
 #: lib/commit.tcl:18
+#, fuzzy
 msgid ""
-"Cannot amend while merging.\n"
-"\n"
+"Cannot amend while merging.\r\n"
+"\r\n"
 "You are currently in the middle of a merge that has not been fully "
 "completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
+"current merge activity.\r\n"
 msgstr ""
 "Não é possível emendar ao mesmo tempo que se integra.\n"
 "\n"
 "Há uma integração em curso que não foi concluída. Não pode emendar o commit "
 "anterior a não ser que primeiro aborte a atividade da integração atual.\n"
 
-#: lib/commit.tcl:48
+#: lib/commit.tcl:50
 msgid "Error loading commit data for amend:"
 msgstr "Erro ao carregar dados do commit para emendar:"
 
-#: lib/commit.tcl:75
+#: lib/commit.tcl:77
 msgid "Unable to obtain your identity:"
 msgstr "Não é possível obter a sua identidade:"
 
-#: lib/commit.tcl:80
+#: lib/commit.tcl:82
 msgid "Invalid GIT_COMMITTER_IDENT:"
 msgstr "GIT_COMMITTER_IDENT inválido:"
 
-#: lib/commit.tcl:129
+#: lib/commit.tcl:132
 #, tcl-format
 msgid "warning: Tcl does not support encoding '%s'."
 msgstr "aviso: Tcl não suporta a codificação '%s'."
 
-#: lib/commit.tcl:149
+#: lib/commit.tcl:152
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "O último estado analisado não corresponde ao estado do repositório.\n"
 "\n"
@@ -2196,49 +2406,51 @@ msgstr ""
 "\n"
 "Irá-se reanalisar automaticamente agora.\n"
 
-#: lib/commit.tcl:173
-#, tcl-format
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
 msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
 "File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
+"before committing.\r\n"
 msgstr ""
 "Não pode fazer commit de ficheiros não integrados.\n"
 "\n"
 "O ficheiro %s tem conflitos de integração. Deve resolvê-los e preparar o "
 "ficheiro antes de submeter.\n"
 
-#: lib/commit.tcl:181
-#, tcl-format
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
 msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
 msgstr ""
 "Detetado estado de ficheiro %s desconhecido.\n"
 "\n"
 "Este programa não pode submeter o ficheiro %s.\n"
 
-#: lib/commit.tcl:189
+#: lib/commit.tcl:192
+#, fuzzy
 msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
 msgstr ""
 "Nenhum alteração para submeter.\n"
 "\n"
 "Deve preparar pelo menos 1 ficheiro antes de submeter.\n"
 
-#: lib/commit.tcl:204
+#: lib/commit.tcl:207
+#, fuzzy
 msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
 msgstr ""
 "Forneça uma mensagem de commit.\n"
 "\n"
@@ -2248,22 +2460,26 @@ msgstr ""
 "- Segunda linha: em branco.\n"
 "- Linhas restantes: descreve porque esta alteração é vantajosa.\n"
 
-#: lib/commit.tcl:235
+#: lib/commit.tcl:238
 msgid "Calling pre-commit hook..."
 msgstr "A invocar gancho de pré-commit (pre-commit hook)..."
 
-#: lib/commit.tcl:250
+#: lib/commit.tcl:253
 msgid "Commit declined by pre-commit hook."
 msgstr "Commit recusado pela retina de pré-commit (pre-commit hook)."
 
-#: lib/commit.tcl:269
+#: lib/commit.tcl:272
+#, fuzzy
 msgid ""
-"You are about to commit on a detached head. This is a potentially dangerous "
-"thing to do because if you switch to another branch you will lose your "
-"changes and it can be difficult to retrieve them later from the reflog. You "
-"should probably cancel this commit and create a new branch to continue.\n"
-" \n"
-" Do you really want to proceed with your Commit?"
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
 msgstr ""
 "Está prestes a submeter numa cabeça destacada. Fazê-lo é potencialmente "
 "perigoso, porque, se mudar para outro ramo, perderá as suas alterações e "
@@ -2272,38 +2488,39 @@ msgstr ""
 "\n"
 "Pretende mesmo continuar com o commit?"
 
-#: lib/commit.tcl:290
+#: lib/commit.tcl:293
 msgid "Calling commit-msg hook..."
 msgstr "A invocar gancho de mensagem-de-commit (commit-msg hook)..."
 
-#: lib/commit.tcl:305
+#: lib/commit.tcl:308
 msgid "Commit declined by commit-msg hook."
 msgstr "Commit recusado pelo gancho de mensagem-de-commit (commit-msg hook)."
 
-#: lib/commit.tcl:318
+#: lib/commit.tcl:321
 msgid "Committing changes..."
 msgstr "A submeter alterações..."
 
-#: lib/commit.tcl:334
+#: lib/commit.tcl:338
 msgid "write-tree failed:"
 msgstr "write-tree falhou:"
 
-#: lib/commit.tcl:335 lib/commit.tcl:379 lib/commit.tcl:400
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
 msgid "Commit failed."
 msgstr "Falha ao submeter."
 
-#: lib/commit.tcl:352
+#: lib/commit.tcl:356
 #, tcl-format
 msgid "Commit %s appears to be corrupt"
 msgstr "O commit %s parece estar corrompido"
 
-#: lib/commit.tcl:357
+#: lib/commit.tcl:361
+#, fuzzy
 msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
 msgstr ""
 "Não há alterações para submeter.\n"
 "\n"
@@ -2312,25 +2529,26 @@ msgstr ""
 "\n"
 "Irá-se reanalisar agora automaticamente.\n"
 
-#: lib/commit.tcl:364
+#: lib/commit.tcl:368
 msgid "No changes to commit."
 msgstr "Não há alterações para submeter."
 
-#: lib/commit.tcl:378
+#: lib/commit.tcl:388
 msgid "commit-tree failed:"
 msgstr "commit-tree falhou:"
 
-#: lib/commit.tcl:399
+#: lib/commit.tcl:415
 msgid "update-ref failed:"
 msgstr "update-ref falhou:"
 
-#: lib/commit.tcl:492
+#: lib/commit.tcl:508
 #, tcl-format
 msgid "Created commit %s: %s"
 msgstr "Commit %s criado: %s"
 
 #: lib/branch_delete.tcl:16
-msgid "Delete Branch"
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
 msgstr "Eliminar ramo"
 
 #: lib/branch_delete.tcl:21
@@ -2349,6 +2567,11 @@ msgstr "Eliminar só se foi integrado"
 #, tcl-format
 msgid "The following branches are not completely merged into %s:"
 msgstr "Os seguintes ramos não foram completamente integrados em %s:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
 
 #: lib/branch_delete.tcl:141
 #, tcl-format
@@ -2414,30 +2637,49 @@ msgstr "Preparar %d ficheiros não controlados?"
 msgid "Adding all changed files"
 msgstr "A adicionar todos os ficheiros controlados"
 
-#: lib/index.tcl:428
+#: lib/index.tcl:440
 #, tcl-format
 msgid "Revert changes in file %s?"
 msgstr "Reverter alterações no ficheiro %s?"
 
-#: lib/index.tcl:430
+#: lib/index.tcl:442
 #, tcl-format
 msgid "Revert changes in these %i files?"
 msgstr "Reverter alterações nestes %i ficheiros?"
 
-#: lib/index.tcl:438
+#: lib/index.tcl:450
 msgid "Any unstaged changes will be permanently lost by the revert."
 msgstr ""
 "Qualquer alteração não preparada será permanentemente perdida ao reverter."
 
-#: lib/index.tcl:441
+#: lib/index.tcl:453 lib/index.tcl:488
 msgid "Do Nothing"
 msgstr "Não fazer nada"
 
-#: lib/index.tcl:459
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Preparar %d ficheiros não controlados?"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Preparar %d ficheiros não controlados?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Eliminar"
+
+#: lib/index.tcl:528
 msgid "Reverting selected files"
 msgstr "A reverter ficheiros selecionados"
 
-#: lib/index.tcl:463
+#: lib/index.tcl:532
 #, tcl-format
 msgid "Reverting %s"
 msgstr "A reverter %s"
@@ -2529,6 +2771,11 @@ msgstr "Objetos compactados à espera de poda"
 msgid "Garbage files"
 msgstr "Ficheiros de lixo"
 
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Estatísticas da base de dados"
+
 #: lib/database.tcl:72
 msgid "Compressing the object database"
 msgstr "A comprimir a base de dados de objetos"
@@ -2538,13 +2785,13 @@ msgid "Verifying the object database with fsck-objects"
 msgstr "A verificar a base de dados de objetos com fsck-objects"
 
 #: lib/database.tcl:107
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
 "To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
+"the database.\r\n"
+"\r\n"
 "Compress the database now?"
 msgstr ""
 "Este repositório tem aproximadamente %i objetos soltos.\n"
@@ -2554,160 +2801,36 @@ msgstr ""
 "\n"
 "Comprimir a base de dados agora?"
 
-#: lib/error.tcl:20 lib/error.tcl:116
-msgid "error"
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
 msgstr "erro"
 
 #: lib/error.tcl:36
-msgid "warning"
+#, fuzzy, tcl-format
+msgid "%s: warning"
 msgstr "aviso"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "A ferramenta falhou: %s"
 
 #: lib/error.tcl:96
 msgid "You must correct the above errors before committing."
 msgstr "Deve corrigir os erros acima antes de submeter."
 
-#: lib/merge.tcl:13
-msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
-msgstr ""
-"Não possível integrar ao mesmo tempo que se emenda.\n"
-"\n"
-"Deve acabar de emendar este commit antes de iniciar qualquer tipo de "
-"integração.\n"
-
-#: lib/merge.tcl:27
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"O último estado analisado não corresponde ao estado do repositório.\n"
-"\n"
-"Outro programa Git modificou este repositório deste a última análise. Deve-"
-"se reanalisar antes de se poder integrar.\n"
-"\n"
-"Irá-se reanalisar agora automaticamente.\n"
-
-#: lib/merge.tcl:45
+#: lib/error.tcl:116
 #, tcl-format
-msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
-"You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+msgid "%s (%s): error"
 msgstr ""
-"Integração com conflitos em curso.\n"
-"\n"
-"O ficheiro %s tem conflitos de integração.\n"
-"\n"
-"Deve resolvê-los, preparar o ficheiro e submeter para concluir a integração "
-"atual. Só então pode iniciar outra integração.\n"
 
-#: lib/merge.tcl:55
-#, tcl-format
-msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
-"You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
-msgstr ""
-"Tem alterações presentes.\n"
-"\n"
-"O ficheiro %s foi modificado.\n"
-"\n"
-"Deve concluir o commit atual antes de iniciar uma integração. Assim, ajuda-o "
-"a abortar uma integração falhada, caso necessário.\n"
-
-#: lib/merge.tcl:108
-#, tcl-format
-msgid "%s of %s"
-msgstr "%s de %s"
-
-#: lib/merge.tcl:122
-#, tcl-format
-msgid "Merging %s and %s..."
-msgstr "A integrar %s e %s..."
-
-#: lib/merge.tcl:133
-msgid "Merge completed successfully."
-msgstr "Integração concluída com sucesso."
-
-#: lib/merge.tcl:135
-msgid "Merge failed.  Conflict resolution is required."
-msgstr "Integração falhada. É necessário resolver conflitos."
-
-#: lib/merge.tcl:160
-#, tcl-format
-msgid "Merge Into %s"
-msgstr "Integrar em %s"
-
-#: lib/merge.tcl:179
-msgid "Revision To Merge"
-msgstr "Revisão a integrar"
-
-#: lib/merge.tcl:214
-msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
-msgstr ""
-"Não é possível abortar enquanto se emenda.\n"
-"\n"
-"Deve acabar de emendar este commit.\n"
-
-#: lib/merge.tcl:224
-msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with aborting the current merge?"
-msgstr ""
-"Abortar integração?\n"
-"\n"
-"Ao abortar a integração atual perderá *TODAS* as alteração que não foram "
-"submetidas.\n"
-"\n"
-"Continuar a abortar a integração atual?"
-
-#: lib/merge.tcl:230
-msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with resetting the current changes?"
-msgstr ""
-"Repor alterações?\n"
-"\n"
-"Ao repor as alterações perderá *TODAS* as alterações não submetidas.\n"
-"\n"
-"Continuar a repor as alterações atuais?"
-
-#: lib/merge.tcl:241
-msgid "Aborting"
-msgstr "A abortar"
-
-#: lib/merge.tcl:241
-msgid "files reset"
-msgstr "ficheiros repostos"
-
-#: lib/merge.tcl:269
-msgid "Abort failed."
-msgstr "Falha ao abortar."
-
-#: lib/merge.tcl:271
-msgid "Abort completed.  Ready."
-msgstr "Aborto concluído. Pronto."
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* O ficheiro não controlado tem %d bytes.\n"
+#~ "* Exibido apenas os primeiros %d bytes.\n"
 
 #~ msgid "Displaying only %s of %s files."
 #~ msgstr "A mostrar apenas %s de %s ficheiros."

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,852 +8,631 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git Russian Localization Project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-01-26 15:47-0800\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2016-06-30 12:39+0000\n"
 "Last-Translator: Dimitriy Ryazantcev <DJm00n@mail.ru>\n"
-"Language-Team: Russian (http://www.transifex.com/djm00n/git-po-ru/language/ru/)\n"
+"Language-Team: Russian (http://www.transifex.com/djm00n/git-po-ru/language/"
+"ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: git-gui.sh:41 git-gui.sh:793 git-gui.sh:807 git-gui.sh:820 git-gui.sh:903
-#: git-gui.sh:922
-msgid "git-gui: fatal error"
-msgstr "git-gui: критическая ошибка"
-
-#: git-gui.sh:743
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "В %s установлен неверный шрифт:"
 
-#: git-gui.sh:779
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Шрифт интерфейса"
 
-#: git-gui.sh:780
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Шрифт консоли и изменений (diff)"
 
-#: git-gui.sh:794
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: критическая ошибка"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "git не найден в PATH."
 
-#: git-gui.sh:821
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Невозможно распознать строку версии Git: "
 
-#: git-gui.sh:839
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
+msgstr ""
+"Невозможно определить версию Git\n"
 "\n"
-"%s claims it is version '%s'.\n"
+"%s указывает на версию «%s».\n"
 "\n"
-"%s requires at least Git 1.5.0 or later.\n"
+"для %s требуется версия Git, начиная с 1.5.0\n"
 "\n"
-"Assume '%s' is version 1.5.0?\n"
-msgstr "Невозможно определить версию Git\n\n%s указывает на версию «%s».\n\nдля %s требуется версия Git, начиная с 1.5.0\n\nПредположить, что «%s» и есть версия 1.5.0?\n"
+"Предположить, что «%s» и есть версия 1.5.0?\n"
 
-#: git-gui.sh:1128
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Каталог Git не найден:"
 
-#: git-gui.sh:1146
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Невозможно перейти к корню рабочего каталога репозитория: "
 
-#: git-gui.sh:1154
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Невозможно использование репозитория без рабочего каталога:"
 
-#: git-gui.sh:1162
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Отсутствует рабочий каталог"
 
-#: git-gui.sh:1334 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Обновление информации о состоянии файлов…"
 
-#: git-gui.sh:1390
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Поиск измененных файлов…"
 
-#: git-gui.sh:1454
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "Вызов перехватчика prepare-commit-msg…"
 
-#: git-gui.sh:1471
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "Коммит прерван перехватчиком prepare-commit-msg."
 
-#: git-gui.sh:1629 lib/browser.tcl:246
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Готово."
 
-#: git-gui.sh:1787
+#: git-gui.sh:1966
 #, tcl-format
-msgid "Displaying only %s of %s files."
-msgstr "Показано %s из %s файлов."
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
 
-#: git-gui.sh:1913
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Не изменено"
 
-#: git-gui.sh:1915
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Изменено, не в индексе"
 
-#: git-gui.sh:1916 git-gui.sh:1924
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "В индексе для коммита"
 
-#: git-gui.sh:1917 git-gui.sh:1925
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Части, в индексе для коммита"
 
-#: git-gui.sh:1918 git-gui.sh:1926
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "В индексе для коммита, отсутствует"
 
-#: git-gui.sh:1920
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Тип файла изменён, не в индексе"
 
-#: git-gui.sh:1921
+#: git-gui.sh:2097 git-gui.sh:2098
+#, fuzzy
+msgid "File type changed, old type staged for commit"
+msgstr "Тип файла изменён, не в индексе"
+
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Тип файла изменён, в индексе"
 
-#: git-gui.sh:1923
+#: git-gui.sh:2100
+#, fuzzy
+msgid "File type change staged, modification not staged"
+msgstr "Тип файла изменён, не в индексе"
+
+#: git-gui.sh:2101
+#, fuzzy
+msgid "File type change staged, file missing"
+msgstr "Тип файла изменён, в индексе"
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Не отслеживается, не в индексе"
 
-#: git-gui.sh:1928
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Отсутствует"
 
-#: git-gui.sh:1929
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "В индексе для удаления"
 
-#: git-gui.sh:1930
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "В индексе для удаления, еще не удалено"
 
-#: git-gui.sh:1932 git-gui.sh:1933 git-gui.sh:1934 git-gui.sh:1935
-#: git-gui.sh:1936 git-gui.sh:1937
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Требуется разрешение конфликта при слиянии"
 
-#: git-gui.sh:1972
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Запускается gitk… Подождите, пожалуйста…"
 
-#: git-gui.sh:1984
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "gitk не найден в PATH."
 
-#: git-gui.sh:2043
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "git gui не найден в PATH."
 
-#: git-gui.sh:2455 lib/choose_repository.tcl:36
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Репозиторий"
 
-#: git-gui.sh:2456
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Редактировать"
 
-#: git-gui.sh:2458 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Ветка"
 
-#: git-gui.sh:2461 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Коммит"
 
-#: git-gui.sh:2464 lib/merge.tcl:121 lib/merge.tcl:150 lib/merge.tcl:168
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Слияние"
 
-#: git-gui.sh:2465 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Внешние репозитории"
 
-#: git-gui.sh:2468
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Вспомогательные операции"
 
-#: git-gui.sh:2477
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Просмотр рабочего каталога"
 
-#: git-gui.sh:2483
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Просмотреть файлы текущей ветки"
 
-#: git-gui.sh:2487
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Показать файлы ветки…"
 
-#: git-gui.sh:2492
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Показать историю текущей ветки"
 
-#: git-gui.sh:2496
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Показать историю всех веток"
 
-#: git-gui.sh:2503
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Показать файлы ветки %s"
 
-#: git-gui.sh:2505
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Показать историю ветки %s"
 
-#: git-gui.sh:2510 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Статистика базы данных"
 
-#: git-gui.sh:2513 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Сжать базу данных"
 
-#: git-gui.sh:2516
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Проверить базу данных"
 
-#: git-gui.sh:2523 git-gui.sh:2527 git-gui.sh:2531 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Создать ярлык на рабочем столе"
 
-#: git-gui.sh:2539 lib/choose_repository.tcl:183 lib/choose_repository.tcl:191
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Выход"
 
-#: git-gui.sh:2547
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Отменить"
 
-#: git-gui.sh:2550
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Повторить"
 
-#: git-gui.sh:2554 git-gui.sh:3109
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Вырезать"
 
-#: git-gui.sh:2557 git-gui.sh:3112 git-gui.sh:3186 git-gui.sh:3259
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Копировать"
 
-#: git-gui.sh:2560 git-gui.sh:3115
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Вставить"
 
-#: git-gui.sh:2563 git-gui.sh:3118 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Удалить"
 
-#: git-gui.sh:2567 git-gui.sh:3122 git-gui.sh:3263 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Выделить все"
 
-#: git-gui.sh:2576
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Создать…"
 
-#: git-gui.sh:2582
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Перейти…"
 
-#: git-gui.sh:2588
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Переименовать…"
 
-#: git-gui.sh:2593
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Удалить…"
 
-#: git-gui.sh:2598
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Сбросить…"
 
-#: git-gui.sh:2608
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Завершено"
 
-#: git-gui.sh:2610
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Закоммитить"
 
-#: git-gui.sh:2619 git-gui.sh:3050
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Новый коммит"
 
-#: git-gui.sh:2627 git-gui.sh:3057
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Исправить последний коммит"
 
-#: git-gui.sh:2637 git-gui.sh:3011 lib/remote_branch_delete.tcl:99
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Перечитать"
 
-#: git-gui.sh:2643
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Добавить в индекс"
 
-#: git-gui.sh:2649
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Добавить изменённые файлы в индекс"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Убрать из издекса"
 
-#: git-gui.sh:2661 lib/index.tcl:412
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Обратить изменения"
 
-#: git-gui.sh:2669 git-gui.sh:3310 git-gui.sh:3341
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Меньше контекста"
 
-#: git-gui.sh:2673 git-gui.sh:3314 git-gui.sh:3345
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Больше контекста"
 
-#: git-gui.sh:2680 git-gui.sh:3024 git-gui.sh:3133
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Вставить Signed-off-by"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Локальное слияние…"
 
-#: git-gui.sh:2701
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Прервать слияние…"
 
-#: git-gui.sh:2713 git-gui.sh:2741
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Добавить…"
 
-#: git-gui.sh:2717
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Отправить…"
 
-#: git-gui.sh:2721
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Удалить ветку…"
 
-#: git-gui.sh:2731 git-gui.sh:3292
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Настройки…"
 
-#: git-gui.sh:2742
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Удалить…"
 
-#: git-gui.sh:2751 lib/choose_repository.tcl:50
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Помощь"
 
-#: git-gui.sh:2755 git-gui.sh:2759 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:53
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "О %s"
 
-#: git-gui.sh:2783
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Документация в интернете"
 
-#: git-gui.sh:2786 lib/choose_repository.tcl:47 lib/choose_repository.tcl:56
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Показать ключ SSH"
 
-#: git-gui.sh:2893
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "ошибка"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr "критическая ошибка: %s: нет такого файла или каталога"
 
-#: git-gui.sh:2926
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Текущая ветка:"
 
-#: git-gui.sh:2947
-msgid "Staged Changes (Will Commit)"
-msgstr "Изменения в индексе (будут закоммичены)"
-
-#: git-gui.sh:2967
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Изменено (не будет сохранено)"
 
-#: git-gui.sh:3017
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Изменения в индексе (будут закоммичены)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Индексировать всё"
 
-#: git-gui.sh:3036 lib/transport.tcl:104 lib/transport.tcl:193
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Отправить"
 
-#: git-gui.sh:3071
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Сообщение первого коммита:"
 
-#: git-gui.sh:3072
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Сообщение исправленного коммита:"
 
-#: git-gui.sh:3073
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Сообщение исправленного первого коммита:"
 
-#: git-gui.sh:3074
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Сообщение исправленного слияния:"
 
-#: git-gui.sh:3075
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Сообщение слияния:"
 
-#: git-gui.sh:3076
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Сообщение коммита:"
 
-#: git-gui.sh:3125 git-gui.sh:3267 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Копировать все"
 
-#: git-gui.sh:3149 lib/blame.tcl:104
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Файл:"
 
-#: git-gui.sh:3255
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Обновить"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Уменьшить размер шрифта"
 
-#: git-gui.sh:3280
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Увеличить размер шрифта"
 
-#: git-gui.sh:3288 lib/blame.tcl:281
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Кодировка"
 
-#: git-gui.sh:3299
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Применить/Убрать изменение"
 
-#: git-gui.sh:3304
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Применить/Убрать строку"
 
-#: git-gui.sh:3323
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Запустить программу слияния"
 
-#: git-gui.sh:3328
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Взять внешнюю версию"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Взять локальную версию"
 
-#: git-gui.sh:3336
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Обратить изменения"
 
-#: git-gui.sh:3354
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Показать эти изменения подмодуля"
 
-#: git-gui.sh:3358
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Показать историю текущей ветки подмодуля"
 
-#: git-gui.sh:3362
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Показать историю всех веток подмодуля"
 
-#: git-gui.sh:3367
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Запустить git gui в подмодуле"
 
-#: git-gui.sh:3389
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Убрать блок из индекса"
 
-#: git-gui.sh:3391
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Убрать строки из индекса"
 
-#: git-gui.sh:3393
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Убрать строку из индекса"
 
-#: git-gui.sh:3396
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Добавить блок в индекс"
 
-#: git-gui.sh:3398
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Добавить строки в индекс"
 
-#: git-gui.sh:3400
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Добавить строку в индекс"
 
-#: git-gui.sh:3424
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Инициализация…"
 
-#: git-gui.sh:3541
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
+msgstr ""
+"Возможны ошибки в переменных окружения.\n"
 "\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
+"Переменные окружения, которые возможно\n"
+"будут проигнорированы командами Git,\n"
+"запущенными из %s\n"
 "\n"
-msgstr "Возможны ошибки в переменных окружения.\n\nПеременные окружения, которые возможно\nбудут проигнорированы командами Git,\nзапущенными из %s\n\n"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
-msgstr "\nЭто известная проблема с Tcl,\nраспространяемым Cygwin."
+msgstr ""
+"\n"
+"Это известная проблема с Tcl,\n"
+"распространяемым Cygwin."
 
-#: git-gui.sh:3575
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
+msgstr ""
 "\n"
 "\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
-msgstr "\n\nВместо использования %s можно\nсохранить значения user.name и\nuser.email в Вашем персональном\nфайле ~/.gitconfig.\n"
-
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - графический пользовательский интерфейс к Git."
-
-#: lib/blame.tcl:72
-msgid "File Viewer"
-msgstr "Просмотр файла"
-
-#: lib/blame.tcl:78
-msgid "Commit:"
-msgstr "Коммит:"
-
-#: lib/blame.tcl:271
-msgid "Copy Commit"
-msgstr "Копировать SHA-1"
-
-#: lib/blame.tcl:275
-msgid "Find Text..."
-msgstr "Найти текст…"
-
-#: lib/blame.tcl:284
-msgid "Do Full Copy Detection"
-msgstr "Провести полный поиск копий"
-
-#: lib/blame.tcl:288
-msgid "Show History Context"
-msgstr "Показать исторический контекст"
-
-#: lib/blame.tcl:291
-msgid "Blame Parent Commit"
-msgstr "Авторы родительского коммита"
-
-#: lib/blame.tcl:450
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Чтение %s…"
-
-#: lib/blame.tcl:557
-msgid "Loading copy/move tracking annotations..."
-msgstr "Загрузка аннотации копирований/переименований…"
-
-#: lib/blame.tcl:577
-msgid "lines annotated"
-msgstr "строк прокомментировано"
-
-#: lib/blame.tcl:769
-msgid "Loading original location annotations..."
-msgstr "Загрузка аннотаций первоначального положения объекта…"
-
-#: lib/blame.tcl:772
-msgid "Annotation complete."
-msgstr "Аннотация завершена."
-
-#: lib/blame.tcl:802
-msgid "Busy"
-msgstr "Занят"
-
-#: lib/blame.tcl:803
-msgid "Annotation process is already running."
-msgstr "Аннотация уже запущена"
-
-#: lib/blame.tcl:842
-msgid "Running thorough copy detection..."
-msgstr "Выполнение полного поиска копий…"
-
-#: lib/blame.tcl:910
-msgid "Loading annotation..."
-msgstr "Загрузка аннотации…"
-
-#: lib/blame.tcl:963
-msgid "Author:"
-msgstr "Автор:"
-
-#: lib/blame.tcl:967
-msgid "Committer:"
-msgstr "Коммитер:"
-
-#: lib/blame.tcl:972
-msgid "Original File:"
-msgstr "Исходный файл:"
-
-#: lib/blame.tcl:1020
-msgid "Cannot find HEAD commit:"
-msgstr "Не удалось найти текущее состояние:"
-
-#: lib/blame.tcl:1075
-msgid "Cannot find parent commit:"
-msgstr "Не удалось найти родительское состояние:"
-
-#: lib/blame.tcl:1090
-msgid "Unable to display parent"
-msgstr "Не могу показать предка"
-
-#: lib/blame.tcl:1091 lib/diff.tcl:320
-msgid "Error loading diff:"
-msgstr "Ошибка загрузки изменений:"
-
-#: lib/blame.tcl:1231
-msgid "Originally By:"
-msgstr "Источник:"
-
-#: lib/blame.tcl:1237
-msgid "In File:"
-msgstr "Файл:"
-
-#: lib/blame.tcl:1242
-msgid "Copied Or Moved Here By:"
-msgstr "Скопировано/перемещено в:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Перейти на ветку"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Перейти"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:579 lib/choose_font.tcl:43 lib/merge.tcl:172
-#: lib/option.tcl:125 lib/remote_add.tcl:32 lib/remote_branch_delete.tcl:42
-#: lib/tools_dlg.tcl:40 lib/tools_dlg.tcl:204 lib/tools_dlg.tcl:352
-#: lib/transport.tcl:108
-msgid "Cancel"
-msgstr "Отмена"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287 lib/tools_dlg.tcl:328
-msgid "Revision"
-msgstr "Версия"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:280
-msgid "Options"
-msgstr "Настройки"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Извлечь изменения из внешней ветки"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "Отсоединить от локальной ветки"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "Создать ветку"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "Создать новую ветку"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:381
-msgid "Create"
-msgstr "Создать"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "Имя ветки"
-
-#: lib/branch_create.tcl:43 lib/remote_add.tcl:39 lib/tools_dlg.tcl:50
-msgid "Name:"
-msgstr "Название:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "Соответствовать имени отслеживаемой ветки"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Начальная версия"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Обновить имеющуюся ветку:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Нет"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Только Fast Forward"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr "Сброс"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "После создания сделать текущей"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "Укажите отлеживаемую ветку."
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "Отслеживаемая ветка %s не является веткой на внешнем репозитории."
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "Укажите имя ветки."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "Недопустимое имя ветки «%s»."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "Удаление ветки"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "Удалить локальную ветку"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "Локальные ветки"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "Удалить только в случае, если было слияние с"
-
-#: lib/branch_delete.tcl:54 lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "Всегда (не выполнять проверку на слияние)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Ветки, которые не полностью сливаются с %s:"
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:217
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr "Восстановить удаленные ветки сложно.\n\nПродолжить?"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr "Не удалось удалить ветки:\n%s"
-
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "Переименование ветки"
-
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "Переименовать"
-
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "Ветка:"
-
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "Новое название:"
-
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "Укажите ветку для переименования."
-
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "Ветка «%s» уже существует."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Не удалось переименовать «%s». "
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Запуск…"
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "Просмотр списка файлов"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Загрузка %s…"
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[На уровень выше]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "Показать файлы ветки"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:398
-#: lib/choose_repository.tcl:486 lib/choose_repository.tcl:497
-#: lib/choose_repository.tcl:1028
-msgid "Browse"
-msgstr "Показать"
+"Вместо использования %s можно\n"
+"сохранить значения user.name и\n"
+"user.email в Вашем персональном\n"
+"файле ~/.gitconfig.\n"
+
+#: lib/line.tcl:17
+msgid "Goto Line:"
+msgstr ""
+
+#: lib/line.tcl:23
+msgid "Go"
+msgstr ""
+
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "В процессе… пожалуйста, ждите…"
+
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Закрыть"
+
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Процесс успешно завершен"
+
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Ошибка: не удалось выполнить команду"
 
 #: lib/checkout_op.tcl:85
 #, tcl-format
@@ -865,11 +644,6 @@ msgstr "Извлечение %s из %s "
 msgid "fatal: Cannot resolve %s"
 msgstr "критическая ошибка: невозможно разрешить %s"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:31
-#: lib/sshkey.tcl:53
-msgid "Close"
-msgstr "Закрыть"
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -880,6 +654,11 @@ msgstr "Ветка «%s» не существует."
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Ошибка создания упрощённой конфигурации git pull для «%s»."
 
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "Ветка «%s» уже существует."
+
 #: lib/checkout_op.tcl:229
 #, tcl-format
 msgid ""
@@ -887,7 +666,11 @@ msgid ""
 "\n"
 "It cannot fast-forward to %s.\n"
 "A merge is required."
-msgstr "Ветка «%s» уже существует.\n\nОна не может быть перемотана вперед к %s.\nТребуется слияние."
+msgstr ""
+"Ветка «%s» уже существует.\n"
+"\n"
+"Она не может быть перемотана вперед к %s.\n"
+"Требуется слияние."
 
 #: lib/checkout_op.tcl:243
 #, tcl-format
@@ -904,13 +687,22 @@ msgid "Staging area (index) is already locked."
 msgstr "Рабочая область заблокирована другим процессом."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Последнее прочитанное состояние репозитория не соответствует текущему.\n"
 "\n"
-"Another Git program has modified this repository since the last scan.  A rescan must be performed before the current branch can be changed.\n"
+"С момента последней проверки репозиторий был изменен другой программой Git. "
+"Необходимо перечитать репозиторий, прежде чем текущая ветка может быть "
+"изменена.\n"
 "\n"
-"The rescan will be automatically started now.\n"
-msgstr "Последнее прочитанное состояние репозитория не соответствует текущему.\n\nС момента последней проверки репозиторий был изменен другой программой Git. Необходимо перечитать репозиторий, прежде чем текущая ветка может быть изменена.\n\nЭто будет сделано сейчас автоматически.\n"
+"Это будет сделано сейчас автоматически.\n"
 
 #: lib/checkout_op.tcl:345
 #, tcl-format
@@ -936,11 +728,17 @@ msgid "Staying on branch '%s'."
 msgstr "Ветка «%s» остаётся текущей."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
+"If you wanted to be on a branch, create one now starting from 'This Detached "
+"Checkout'."
+msgstr ""
+"Вы более не находитесь на локальной ветке.\n"
 "\n"
-"If you wanted to be on a branch, create one now starting from 'This Detached Checkout'."
-msgstr "Вы более не находитесь на локальной ветке.\n\nЕсли вы хотите снова вернуться к какой-нибудь ветке, создайте её сейчас, начиная с «Текущего отсоединенного состояния»."
+"Если вы хотите снова вернуться к какой-нибудь ветке, создайте её сейчас, "
+"начиная с «Текущего отсоединенного состояния»."
 
 #: lib/checkout_op.tcl:503 lib/checkout_op.tcl:507
 #, tcl-format
@@ -961,1160 +759,461 @@ msgstr "Восстановить потерянные коммиты будет 
 msgid "Reset '%s'?"
 msgstr "Сбросить «%s»?"
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:164 lib/tools_dlg.tcl:343
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Наглядно"
 
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Сброс"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Отмена"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
-"This working directory is only partially switched.  We successfully updated your files, but failed to update an internal Git file.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
+"This working directory is only partially switched.  We successfully updated "
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
-msgstr "Не удалось установить текущую ветку.\n\nВаш рабочий каталог обновлён только частично. Были обновлены все файлы кроме служебных файлов Git. \n\nЭтого не должно было произойти. %s завершается."
-
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "Выбрать"
-
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "Шрифт"
-
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "Размер шрифта"
-
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "Пример текста"
-
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
-msgstr "Это пример текста.\nЕсли Вам нравится этот текст, это может быть Ваш шрифт."
-
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
-
-#: lib/choose_repository.tcl:87 lib/choose_repository.tcl:386
-msgid "Create New Repository"
-msgstr "Создать новый репозиторий"
-
-#: lib/choose_repository.tcl:93
-msgid "New..."
-msgstr "Новый…"
-
-#: lib/choose_repository.tcl:100 lib/choose_repository.tcl:471
-msgid "Clone Existing Repository"
-msgstr "Склонировать существующий репозиторий"
-
-#: lib/choose_repository.tcl:106
-msgid "Clone..."
-msgstr "Клонировать…"
-
-#: lib/choose_repository.tcl:113 lib/choose_repository.tcl:1016
-msgid "Open Existing Repository"
-msgstr "Выбрать существующий репозиторий"
-
-#: lib/choose_repository.tcl:119
-msgid "Open..."
-msgstr "Открыть…"
-
-#: lib/choose_repository.tcl:132
-msgid "Recent Repositories"
-msgstr "Недавние репозитории"
-
-#: lib/choose_repository.tcl:138
-msgid "Open Recent Repository:"
-msgstr "Открыть последний репозиторий"
-
-#: lib/choose_repository.tcl:306 lib/choose_repository.tcl:313
-#: lib/choose_repository.tcl:320
-#, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Не удалось создать репозиторий %s:"
-
-#: lib/choose_repository.tcl:391
-msgid "Directory:"
-msgstr "Каталог:"
-
-#: lib/choose_repository.tcl:423 lib/choose_repository.tcl:550
-#: lib/choose_repository.tcl:1052
-msgid "Git Repository"
-msgstr "Репозиторий"
-
-#: lib/choose_repository.tcl:448
-#, tcl-format
-msgid "Directory %s already exists."
-msgstr "Каталог '%s' уже существует."
-
-#: lib/choose_repository.tcl:452
-#, tcl-format
-msgid "File %s already exists."
-msgstr "Файл '%s' уже существует."
-
-#: lib/choose_repository.tcl:466
-msgid "Clone"
-msgstr "Склонировать"
-
-#: lib/choose_repository.tcl:479
-msgid "Source Location:"
-msgstr "Исходное положение:"
-
-#: lib/choose_repository.tcl:490
-msgid "Target Directory:"
-msgstr "Каталог назначения:"
-
-#: lib/choose_repository.tcl:502
-msgid "Clone Type:"
-msgstr "Тип клона:"
-
-#: lib/choose_repository.tcl:508
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Стандартный (Быстрый, полуизбыточный, «жесткие» ссылки)"
-
-#: lib/choose_repository.tcl:514
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Полная копия (Медленный, создает резервную копию)"
-
-#: lib/choose_repository.tcl:520
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Общий (Самый быстрый, не рекомендуется, без резервной копии)"
-
-#: lib/choose_repository.tcl:556 lib/choose_repository.tcl:603
-#: lib/choose_repository.tcl:749 lib/choose_repository.tcl:819
-#: lib/choose_repository.tcl:1058 lib/choose_repository.tcl:1066
-#, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Каталог не является репозиторием: %s"
-
-#: lib/choose_repository.tcl:592
-msgid "Standard only available for local repository."
-msgstr "Стандартный клон возможен только для локального репозитория."
-
-#: lib/choose_repository.tcl:596
-msgid "Shared only available for local repository."
-msgstr "Общий клон возможен только для локального репозитория."
-
-#: lib/choose_repository.tcl:617
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "Путь '%s' уже существует."
-
-#: lib/choose_repository.tcl:628
-msgid "Failed to configure origin"
-msgstr "Не могу сконфигурировать исходный репозиторий."
-
-#: lib/choose_repository.tcl:640
-msgid "Counting objects"
-msgstr "Считаю объекты"
-
-#: lib/choose_repository.tcl:641
-msgid "buckets"
-msgstr "блоки"
-
-#: lib/choose_repository.tcl:665
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Не могу скопировать objects/info/alternates: %s"
-
-#: lib/choose_repository.tcl:701
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Нечего клонировать с %s."
-
-#: lib/choose_repository.tcl:703 lib/choose_repository.tcl:917
-#: lib/choose_repository.tcl:929
-msgid "The 'master' branch has not been initialized."
-msgstr "Не инициализирована ветвь «master»."
-
-#: lib/choose_repository.tcl:716
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "«Жесткие ссылки» недоступны. Будет использовано копирование."
-
-#: lib/choose_repository.tcl:728
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Клонирование %s"
-
-#: lib/choose_repository.tcl:759
-msgid "Copying objects"
-msgstr "Копирование objects"
-
-#: lib/choose_repository.tcl:760
-msgid "KiB"
-msgstr "КБ"
-
-#: lib/choose_repository.tcl:784
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Не могу скопировать объект: %s"
-
-#: lib/choose_repository.tcl:794
-msgid "Linking objects"
-msgstr "Создание ссылок на objects"
-
-#: lib/choose_repository.tcl:795
-msgid "objects"
-msgstr "объекты"
-
-#: lib/choose_repository.tcl:803
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Не могу создать «жесткую ссылку» на объект: %s"
-
-#: lib/choose_repository.tcl:858
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr "Не удалось извлечь ветки и объекты. Дополнительная информация на консоли."
-
-#: lib/choose_repository.tcl:869
-msgid "Cannot fetch tags.  See console output for details."
-msgstr "Не удалось извлечь метки. Дополнительная информация на консоли."
-
-#: lib/choose_repository.tcl:893
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr "Не могу определить HEAD. Дополнительная информация на консоли."
-
-#: lib/choose_repository.tcl:902
-#, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Не могу очистить %s"
-
-#: lib/choose_repository.tcl:908
-msgid "Clone failed."
-msgstr "Клонирование не удалось."
-
-#: lib/choose_repository.tcl:915
-msgid "No default branch obtained."
-msgstr "Ветка по умолчанию не была получена."
-
-#: lib/choose_repository.tcl:926
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Не могу распознать %s как коммит."
-
-#: lib/choose_repository.tcl:938
-msgid "Creating working directory"
-msgstr "Создаю рабочий каталог"
-
-#: lib/choose_repository.tcl:939 lib/index.tcl:67 lib/index.tcl:130
-#: lib/index.tcl:198
-msgid "files"
-msgstr "файлов"
-
-#: lib/choose_repository.tcl:968
-msgid "Initial file checkout failed."
-msgstr "Не удалось получить начальное состояние файлов репозитория."
-
-#: lib/choose_repository.tcl:1011
-msgid "Open"
-msgstr "Открыть"
-
-#: lib/choose_repository.tcl:1021
-msgid "Repository:"
-msgstr "Репозиторий:"
-
-#: lib/choose_repository.tcl:1072
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Не удалось открыть репозиторий %s:"
-
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "Текущее отсоединенное состояние"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Выражение для определения версии:"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "Локальная ветка:"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "Отслеживаемая ветка"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "Метка"
-
-#: lib/choose_rev.tcl:317
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Неверная версия: %s"
-
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "Версия не указана."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "Пустое выражение для определения версии."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "Обновлено"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "Ссылка"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
+msgstr ""
+"Не удалось установить текущую ветку.\n"
 "\n"
-"You are about to create the initial commit.  There is no commit before this to amend.\n"
-msgstr "Отсутствует коммиты для исправления.\n\nВы создаете начальный коммит, здесь еще нечего исправлять.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
+"Ваш рабочий каталог обновлён только частично. Были обновлены все файлы кроме "
+"служебных файлов Git. \n"
 "\n"
-"You are currently in the middle of a merge that has not been fully completed.  You cannot amend the prior commit unless you first abort the current merge activity.\n"
-msgstr "Невозможно исправить коммит во время слияния.\n\nТекущее слияние не завершено. Невозможно исправить предыдуий коммит, не прерывая эту операцию.\n"
+"Этого не должно было произойти. %s завершается."
 
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Ошибка при загрузке данных для исправления коммита:"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Невозможно получить информацию об авторстве:"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Недопустимый GIT_COMMITTER_IDENT:"
-
-#: lib/commit.tcl:129
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
 #, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "предупреждение: Tcl не поддерживает кодировку «%s»."
+msgid "fetch %s"
+msgstr "извлечение %s"
 
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr "Последнее прочитанное состояние репозитория не соответствует текущему.\n\nС момента последней проверки репозиторий был изменен другой программой Git. Необходимо перечитать репозиторий, прежде чем изменять текущую ветвь. \n\nЭто будет сделано сейчас автоматически.\n"
-
-#: lib/commit.tcl:172
+#: lib/transport.tcl:7
 #, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file before committing.\n"
-msgstr "Нельзя выполнить коммит с незавершённой операцией слияния.\n\nДля файла %s возник конфликт слияния. Разрешите конфликт и добавьте их в индекс перед выполнением коммита.\n"
+msgid "Fetching new changes from %s"
+msgstr "Извлечение изменений из %s "
 
-#: lib/commit.tcl:180
+#: lib/transport.tcl:18
 #, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr "Обнаружено неизвестное состояние файла %s.\n\nФайл %s не может быть закоммичен этой программой.\n"
+msgid "remote prune %s"
+msgstr "чистка внешнего %s"
 
-#: lib/commit.tcl:188
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr "Отсутствуют изменения для сохранения.\n\nДобавьте в индекс хотя бы один файл перед выполнением коммита.\n"
-
-#: lib/commit.tcl:203
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr "Укажите сообщение коммита.\n\nРекомендуется следующий формат сообщения:\n\n- в первой строке краткое описание сделанных изменений\n- вторая строка пустая\n- в оставшихся строках опишите, что дают ваши изменения\n"
-
-#: lib/commit.tcl:234
-msgid "Calling pre-commit hook..."
-msgstr "Вызов перехватчика pre-commit…"
-
-#: lib/commit.tcl:249
-msgid "Commit declined by pre-commit hook."
-msgstr "Коммит прерван переватчиком pre-commit."
-
-#: lib/commit.tcl:272
-msgid "Calling commit-msg hook..."
-msgstr "Вызов перехватчика commit-msg…"
-
-#: lib/commit.tcl:287
-msgid "Commit declined by commit-msg hook."
-msgstr "Коммит прерван переватчиком commit-msg"
-
-#: lib/commit.tcl:300
-msgid "Committing changes..."
-msgstr "Коммит изменений…"
-
-#: lib/commit.tcl:316
-msgid "write-tree failed:"
-msgstr "Программа write-tree завершилась с ошибкой:"
-
-#: lib/commit.tcl:317 lib/commit.tcl:361 lib/commit.tcl:382
-msgid "Commit failed."
-msgstr "Не удалось закоммитить изменения."
-
-#: lib/commit.tcl:334
+#: lib/transport.tcl:19
 #, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Коммит %s похоже поврежден"
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Чистка отслеживаемых веток, удалённых из %s"
 
-#: lib/commit.tcl:339
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr "Нет изменения для коммита.\n\nНи один файл не был изменен и не было слияния.\n\nСейчас автоматически запустится перечитывание репозитория.\n"
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
+msgstr ""
 
-#: lib/commit.tcl:346
-msgid "No changes to commit."
-msgstr "Нет изменения для коммита."
+#: lib/transport.tcl:26
+#, fuzzy
+msgid "Fetching new changes from all remotes"
+msgstr "Извлечение изменений из %s "
 
-#: lib/commit.tcl:360
-msgid "commit-tree failed:"
-msgstr "Программа commit-tree завершилась с ошибкой:"
+#: lib/transport.tcl:40
+#, fuzzy
+msgid "remote prune all remotes"
+msgstr "чистка внешнего %s"
 
-#: lib/commit.tcl:381
-msgid "update-ref failed:"
-msgstr "Программа update-ref завершилась с ошибкой:"
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Чистка отслеживаемых веток, удалённых из %s"
 
-#: lib/commit.tcl:469
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Создан коммит %s: %s "
+msgid "push %s"
+msgstr "отправить %s"
 
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "В процессе… пожалуйста, ждите…"
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Процесс успешно завершен"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Ошибка: не удалось выполнить команду"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "Количество несвязанных объектов"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "Объем дискового пространства, занятый несвязанными объектами"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "Количество упакованных объектов"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "Количество pack-файлов"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "Объем дискового пространства, занятый упакованными объектами"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "Несвязанные объекты, которые можно удалить"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "Мусор"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Сжатие базы объектов"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Проверка базы объектов при помощи fsck"
-
-#: lib/database.tcl:107
+#: lib/transport.tcl:55
 #, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress the database.\n"
-"\n"
-"Compress the database now?"
-msgstr "Этот репозиторий сейчас содержит примерно %i свободных объектов\n\nДля лучшей производительности рекомендуется сжать базу данных.\n\nСжать базу данных сейчас?"
+msgid "Pushing changes to %s"
+msgstr "Отправка изменений в %s "
 
-#: lib/date.tcl:25
+#: lib/transport.tcl:93
 #, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Неправильная дата в репозитории: %s"
+msgid "Mirroring to %s"
+msgstr "Точное копирование в %s"
 
-#: lib/diff.tcl:64
+#: lib/transport.tcl:111
 #, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have the same state."
-msgstr "Изменений не обнаружено.\n\nв %s отсутствуют изменения.\n\nДата изменения файла была обновлена другой программой, но содержимое файла осталось прежним.\n\nСейчас будет запущено перечитывание репозитория, чтобы найти подобные файлы."
+msgid "Pushing %s %s to %s"
+msgstr "Отправка %s %s в %s"
 
-#: lib/diff.tcl:104
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Отправить ветки"
+
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Исходные ветки"
+
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Репозиторий назначения"
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "внешний:"
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Указанное положение:"
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Настройки отправки"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr ""
+"Принудительно перезаписать существующую ветку (возможна потеря изменений)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Использовать thin pack (для медленных сетевых подключений)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Передать метки"
+
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Загрузка изменений %s…"
-
-#: lib/diff.tcl:125
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr "ЛОКАЛЬНО: удалён\nВНЕШНИЙ:\n"
-
-#: lib/diff.tcl:130
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr "ВНЕШНИЙ: удалён\nЛОКАЛЬНО:\n"
-
-#: lib/diff.tcl:137
-msgid "LOCAL:\n"
-msgstr "ЛОКАЛЬНО:\n"
-
-#: lib/diff.tcl:140
-msgid "REMOTE:\n"
-msgstr "ВНЕШНИЙ:\n"
-
-#: lib/diff.tcl:202 lib/diff.tcl:319
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Не могу показать %s"
-
-#: lib/diff.tcl:203
-msgid "Error loading file:"
-msgstr "Ошибка загрузки файла:"
-
-#: lib/diff.tcl:210
-msgid "Git Repository (subproject)"
-msgstr "Репозиторий Git (подпроект)"
-
-#: lib/diff.tcl:222
-msgid "* Binary file (not showing content)."
-msgstr "* Двоичный файл (содержимое не показано)"
-
-#: lib/diff.tcl:227
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr "* Размер неотслеживаемого файла %d байт.\n* Показано первых %d байт.\n"
-
-#: lib/diff.tcl:233
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr "\n* Неотслеживаемый файл обрезан: %s.\n* Чтобы увидеть весь файл, используйте внешний редактор.\n"
-
-#: lib/diff.tcl:482
-msgid "Failed to unstage selected hunk."
-msgstr "Не удалось исключить выбранную часть."
-
-#: lib/diff.tcl:489
-msgid "Failed to stage selected hunk."
-msgstr "Не удалось проиндексировать выбранный блок изменений."
-
-#: lib/diff.tcl:568
-msgid "Failed to unstage selected line."
-msgstr "Не удалось исключить выбранную строку."
-
-#: lib/diff.tcl:576
-msgid "Failed to stage selected line."
-msgstr "Не удалось проиндексировать выбранную строку."
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "По умолчанию"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Системная (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Другая"
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "ошибка"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "предупреждение"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr "Перед коммитом, исправьте вышеуказанные ошибки."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Не удалось разблокировать индекс"
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "Ошибка в индексе"
-
-#: lib/index.tcl:17
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr "Не удалось обновить индекс Git. Состояние репозитория будет перечитано автоматически."
-
-#: lib/index.tcl:28
-msgid "Continue"
-msgstr "Продолжить"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "Разблокировать индекс"
-
-#: lib/index.tcl:289
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Удаление %s из индекса"
-
-#: lib/index.tcl:328
-msgid "Ready to commit."
-msgstr "Готов для коммита."
-
-#: lib/index.tcl:341
-#, tcl-format
-msgid "Adding %s"
-msgstr "Добавление %s…"
-
-#: lib/index.tcl:398
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Обратить изменения в файле %s?"
-
-#: lib/index.tcl:400
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Обратить изменения в %i файле(-ах)?"
-
-#: lib/index.tcl:408
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr "Любые непроиндексированные изменения, будут потеряны при обращении изменений."
-
-#: lib/index.tcl:411
-msgid "Do Nothing"
-msgstr "Ничего не делать"
-
-#: lib/index.tcl:429
-msgid "Reverting selected files"
-msgstr "Обращение изменений в выбранных файлах"
-
-#: lib/index.tcl:433
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Обращение изменений в %s"
-
-#: lib/merge.tcl:13
-msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
-msgstr "Невозможно выполнить слияние во время исправления.\n\nЗавершите исправление данного коммита перед выполнением операции слияния.\n"
-
-#: lib/merge.tcl:27
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr "Последнее прочитанное состояние репозитория не соответствует текущему.\n\nС момента последней проверки репозиторий был изменен другой программой Git. Необходимо перечитать репозиторий, прежде чем слияние может быть сделано.\n\nЭто будет сделано сейчас автоматически.\n"
-
-#: lib/merge.tcl:45
-#, tcl-format
-msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
-"You must resolve them, stage the file, and commit to complete the current merge.  Only then can you begin another merge.\n"
-msgstr "Предыдущее слияние не завершено из-за конфликта.\n\nДля файла %s возник конфликт слияния.\n\nРазрешите конфликт, добавьте файл в индекс и закоммитьте. Только после этого можно начать следующее слияние.\n"
-
-#: lib/merge.tcl:55
-#, tcl-format
-msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
-"You should complete the current commit before starting a merge.  Doing so will help you abort a failed merge, should the need arise.\n"
-msgstr "Вы находитесь в процессе изменений.\n\nФайл %s изменён.\n\nВы должны завершить текущий коммит перед началом слияния. В случае необходимости, это позволит прервать операцию слияния.\n"
-
-#: lib/merge.tcl:107
-#, tcl-format
-msgid "%s of %s"
-msgstr "%s из %s"
-
-#: lib/merge.tcl:120
-#, tcl-format
-msgid "Merging %s and %s..."
-msgstr "Слияние %s и %s…"
-
-#: lib/merge.tcl:131
-msgid "Merge completed successfully."
-msgstr "Слияние успешно завершено."
-
-#: lib/merge.tcl:133
-msgid "Merge failed.  Conflict resolution is required."
-msgstr "Не удалось завершить слияние. Требуется разрешение конфликта."
-
-#: lib/merge.tcl:158
-#, tcl-format
-msgid "Merge Into %s"
-msgstr "Слияние с %s"
-
-#: lib/merge.tcl:177
-msgid "Revision To Merge"
-msgstr "Версия, с которой провести слияние"
-
-#: lib/merge.tcl:212
-msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
-msgstr "Невозможно прервать исправление.\n\nЗавершите текущее исправление коммита.\n"
-
-#: lib/merge.tcl:222
-msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with aborting the current merge?"
-msgstr "Прервать операцию слияния?\n\nПрерывание текущего слияния приведет к потере *ВСЕХ* несохраненных изменений.\n\nПродолжить?"
-
-#: lib/merge.tcl:228
-msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with resetting the current changes?"
-msgstr "Сбросить изменения?\n\nСброс изменений приведет к потере *ВСЕХ* несохраненных изменений.\n\nПродолжить?"
-
-#: lib/merge.tcl:239
-msgid "Aborting"
-msgstr "Прерываю"
-
-#: lib/merge.tcl:239
-msgid "files reset"
-msgstr "изменения в файлах отменены"
-
-#: lib/merge.tcl:267
-msgid "Abort failed."
-msgstr "Прервать не удалось."
-
-#: lib/merge.tcl:269
-msgid "Abort completed.  Ready."
-msgstr "Прервано."
-
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Использовать базовую версию для разрешения конфликта?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Использовать версию из этой ветки для разрешения конфликта?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Использовать версию из другой ветки для разрешения конфликта?"
-
-#: lib/mergetool.tcl:14
-#, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr "Внимание! Список изменений показывает только конфликтующие отличия.\n\n%s будет переписан.\n\nЭто действие можно отменить только перезапуском операции слияния."
-
-#: lib/mergetool.tcl:45
-#, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr "Похоже, что файл %s содержит неразрешенные конфликты. Продолжить индексацию?"
-
-#: lib/mergetool.tcl:60
-#, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Добавляю результат разрешения для %s"
-
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr "Программа слияния не обрабатывает конфликты с удалением или участием ссылок"
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "Конфликтующий файл не существует"
-
-#: lib/mergetool.tcl:264
-#, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "«%s» не является программой слияния"
-
-#: lib/mergetool.tcl:268
-#, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "Неподдерживаемая программа слияния «%s»"
-
-#: lib/mergetool.tcl:303
-msgid "Merge tool is already running, terminate it?"
-msgstr "Программа слияния уже работает. Прервать?"
-
-#: lib/mergetool.tcl:323
-#, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr "Ошибка получения версий:\n%s"
-
-#: lib/mergetool.tcl:343
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr "Ошибка запуска программы слияния:\n\n%s"
-
-#: lib/mergetool.tcl:347
-msgid "Running merge tool..."
-msgstr "Запуск программы слияния…"
-
-#: lib/mergetool.tcl:375 lib/mergetool.tcl:383
-msgid "Merge tool failed."
-msgstr "Ошибка выполнения программы слияния."
-
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr "Неверная глобальная кодировка «%s»"
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr "Неверная кодировка репозитория «%s»"
-
-#: lib/option.tcl:117
-msgid "Restore Defaults"
-msgstr "Восстановить настройки по умолчанию"
-
-#: lib/option.tcl:121
-msgid "Save"
-msgstr "Сохранить"
-
-#: lib/option.tcl:131
-#, tcl-format
-msgid "%s Repository"
-msgstr "Для репозитория %s"
-
-#: lib/option.tcl:132
-msgid "Global (All Repositories)"
-msgstr "Общие (для всех репозиториев)"
-
-#: lib/option.tcl:138
-msgid "User Name"
-msgstr "Имя пользователя"
-
-#: lib/option.tcl:139
-msgid "Email Address"
-msgstr "Адрес электронной почты"
-
-#: lib/option.tcl:141
-msgid "Summarize Merge Commits"
-msgstr "Суммарное сообщение при слиянии"
-
-#: lib/option.tcl:142
-msgid "Merge Verbosity"
-msgstr "Уровень детальности сообщений при слиянии"
-
-#: lib/option.tcl:143
-msgid "Show Diffstat After Merge"
-msgstr "Показать отчет об изменениях после слияния"
-
-#: lib/option.tcl:144
-msgid "Use Merge Tool"
-msgstr "Использовать для слияния программу"
-
-#: lib/option.tcl:146
-msgid "Trust File Modification Timestamps"
-msgstr "Доверять времени модификации файла"
-
-#: lib/option.tcl:147
-msgid "Prune Tracking Branches During Fetch"
-msgstr "Чистка отслеживаемых веток при извлечении изменений"
-
-#: lib/option.tcl:148
-msgid "Match Tracking Branches"
-msgstr "Такое же имя, как и у отслеживаемой ветки"
-
-#: lib/option.tcl:149
-msgid "Blame Copy Only On Changed Files"
-msgstr "Поиск копий только в изменённых файлах"
-
-#: lib/option.tcl:150
-msgid "Minimum Letters To Blame Copy On"
-msgstr "Минимальное количество символов для поиска копий"
-
-#: lib/option.tcl:151
-msgid "Blame History Context Radius (days)"
-msgstr "Радиус исторического контекста (в днях)"
-
-#: lib/option.tcl:152
-msgid "Number of Diff Context Lines"
-msgstr "Число строк в контексте diff"
-
-#: lib/option.tcl:153
-msgid "Commit Message Text Width"
-msgstr "Ширина текста сообщения коммита"
-
-#: lib/option.tcl:154
-msgid "New Branch Name Template"
-msgstr "Шаблон для имени новой ветки"
-
-#: lib/option.tcl:155
-msgid "Default File Contents Encoding"
-msgstr "Кодировка содержания файла по умолчанию"
-
-#: lib/option.tcl:203
-msgid "Change"
-msgstr "Изменить"
-
-#: lib/option.tcl:230
-msgid "Spelling Dictionary:"
-msgstr "Словарь для проверки правописания:"
-
-#: lib/option.tcl:254
-msgid "Change Font"
-msgstr "Изменить"
-
-#: lib/option.tcl:258
-#, tcl-format
-msgid "Choose %s"
-msgstr "Выберите %s"
-
-#: lib/option.tcl:264
-msgid "pt."
-msgstr "pt."
-
-#: lib/option.tcl:278
-msgid "Preferences"
-msgstr "Настройки"
-
-#: lib/option.tcl:314
-msgid "Failed to completely save options:"
-msgstr "Не удалось полностью сохранить настройки:"
-
-#: lib/remote.tcl:163
-msgid "Remove Remote"
-msgstr "Удалить ссылку на внешний репозиторий"
-
-#: lib/remote.tcl:168
-msgid "Prune from"
-msgstr "Чистка"
-
-#: lib/remote.tcl:173
-msgid "Fetch from"
-msgstr "Извлечение из"
-
-#: lib/remote.tcl:215
-msgid "Push to"
-msgstr "Отправить"
-
-#: lib/remote_add.tcl:19
-msgid "Add Remote"
+msgid "%s (%s): Push"
+msgstr ""
+
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
 msgstr "Зарегистрировать внешний репозиторий"
 
-#: lib/remote_add.tcl:24
+#: lib/remote_add.tcl:25
 msgid "Add New Remote"
 msgstr "Добавить внешний репозиторий"
 
-#: lib/remote_add.tcl:28 lib/tools_dlg.tcl:36
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
 msgid "Add"
 msgstr "Добавить"
 
-#: lib/remote_add.tcl:37
+#: lib/remote_add.tcl:39
 msgid "Remote Details"
 msgstr "Информация о внешнем репозитории"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Название:"
 
 #: lib/remote_add.tcl:50
 msgid "Location:"
 msgstr "Положение:"
 
-#: lib/remote_add.tcl:62
+#: lib/remote_add.tcl:60
 msgid "Further Action"
 msgstr "Следующая операция"
 
-#: lib/remote_add.tcl:65
+#: lib/remote_add.tcl:63
 msgid "Fetch Immediately"
 msgstr "Сразу извлечь изменения"
 
-#: lib/remote_add.tcl:71
+#: lib/remote_add.tcl:69
 msgid "Initialize Remote Repository and Push"
 msgstr "Инициализировать внешний репозиторий и отправить"
 
-#: lib/remote_add.tcl:77
+#: lib/remote_add.tcl:75
 msgid "Do Nothing Else Now"
 msgstr "Больше ничего не делать"
 
-#: lib/remote_add.tcl:101
+#: lib/remote_add.tcl:100
 msgid "Please supply a remote name."
 msgstr "Укажите название внешнего репозитория."
 
-#: lib/remote_add.tcl:114
+#: lib/remote_add.tcl:113
 #, tcl-format
 msgid "'%s' is not an acceptable remote name."
 msgstr "«%s» не является допустимым именем внешнего репозитория."
 
-#: lib/remote_add.tcl:125
+#: lib/remote_add.tcl:124
 #, tcl-format
 msgid "Failed to add remote '%s' of location '%s'."
 msgstr "Не удалось добавить «%s» из «%s». "
 
-#: lib/remote_add.tcl:133 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "извлечение %s"
-
-#: lib/remote_add.tcl:134
+#: lib/remote_add.tcl:133
 #, tcl-format
 msgid "Fetching the %s"
 msgstr "Извлечение %s"
 
-#: lib/remote_add.tcl:157
+#: lib/remote_add.tcl:156
 #, tcl-format
 msgid "Do not know how to initialize repository at location '%s'."
 msgstr "Невозможно инициализировать репозиторий в «%s»."
 
-#: lib/remote_add.tcl:163 lib/transport.tcl:25 lib/transport.tcl:63
-#: lib/transport.tcl:81
-#, tcl-format
-msgid "push %s"
-msgstr "отправить %s"
-
-#: lib/remote_add.tcl:164
+#: lib/remote_add.tcl:163
 #, tcl-format
 msgid "Setting up the %s (at %s)"
 msgstr "Настройка %s (в %s)"
 
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Удаление ветки во внешнем репозитории"
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Запуск…"
 
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "Из репозитория"
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Просмотр списка файлов"
 
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:134
-msgid "Remote:"
-msgstr "внешний:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:149
-msgid "Arbitrary Location:"
-msgstr "Указанное положение:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "Ветки"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "Удалить только в случае, если"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "Слияние с:"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "Для операции «Слияние с» требуется указать ветку."
-
-#: lib/remote_branch_delete.tcl:184
+#: lib/browser.tcl:132 lib/browser.tcl:149
 #, tcl-format
+msgid "Loading %s..."
+msgstr "Загрузка %s…"
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[На уровень выше]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Показать файлы ветки"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Показать файлы ветки"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Показать"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Версия"
+
+#: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"The following branches are not completely merged into %s:\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
+msgstr ""
+"Невозможно выполнить слияние во время исправления.\n"
 "\n"
-" - %s"
-msgstr "Следующие ветки могут быть объединены с %s при помощи операции слияния:\n\n - %s"
+"Завершите исправление данного коммита перед выполнением операции слияния.\n"
 
-#: lib/remote_branch_delete.tcl:189
-#, tcl-format
+#: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr "Некоторые тесты на слияние не прошли, потому что вы не извлекли необходимые коммиты. Попытайтесь извлечь их из %s."
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Последнее прочитанное состояние репозитория не соответствует текущему.\n"
+"\n"
+"С момента последней проверки репозиторий был изменен другой программой Git. "
+"Необходимо перечитать репозиторий, прежде чем слияние может быть сделано.\n"
+"\n"
+"Это будет сделано сейчас автоматически.\n"
 
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "Укажите одну или несколько веток для удаления."
+#: lib/merge.tcl:45
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
+"You must resolve them, stage the file, and commit to complete the current "
+"merge.  Only then can you begin another merge.\r\n"
+msgstr ""
+"Предыдущее слияние не завершено из-за конфликта.\n"
+"\n"
+"Для файла %s возник конфликт слияния.\n"
+"\n"
+"Разрешите конфликт, добавьте файл в индекс и закоммитьте. Только после этого "
+"можно начать следующее слияние.\n"
 
-#: lib/remote_branch_delete.tcl:226
+#: lib/merge.tcl:55
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
+"You should complete the current commit before starting a merge.  Doing so "
+"will help you abort a failed merge, should the need arise.\r\n"
+msgstr ""
+"Вы находитесь в процессе изменений.\n"
+"\n"
+"Файл %s изменён.\n"
+"\n"
+"Вы должны завершить текущий коммит перед началом слияния. В случае "
+"необходимости, это позволит прервать операцию слияния.\n"
+
+#: lib/merge.tcl:108
 #, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Удаление веток из %s"
+msgid "%s of %s"
+msgstr "%s из %s"
 
-#: lib/remote_branch_delete.tcl:292
-msgid "No repository selected."
-msgstr "Не указан репозиторий."
-
-#: lib/remote_branch_delete.tcl:297
+#: lib/merge.tcl:126
 #, tcl-format
-msgid "Scanning %s..."
-msgstr "Перечитывание %s…"
+msgid "Merging %s and %s..."
+msgstr "Слияние %s и %s…"
 
-#: lib/search.tcl:21
-msgid "Find:"
-msgstr "Поиск:"
+#: lib/merge.tcl:137
+msgid "Merge completed successfully."
+msgstr "Слияние успешно завершено."
 
-#: lib/search.tcl:23
-msgid "Next"
-msgstr "Дальше"
+#: lib/merge.tcl:139
+msgid "Merge failed.  Conflict resolution is required."
+msgstr "Не удалось завершить слияние. Требуется разрешение конфликта."
 
-#: lib/search.tcl:24
-msgid "Prev"
-msgstr "Обратно"
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
 
-#: lib/search.tcl:25
-msgid "Case-Sensitive"
-msgstr "Игн. большие/маленькие"
+#: lib/merge.tcl:164
+#, tcl-format
+msgid "Merge Into %s"
+msgstr "Слияние с %s"
 
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "Невозможно записать ссылку:"
+#: lib/merge.tcl:183
+msgid "Revision To Merge"
+msgstr "Версия, с которой провести слияние"
 
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "Невозможно записать значок:"
+#: lib/merge.tcl:218
+#, fuzzy
+msgid ""
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
+msgstr ""
+"Невозможно прервать исправление.\n"
+"\n"
+"Завершите текущее исправление коммита.\n"
+
+#: lib/merge.tcl:228
+#, fuzzy
+msgid ""
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
+"Continue with aborting the current merge?"
+msgstr ""
+"Прервать операцию слияния?\n"
+"\n"
+"Прерывание текущего слияния приведет к потере *ВСЕХ* несохраненных "
+"изменений.\n"
+"\n"
+"Продолжить?"
+
+#: lib/merge.tcl:234
+#, fuzzy
+msgid ""
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
+"Continue with resetting the current changes?"
+msgstr ""
+"Сбросить изменения?\n"
+"\n"
+"Сброс изменений приведет к потере *ВСЕХ* несохраненных изменений.\n"
+"\n"
+"Продолжить?"
+
+#: lib/merge.tcl:245
+msgid "Aborting"
+msgstr "Прерываю"
+
+#: lib/merge.tcl:245
+msgid "files reset"
+msgstr "изменения в файлах отменены"
+
+#: lib/merge.tcl:273
+msgid "Abort failed."
+msgstr "Прервать не удалось."
+
+#: lib/merge.tcl:275
+msgid "Abort completed.  Ready."
+msgstr "Прервано."
+
+#: lib/tools.tcl:76
+#, tcl-format
+msgid "Running %s requires a selected file."
+msgstr "Запуск %s требует выбранного файла."
+
+#: lib/tools.tcl:92
+#, fuzzy, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Действительно запустить %s?"
+
+#: lib/tools.tcl:96
+#, tcl-format
+msgid "Are you sure you want to run %s?"
+msgstr "Действительно запустить %s?"
+
+#: lib/tools.tcl:118
+#, tcl-format
+msgid "Tool: %s"
+msgstr "Вспомогательная операция: %s"
+
+#: lib/tools.tcl:119
+#, tcl-format
+msgid "Running: %s"
+msgstr "Выполнение: %s"
+
+#: lib/tools.tcl:158
+#, tcl-format
+msgid "Tool completed successfully: %s"
+msgstr "Программа %s завершилась успешно."
+
+#: lib/tools.tcl:160
+#, tcl-format
+msgid "Tool failed: %s"
+msgstr "Ошибка выполнения программы: %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Перейти на ветку"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Перейти на ветку"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Перейти"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Настройки"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Извлечь изменения из внешней ветки"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Отсоединить от локальной ветки"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -2153,6 +1252,1009 @@ msgstr "Программа проверки правописания прерв�
 msgid "Spell Checker Failed"
 msgstr "Ошибка проверки правописания"
 
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s … %*i из %*i %s (%3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Изменений не обнаружено.\n"
+"\n"
+"в %s отсутствуют изменения.\n"
+"\n"
+"Дата изменения файла была обновлена другой программой, но содержимое файла "
+"осталось прежним.\n"
+"\n"
+"Сейчас будет запущено перечитывание репозитория, чтобы найти подобные файлы."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Загрузка изменений %s…"
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"ЛОКАЛЬНО: удалён\n"
+"ВНЕШНИЙ:\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"ВНЕШНИЙ: удалён\n"
+"ЛОКАЛЬНО:\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "ЛОКАЛЬНО:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "ВНЕШНИЙ:\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Не могу показать %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Ошибка загрузки файла:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Репозиторий Git (подпроект)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Двоичный файл (содержимое не показано)"
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* Неотслеживаемый файл обрезан: %s.\n"
+"* Чтобы увидеть весь файл, используйте внешний редактор.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Ошибка загрузки изменений:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Не удалось исключить выбранную часть."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Не удалось проиндексировать выбранный блок изменений."
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Не удалось исключить выбранную строку."
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Не удалось проиндексировать выбранную строку."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Отправить"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Удалить ссылку на внешний репозиторий"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Чистка"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Извлечение из"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "Выбрать"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "Шрифт"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "Размер шрифта"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "Пример текста"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"Это пример текста.\n"
+"Если Вам нравится этот текст, это может быть Ваш шрифт."
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr "Неверная глобальная кодировка «%s»"
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr "Неверная кодировка репозитория «%s»"
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "Восстановить настройки по умолчанию"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "Сохранить"
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr "Для репозитория %s"
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "Общие (для всех репозиториев)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "Имя пользователя"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Адрес электронной почты"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "Суммарное сообщение при слиянии"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "Уровень детальности сообщений при слиянии"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "Показать отчет об изменениях после слияния"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr "Использовать для слияния программу"
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "Доверять времени модификации файла"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr "Чистка отслеживаемых веток при извлечении изменений"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "Такое же имя, как и у отслеживаемой ветки"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr "Поиск копий только в изменённых файлах"
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "Недавние репозитории"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr "Минимальное количество символов для поиска копий"
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr "Радиус исторического контекста (в днях)"
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Число строк в контексте diff"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr "Ширина текста сообщения коммита"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "Шаблон для имени новой ветки"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr "Кодировка содержания файла по умолчанию"
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
+msgid "Change"
+msgstr "Изменить"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr "Словарь для проверки правописания:"
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "Изменить"
+
+#: lib/option.tcl:288
+#, tcl-format
+msgid "Choose %s"
+msgstr "Выберите %s"
+
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "pt."
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "Настройки"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "Не удалось полностью сохранить настройки:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Использовать базовую версию для разрешения конфликта?"
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Использовать версию из этой ветки для разрешения конфликта?"
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Использовать версию из другой ветки для разрешения конфликта?"
+
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+"Внимание! Список изменений показывает только конфликтующие отличия.\n"
+"\n"
+"%s будет переписан.\n"
+"\n"
+"Это действие можно отменить только перезапуском операции слияния."
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+"Похоже, что файл %s содержит неразрешенные конфликты. Продолжить индексацию?"
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr "Добавляю результат разрешения для %s"
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+"Программа слияния не обрабатывает конфликты с удалением или участием ссылок"
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "Конфликтующий файл не существует"
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "«%s» не является программой слияния"
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr "Неподдерживаемая программа слияния «%s»"
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "Программа слияния уже работает. Прервать?"
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Ошибка получения версий:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+"Ошибка запуска программы слияния:\n"
+"\n"
+"%s"
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "Запуск программы слияния…"
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "Ошибка выполнения программы слияния."
+
+#: lib/tools_dlg.tcl:22
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr "Добавить вспомогательную операцию"
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr "Новая вспомогательная операция"
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr "Добавить для всех репозиториев"
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr "Описание вспомогательной операции"
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr "Используйте «/» для создания подменю"
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr "Команда:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr "Показать диалог перед запуском"
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr "Запрос на выбор версии (устанавливает $REVISION)"
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr "Запрос дополнительных аргументов (устанавливает $ARGS)"
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr "Не показывать окно вывода команды"
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr "Запуск только если показан список изменений ($FILENAME не пусто)"
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr "Укажите название вспомогательной операции."
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "Вспомогательная операция «%s» уже существует."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+"Ошибка добавления программы:\n"
+"%s"
+
+#: lib/tools_dlg.tcl:187
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr "Удалить программу"
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr "Удалить команды программы"
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr "Удалить"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr "(Синим выделены программы локальные репозиторию)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Системная (%s)"
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr "Запуск команды: %s"
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr "Аргументы"
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr "OK"
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Поиск:"
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Дальше"
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Обратно"
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Создать ярлык на рабочем столе"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Невозможно записать ссылку:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Невозможно записать значок:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Переименование ветки"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Переименование ветки"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Переименовать"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Ветка:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Новое название:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Укажите ветку для переименования."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Укажите имя ветки."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "Недопустимое имя ветки «%s»."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Не удалось переименовать «%s». "
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Удаление ветки во внешнем репозитории"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Удаление ветки во внешнем репозитории"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Из репозитория"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Ветки"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Удалить только в случае, если"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Слияние с:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Всегда (не выполнять проверку на слияние)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "Для операции «Слияние с» требуется указать ветку."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"Следующие ветки могут быть объединены с %s при помощи операции слияния:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Некоторые тесты на слияние не прошли, потому что вы не извлекли необходимые "
+"коммиты. Попытайтесь извлечь их из %s."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Укажите одну или несколько веток для удаления."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Восстановить удаленные ветки сложно.\n"
+"\n"
+"Продолжить?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Удаление веток из %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Не указан репозиторий."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Перечитывание %s…"
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Создать новый репозиторий"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Новый…"
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Склонировать существующий репозиторий"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Клонировать…"
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Выбрать существующий репозиторий"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Открыть…"
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Недавние репозитории"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Открыть последний репозиторий"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Не удалось создать репозиторий %s:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Создать"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Каталог:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Репозиторий"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "Каталог '%s' уже существует."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Файл '%s' уже существует."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Склонировать"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Исходное положение:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Каталог назначения:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Тип клона:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Стандартный (Быстрый, полуизбыточный, «жесткие» ссылки)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Полная копия (Медленный, создает резервную копию)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Общий (Самый быстрый, не рекомендуется, без резервной копии)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Каталог не является репозиторием: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Стандартный клон возможен только для локального репозитория."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "Общий клон возможен только для локального репозитория."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "Путь '%s' уже существует."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Не могу сконфигурировать исходный репозиторий."
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Считаю объекты"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "блоки"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Не могу скопировать objects/info/alternates: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Нечего клонировать с %s."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "Не инициализирована ветвь «master»."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "«Жесткие ссылки» недоступны. Будет использовано копирование."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Клонирование %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Копирование objects"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "КБ"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Не могу скопировать объект: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Создание ссылок на objects"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "объекты"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Не могу создать «жесткую ссылку» на объект: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Не удалось извлечь ветки и объекты. Дополнительная информация на консоли."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr "Не удалось извлечь метки. Дополнительная информация на консоли."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr "Не могу определить HEAD. Дополнительная информация на консоли."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Не могу очистить %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Клонирование не удалось."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Ветка по умолчанию не была получена."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Не могу распознать %s как коммит."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Создаю рабочий каталог"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "файлов"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Клонирование %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Не удалось получить начальное состояние файлов репозитория."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Открыть"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Репозиторий:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Не удалось открыть репозиторий %s:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - графический пользовательский интерфейс к Git."
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Просмотр файла"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Коммит:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Копировать SHA-1"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Найти текст…"
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "Клонировать…"
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Провести полный поиск копий"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Показать исторический контекст"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Авторы родительского коммита"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Чтение %s…"
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Загрузка аннотации копирований/переименований…"
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "строк прокомментировано"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Загрузка аннотаций первоначального положения объекта…"
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Аннотация завершена."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Занят"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "Аннотация уже запущена"
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Выполнение полного поиска копий…"
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Загрузка аннотации…"
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Автор:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Коммитер:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Исходный файл:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Не удалось найти текущее состояние:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Не удалось найти родительское состояние:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Не могу показать предка"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Источник:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "Файл:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Скопировано/перемещено в:"
+
 #: lib/sshkey.tcl:31
 msgid "No keys found."
 msgstr "Ключ не найден"
@@ -2166,217 +2268,569 @@ msgstr "Публичный ключ из %s"
 msgid "Generate Key"
 msgstr "Создать ключ"
 
-#: lib/sshkey.tcl:56
+#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "Скопировать в буфер обмена"
 
-#: lib/sshkey.tcl:70
+#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "Ваш публичный ключ OpenSSH"
 
-#: lib/sshkey.tcl:78
+#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Создание…"
 
-#: lib/sshkey.tcl:84
+#: lib/sshkey.tcl:86
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
 "\n"
 "%s"
-msgstr "Ошибка запуска ssh-keygen:\n\n%s"
+msgstr ""
+"Ошибка запуска ssh-keygen:\n"
+"\n"
+"%s"
 
-#: lib/sshkey.tcl:111
+#: lib/sshkey.tcl:113
 msgid "Generation failed."
 msgstr "Ключ не создан."
 
-#: lib/sshkey.tcl:118
+#: lib/sshkey.tcl:120
 msgid "Generation succeeded, but no keys found."
 msgstr "Создание ключа завершилось, но результат не был найден"
 
-#: lib/sshkey.tcl:121
+#: lib/sshkey.tcl:123
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "Ваш ключ находится в: %s"
 
-#: lib/status_bar.tcl:83
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Создать ветку"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Создать новую ветку"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Имя ветки"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Соответствовать имени отслеживаемой ветки"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Начальная версия"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Обновить имеющуюся ветку:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Нет"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Только Fast Forward"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "После создания сделать текущей"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Укажите отлеживаемую ветку."
+
+#: lib/branch_create.tcl:141
 #, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s … %*i из %*i %s (%3i%%)"
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "Отслеживаемая ветка %s не является веткой на внешнем репозитории."
 
-#: lib/tools.tcl:75
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Отсутствует коммиты для исправления.\n"
+"\n"
+"Вы создаете начальный коммит, здесь еще нечего исправлять.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Невозможно исправить коммит во время слияния.\n"
+"\n"
+"Текущее слияние не завершено. Невозможно исправить предыдуий коммит, не "
+"прерывая эту операцию.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Ошибка при загрузке данных для исправления коммита:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Невозможно получить информацию об авторстве:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Недопустимый GIT_COMMITTER_IDENT:"
+
+#: lib/commit.tcl:132
 #, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "Запуск %s требует выбранного файла."
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "предупреждение: Tcl не поддерживает кодировку «%s»."
 
-#: lib/tools.tcl:90
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Последнее прочитанное состояние репозитория не соответствует текущему.\n"
+"\n"
+"С момента последней проверки репозиторий был изменен другой программой Git. "
+"Необходимо перечитать репозиторий, прежде чем изменять текущую ветвь. \n"
+"\n"
+"Это будет сделано сейчас автоматически.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Нельзя выполнить коммит с незавершённой операцией слияния.\n"
+"\n"
+"Для файла %s возник конфликт слияния. Разрешите конфликт и добавьте их в "
+"индекс перед выполнением коммита.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Обнаружено неизвестное состояние файла %s.\n"
+"\n"
+"Файл %s не может быть закоммичен этой программой.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Отсутствуют изменения для сохранения.\n"
+"\n"
+"Добавьте в индекс хотя бы один файл перед выполнением коммита.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Укажите сообщение коммита.\n"
+"\n"
+"Рекомендуется следующий формат сообщения:\n"
+"\n"
+"- в первой строке краткое описание сделанных изменений\n"
+"- вторая строка пустая\n"
+"- в оставшихся строках опишите, что дают ваши изменения\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Вызов перехватчика pre-commit…"
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Коммит прерван переватчиком pre-commit."
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Вызов перехватчика commit-msg…"
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Коммит прерван переватчиком commit-msg"
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Коммит изменений…"
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "Программа write-tree завершилась с ошибкой:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Не удалось закоммитить изменения."
+
+#: lib/commit.tcl:356
 #, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Действительно запустить %s?"
+msgid "Commit %s appears to be corrupt"
+msgstr "Коммит %s похоже поврежден"
 
-#: lib/tools.tcl:110
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Нет изменения для коммита.\n"
+"\n"
+"Ни один файл не был изменен и не было слияния.\n"
+"\n"
+"Сейчас автоматически запустится перечитывание репозитория.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Нет изменения для коммита."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "Программа commit-tree завершилась с ошибкой:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "Программа update-ref завершилась с ошибкой:"
+
+#: lib/commit.tcl:508
 #, tcl-format
-msgid "Tool: %s"
-msgstr "Вспомогательная операция: %s"
+msgid "Created commit %s: %s"
+msgstr "Создан коммит %s: %s "
 
-#: lib/tools.tcl:111
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Удаление ветки"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Удалить локальную ветку"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Локальные ветки"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Удалить только в случае, если было слияние с"
+
+#: lib/branch_delete.tcl:103
 #, tcl-format
-msgid "Running: %s"
-msgstr "Выполнение: %s"
+msgid "The following branches are not completely merged into %s:"
+msgstr "Ветки, которые не полностью сливаются с %s:"
 
-#: lib/tools.tcl:149
+#: lib/branch_delete.tcl:131
 #, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Программа %s завершилась успешно."
+msgid " - %s:"
+msgstr ""
 
-#: lib/tools.tcl:151
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr "Ошибка выполнения программы: %s"
-
-#: lib/tools_dlg.tcl:22
-msgid "Add Tool"
-msgstr "Добавить вспомогательную операцию"
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr "Новая вспомогательная операция"
-
-#: lib/tools_dlg.tcl:33
-msgid "Add globally"
-msgstr "Добавить для всех репозиториев"
-
-#: lib/tools_dlg.tcl:45
-msgid "Tool Details"
-msgstr "Описание вспомогательной операции"
-
-#: lib/tools_dlg.tcl:48
-msgid "Use '/' separators to create a submenu tree:"
-msgstr "Используйте «/» для создания подменю"
-
-#: lib/tools_dlg.tcl:61
-msgid "Command:"
-msgstr "Команда:"
-
-#: lib/tools_dlg.tcl:74
-msgid "Show a dialog before running"
-msgstr "Показать диалог перед запуском"
-
-#: lib/tools_dlg.tcl:80
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr "Запрос на выбор версии (устанавливает $REVISION)"
-
-#: lib/tools_dlg.tcl:85
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr "Запрос дополнительных аргументов (устанавливает $ARGS)"
-
-#: lib/tools_dlg.tcl:92
-msgid "Don't show the command output window"
-msgstr "Не показывать окно вывода команды"
-
-#: lib/tools_dlg.tcl:97
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr "Запуск только если показан список изменений ($FILENAME не пусто)"
-
-#: lib/tools_dlg.tcl:121
-msgid "Please supply a name for the tool."
-msgstr "Укажите название вспомогательной операции."
-
-#: lib/tools_dlg.tcl:129
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr "Вспомогательная операция «%s» уже существует."
-
-#: lib/tools_dlg.tcl:151
+#: lib/branch_delete.tcl:141
 #, tcl-format
 msgid ""
-"Could not add tool:\n"
+"Failed to delete branches:\n"
 "%s"
-msgstr "Ошибка добавления программы:\n%s"
+msgstr ""
+"Не удалось удалить ветки:\n"
+"%s"
 
-#: lib/tools_dlg.tcl:190
-msgid "Remove Tool"
-msgstr "Удалить программу"
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Не удалось разблокировать индекс"
 
-#: lib/tools_dlg.tcl:196
-msgid "Remove Tool Commands"
-msgstr "Удалить команды программы"
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Ошибка в индексе"
 
-#: lib/tools_dlg.tcl:200
-msgid "Remove"
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Не удалось обновить индекс Git. Состояние репозитория будет перечитано "
+"автоматически."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Продолжить"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Разблокировать индекс"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Удаление %s из индекса"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "Удаление %s из индекса"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Готов для коммита."
+
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Обращение изменений в выбранных файлах"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "Добавление %s…"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr ""
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Обратить изменения в файле %s?"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Обратить изменения в %i файле(-ах)?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Любые непроиндексированные изменения, будут потеряны при обращении изменений."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Ничего не делать"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Удаление веток из %s"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Обратить изменения в %i файле(-ах)?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
 msgstr "Удалить"
 
-#: lib/tools_dlg.tcl:236
-msgid "(Blue denotes repository-local tools)"
-msgstr "(Синим выделены программы локальные репозиторию)"
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Обращение изменений в выбранных файлах"
 
-#: lib/tools_dlg.tcl:297
+#: lib/index.tcl:532
 #, tcl-format
-msgid "Run Command: %s"
-msgstr "Запуск команды: %s"
+msgid "Reverting %s"
+msgstr "Обращение изменений в %s"
 
-#: lib/tools_dlg.tcl:311
-msgid "Arguments"
-msgstr "Аргументы"
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "По умолчанию"
 
-#: lib/tools_dlg.tcl:348
-msgid "OK"
-msgstr "OK"
-
-#: lib/transport.tcl:7
+#: lib/encoding.tcl:448
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Извлечение изменений из %s "
+msgid "System (%s)"
+msgstr "Системная (%s)"
 
-#: lib/transport.tcl:18
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Другая"
+
+#: lib/date.tcl:25
 #, tcl-format
-msgid "remote prune %s"
-msgstr "чистка внешнего %s"
+msgid "Invalid date from Git: %s"
+msgstr "Неправильная дата в репозитории: %s"
 
-#: lib/transport.tcl:19
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Текущее отсоединенное состояние"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Выражение для определения версии:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Локальная ветка:"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Отслеживаемая ветка"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Метка"
+
+#: lib/choose_rev.tcl:321
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Чистка отслеживаемых веток, удалённых из %s"
+msgid "Invalid revision: %s"
+msgstr "Неверная версия: %s"
 
-#: lib/transport.tcl:26
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Версия не указана."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "Пустое выражение для определения версии."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Обновлено"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "Ссылка"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Количество несвязанных объектов"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Объем дискового пространства, занятый несвязанными объектами"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Количество упакованных объектов"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Количество pack-файлов"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Объем дискового пространства, занятый упакованными объектами"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Несвязанные объекты, которые можно удалить"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Мусор"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Статистика базы данных"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Сжатие базы объектов"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Проверка базы объектов при помощи fsck"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Этот репозиторий сейчас содержит примерно %i свободных объектов\n"
+"\n"
+"Для лучшей производительности рекомендуется сжать базу данных.\n"
+"\n"
+"Сжать базу данных сейчас?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "ошибка"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "предупреждение"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "Ошибка выполнения программы: %s"
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Перед коммитом, исправьте вышеуказанные ошибки."
+
+#: lib/error.tcl:116
 #, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Отправка изменений в %s "
+msgid "%s (%s): error"
+msgstr ""
 
-#: lib/transport.tcl:64
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr "Точное копирование в %s"
+#~ msgid "Displaying only %s of %s files."
+#~ msgstr "Показано %s из %s файлов."
 
-#: lib/transport.tcl:82
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Отправка %s %s в %s"
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Размер неотслеживаемого файла %d байт.\n"
+#~ "* Показано первых %d байт.\n"
 
-#: lib/transport.tcl:100
-msgid "Push Branches"
-msgstr "Отправить ветки"
-
-#: lib/transport.tcl:114
-msgid "Source Branches"
-msgstr "Исходные ветки"
-
-#: lib/transport.tcl:131
-msgid "Destination Repository"
-msgstr "Репозиторий назначения"
-
-#: lib/transport.tcl:169
-msgid "Transfer Options"
-msgstr "Настройки отправки"
-
-#: lib/transport.tcl:171
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr "Принудительно перезаписать существующую ветку (возможна потеря изменений)"
-
-#: lib/transport.tcl:175
-msgid "Use thin pack (for slow network connections)"
-msgstr "Использовать thin pack (для медленных сетевых подключений)"
-
-#: lib/transport.tcl:179
-msgid "Include tags"
-msgstr "Передать метки"
+#~ msgid "Case-Sensitive"
+#~ msgstr "Игн. большие/маленькие"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,15 +1,15 @@
 # Swedish translation of git-gui.
 # Copyright (C) 2007-2008 Shawn Pearce, et al.
 # This file is distributed under the same license as the git-gui package.
-#
+# 
 # Mikael Magnusson <mikachu@gmail.com>, 2008.
 # Peter Krefting <peter@softwolves.pp.se>, 2007-2008, 2015.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: sv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-27 10:15+0100\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2015-03-27 10:24+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -20,42 +20,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Gtranslator 2.91.6\n"
 
-#: git-gui.sh:861
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Ogiltigt teckensnitt angivet i %s:"
 
-#: git-gui.sh:915
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Huvudteckensnitt"
 
-#: git-gui.sh:916
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Diff/konsolteckensnitt"
 
-#: git-gui.sh:931 git-gui.sh:945 git-gui.sh:958 git-gui.sh:1048
-#: git-gui.sh:1067 git-gui.sh:3125
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
 msgid "git-gui: fatal error"
 msgstr "git-gui: ödesdigert fel"
 
-#: git-gui.sh:932
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Hittar inte git i PATH."
 
-#: git-gui.sh:959
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Kan inte tolka versionssträng från Git:"
 
-#: git-gui.sh:984
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Kan inte avgöra Gits version.\n"
 "\n"
@@ -65,47 +65,47 @@ msgstr ""
 "\n"
 "Anta att \"%s\" är version 1.5.0?\n"
 
-#: git-gui.sh:1281
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Git-katalogen hittades inte:"
 
-#: git-gui.sh:1315
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Kan inte gå till början på arbetskatalogen:"
 
-#: git-gui.sh:1323
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Kan inte använda naket arkiv:"
 
-#: git-gui.sh:1331
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Ingen arbetskatalog"
 
-#: git-gui.sh:1503 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Uppdaterar filstatus..."
 
-#: git-gui.sh:1563
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Söker efter ändrade filer..."
 
-#: git-gui.sh:1639
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr ""
 "Anropar kroken för förberedelse av incheckningsmeddelande (prepare-commit-"
 "msg)..."
 
-#: git-gui.sh:1656
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr ""
 "Incheckningen avvisades av kroken för förberedelse av incheckningsmeddelande "
 "(prepare-commit-msg)."
 
-#: git-gui.sh:1814 lib/browser.tcl:252
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Klar."
 
-#: git-gui.sh:1978
+#: git-gui.sh:1966
 #, tcl-format
 msgid ""
 "Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
@@ -113,465 +113,469 @@ msgstr ""
 "Visningsgräns (gui.maxfilesdisplayed = %s) nådd, visare inte samtliga %s "
 "filer."
 
-#: git-gui.sh:2101
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Oförändrade"
 
-#: git-gui.sh:2103
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Förändrade, ej köade"
 
-#: git-gui.sh:2104 git-gui.sh:2116
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Köade för incheckning"
 
-#: git-gui.sh:2105 git-gui.sh:2117
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Delar köade för incheckning"
 
-#: git-gui.sh:2106 git-gui.sh:2118
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Köade för incheckning, saknade"
 
-#: git-gui.sh:2108
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Filtyp ändrad, ej köade"
 
-#: git-gui.sh:2109 git-gui.sh:2110
+#: git-gui.sh:2097 git-gui.sh:2098
 msgid "File type changed, old type staged for commit"
 msgstr "Filtyp ändrad, gammal typ köade för incheckning"
 
-#: git-gui.sh:2111
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Filtyp ändrad, köade"
 
-#: git-gui.sh:2112
+#: git-gui.sh:2100
 msgid "File type change staged, modification not staged"
 msgstr "Filtypsändringar köade, innehållsändringar ej köade"
 
-#: git-gui.sh:2113
+#: git-gui.sh:2101
 msgid "File type change staged, file missing"
 msgstr "Filtypsändringar köade, fil saknas"
 
-#: git-gui.sh:2115
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Ej spårade, ej köade"
 
-#: git-gui.sh:2120
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Saknade"
 
-#: git-gui.sh:2121
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Köade för borttagning"
 
-#: git-gui.sh:2122
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Köade för borttagning, fortfarande närvarande"
 
-#: git-gui.sh:2124 git-gui.sh:2125 git-gui.sh:2126 git-gui.sh:2127
-#: git-gui.sh:2128 git-gui.sh:2129
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Kräver konflikthantering efter sammanslagning"
 
-#: git-gui.sh:2164
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Startar gitk... vänta..."
 
-#: git-gui.sh:2176
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Hittade inte gitk i PATH."
 
-#: git-gui.sh:2235
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "Hittade inte git gui i PATH."
 
-#: git-gui.sh:2654 lib/choose_repository.tcl:41
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Arkiv"
 
-#: git-gui.sh:2655
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Redigera"
 
-#: git-gui.sh:2657 lib/choose_rev.tcl:567
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Gren"
 
-#: git-gui.sh:2660 lib/choose_rev.tcl:554
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Incheckning"
 
-#: git-gui.sh:2663 lib/merge.tcl:123 lib/merge.tcl:152 lib/merge.tcl:170
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Slå ihop"
 
-#: git-gui.sh:2664 lib/choose_rev.tcl:563
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Fjärrarkiv"
 
-#: git-gui.sh:2667
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Verktyg"
 
-#: git-gui.sh:2676
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Utforska arbetskopia"
 
-#: git-gui.sh:2682
+#: git-gui.sh:2686
 msgid "Git Bash"
 msgstr "Git Bash"
 
-#: git-gui.sh:2692
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Bläddra i grenens filer"
 
-#: git-gui.sh:2696
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Bläddra filer på gren..."
 
-#: git-gui.sh:2701
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Visualisera grenens historik"
 
-#: git-gui.sh:2705
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Visualisera alla grenars historik"
 
-#: git-gui.sh:2712
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Bläddra i filer för %s"
 
-#: git-gui.sh:2714
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Visualisera historik för %s"
 
-#: git-gui.sh:2719 lib/database.tcl:40 lib/database.tcl:66
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Databasstatistik"
 
-#: git-gui.sh:2722 lib/database.tcl:33
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Komprimera databas"
 
-#: git-gui.sh:2725
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Verifiera databas"
 
-#: git-gui.sh:2732 git-gui.sh:2736 git-gui.sh:2740 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Skapa skrivbordsikon"
 
-#: git-gui.sh:2748 lib/choose_repository.tcl:193 lib/choose_repository.tcl:201
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Avsluta"
 
-#: git-gui.sh:2756
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Ångra"
 
-#: git-gui.sh:2759
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Gör om"
 
-#: git-gui.sh:2763 git-gui.sh:3368
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: git-gui.sh:2766 git-gui.sh:3371 git-gui.sh:3445 git-gui.sh:3530
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Kopiera"
 
-#: git-gui.sh:2769 git-gui.sh:3374
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Klistra in"
 
-#: git-gui.sh:2772 git-gui.sh:3377 lib/remote_branch_delete.tcl:39
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
 #: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Ta bort"
 
-#: git-gui.sh:2776 git-gui.sh:3381 git-gui.sh:3534 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Markera alla"
 
-#: git-gui.sh:2785
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Skapa..."
 
-#: git-gui.sh:2791
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Checka ut..."
 
-#: git-gui.sh:2797
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Byt namn..."
 
-#: git-gui.sh:2802
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Ta bort..."
 
-#: git-gui.sh:2807
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Återställ..."
 
-#: git-gui.sh:2817
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Färdig"
 
-#: git-gui.sh:2819
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Checka in"
 
-#: git-gui.sh:2828 git-gui.sh:3309
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Ny incheckning"
 
-#: git-gui.sh:2836 git-gui.sh:3316
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Lägg till föregående incheckning"
 
-#: git-gui.sh:2846 git-gui.sh:3270 lib/remote_branch_delete.tcl:101
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Sök på nytt"
 
-#: git-gui.sh:2852
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Köa för incheckning"
 
-#: git-gui.sh:2858
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Köa ändrade filer för incheckning"
 
-#: git-gui.sh:2864
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Ta bort från incheckningskö"
 
-#: git-gui.sh:2870 lib/index.tcl:442
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Återställ ändringar"
 
-#: git-gui.sh:2878 git-gui.sh:3581 git-gui.sh:3612
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Visa mindre sammanhang"
 
-#: git-gui.sh:2882 git-gui.sh:3585 git-gui.sh:3616
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Visa mer sammanhang"
 
-#: git-gui.sh:2889 git-gui.sh:3283 git-gui.sh:3392
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Skriv under"
 
-#: git-gui.sh:2905
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Lokal sammanslagning..."
 
-#: git-gui.sh:2910
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Avbryt sammanslagning..."
 
-#: git-gui.sh:2922 git-gui.sh:2950
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Lägg till..."
 
-#: git-gui.sh:2926
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Sänd..."
 
-#: git-gui.sh:2930
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Ta bort gren..."
 
-#: git-gui.sh:2940 git-gui.sh:3563
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Alternativ..."
 
-#: git-gui.sh:2951
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Ta bort..."
 
-#: git-gui.sh:2960 lib/choose_repository.tcl:55
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Hjälp"
 
-#: git-gui.sh:2964 git-gui.sh:2968 lib/choose_repository.tcl:49
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
 #: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Om %s"
 
-#: git-gui.sh:2992
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Webbdokumentation"
 
-#: git-gui.sh:2995 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Visa SSH-nyckel"
 
 #: git-gui.sh:3014 git-gui.sh:3146
+#, fuzzy
+msgid "usage:"
+msgstr "Användning"
+
+#: git-gui.sh:3018 git-gui.sh:3150
 msgid "Usage"
 msgstr "Användning"
 
-#: git-gui.sh:3095 lib/blame.tcl:573
+#: git-gui.sh:3099 lib/blame.tcl:573
 msgid "Error"
 msgstr "Fel"
 
-#: git-gui.sh:3126
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "ödesdigert: kunde inte ta status på sökvägen %s: Fil eller katalog saknas"
 
-#: git-gui.sh:3159
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Aktuell gren:"
 
-#: git-gui.sh:3185
-msgid "Staged Changes (Will Commit)"
-msgstr "Köade ändringar (kommer att checkas in)"
-
-#: git-gui.sh:3205
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Oköade ändringar"
 
-#: git-gui.sh:3276
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Köade ändringar (kommer att checkas in)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Köa ändrade"
 
-#: git-gui.sh:3295 lib/transport.tcl:137 lib/transport.tcl:229
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Sänd"
 
-#: git-gui.sh:3330
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Inledande incheckningsmeddelande:"
 
-#: git-gui.sh:3331
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Utökat incheckningsmeddelande:"
 
-#: git-gui.sh:3332
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Utökat inledande incheckningsmeddelande:"
 
-#: git-gui.sh:3333
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Utökat incheckningsmeddelande för sammanslagning:"
 
-#: git-gui.sh:3334
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Incheckningsmeddelande för sammanslagning:"
 
-#: git-gui.sh:3335
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Incheckningsmeddelande:"
 
-#: git-gui.sh:3384 git-gui.sh:3538 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Kopiera alla"
 
-#: git-gui.sh:3408 lib/blame.tcl:105
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Fil:"
 
-#: git-gui.sh:3526
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Uppdatera"
 
-#: git-gui.sh:3547
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Minska teckensnittsstorlek"
 
-#: git-gui.sh:3551
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Öka teckensnittsstorlek"
 
-#: git-gui.sh:3559 lib/blame.tcl:294
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Teckenkodning"
 
-#: git-gui.sh:3570
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Använd/återställ del"
 
-#: git-gui.sh:3575
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Använd/återställ rad"
 
-#: git-gui.sh:3594
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Starta verktyg för sammanslagning"
 
-#: git-gui.sh:3599
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Använd versionen från fjärrarkivet"
 
-#: git-gui.sh:3603
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Använd lokala versionen"
 
-#: git-gui.sh:3607
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Återställ till basversionen"
 
-#: git-gui.sh:3625
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Visualisera ändringarna i undermodulen"
 
-#: git-gui.sh:3629
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Visualisera grenens historik i undermodulen"
 
-#: git-gui.sh:3633
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Visualisera alla grenars historik i undermodulen"
 
-#: git-gui.sh:3638
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Starta git gui i undermodulen"
 
-#: git-gui.sh:3673
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Ta bort del ur incheckningskö"
 
-#: git-gui.sh:3675
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Ta bort rader ur incheckningskö"
 
-#: git-gui.sh:3677
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Ta bort rad ur incheckningskö"
 
-#: git-gui.sh:3680
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Ställ del i incheckningskö"
 
-#: git-gui.sh:3682
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Ställ rader i incheckningskö"
 
-#: git-gui.sh:3684
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Ställ rad i incheckningskö"
 
-#: git-gui.sh:3709
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Initierar..."
 
-#: git-gui.sh:3852
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Det finns möjliga problem med miljövariabler.\n"
 "\n"
@@ -580,25 +584,26 @@ msgstr ""
 "av %s:\n"
 "\n"
 
-#: git-gui.sh:3881
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Detta beror på ett känt problem med\n"
 "Tcl-binären som följer med Cygwin."
 
-#: git-gui.sh:3886
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -685,13 +690,14 @@ msgid "Staging area (index) is already locked."
 msgstr "Köområdet (index) är redan låst."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Det senaste inlästa tillståndet motsvarar inte tillståndet i arkivet.\n"
 "\n"
@@ -724,9 +730,10 @@ msgid "Staying on branch '%s'."
 msgstr "Stannar på grenen \"%s\"."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -755,7 +762,7 @@ msgstr "Det kanske inte är så enkelt att återskapa förlorade incheckningar."
 msgid "Reset '%s'?"
 msgstr "Återställa \"%s\"?"
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:166 lib/tools_dlg.tcl:336
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Visualisera"
 
@@ -764,7 +771,7 @@ msgid "Reset"
 msgstr "Återställ"
 
 #: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
-#: lib/browser.tcl:292 lib/merge.tcl:174 lib/branch_checkout.tcl:30
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
 #: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
 #: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
 #: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
@@ -773,13 +780,13 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Kunde inte ställa in aktuell gren.\n"
@@ -882,8 +889,14 @@ msgstr "Använd tunt paket (för långsamma nätverksanslutningar)"
 msgid "Include tags"
 msgstr "Ta med taggar"
 
+#: lib/transport.tcl:229
+#, tcl-format
+msgid "%s (%s): Push"
+msgstr ""
+
 #: lib/remote_add.tcl:20
-msgid "Add Remote"
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
 msgstr "Lägg till fjärrarkiv"
 
 #: lib/remote_add.tcl:25
@@ -956,7 +969,8 @@ msgid "Starting..."
 msgstr "Startar..."
 
 #: lib/browser.tcl:27
-msgid "File Browser"
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
 msgstr "Filbläddrare"
 
 #: lib/browser.tcl:132 lib/browser.tcl:149
@@ -968,13 +982,18 @@ msgstr "Läser %s..."
 msgid "[Up To Parent]"
 msgstr "[Upp till förälder]"
 
-#: lib/browser.tcl:275 lib/browser.tcl:282
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Bläddra filer på grenen"
+
+#: lib/browser.tcl:282
 msgid "Browse Branch Files"
 msgstr "Bläddra filer på grenen"
 
-#: lib/browser.tcl:288 lib/choose_repository.tcl:422
-#: lib/choose_repository.tcl:509 lib/choose_repository.tcl:518
-#: lib/choose_repository.tcl:1074
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
 msgid "Browse"
 msgstr "Bläddra"
 
@@ -983,10 +1002,11 @@ msgid "Revision"
 msgstr "Revision"
 
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "Kan inte slå ihop vid utökning.\n"
 "\n"
@@ -994,13 +1014,14 @@ msgstr ""
 "slags sammanslagning.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Det senaste inlästa tillståndet motsvarar inte tillståndet i arkivet.\n"
 "\n"
@@ -1010,14 +1031,14 @@ msgstr ""
 "Sökningen kommer att startas automatiskt nu.\n"
 
 #: lib/merge.tcl:45
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "Du är mitt i en sammanslagning med konflikter.\n"
 "\n"
@@ -1027,14 +1048,14 @@ msgstr ""
 "sammanslagningen. När du gjort det kan du påbörja en ny sammanslagning.\n"
 
 #: lib/merge.tcl:55
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "Du är mitt i en ändring.\n"
 "\n"
@@ -1049,44 +1070,52 @@ msgstr ""
 msgid "%s of %s"
 msgstr "%s av %s"
 
-#: lib/merge.tcl:122
+#: lib/merge.tcl:126
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Slår ihop %s och %s..."
 
-#: lib/merge.tcl:133
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "Sammanslagningen avslutades framgångsrikt."
 
-#: lib/merge.tcl:135
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "Sammanslagningen misslyckades. Du måste lösa konflikterna."
 
-#: lib/merge.tcl:160
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Slå ihop i %s"
 
-#: lib/merge.tcl:179
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "Revisioner att slå ihop"
 
-#: lib/merge.tcl:214
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "Kan inte avbryta vid utökning.\n"
 "\n"
 "Du måste göra dig färdig med att utöka incheckningen.\n"
 
-#: lib/merge.tcl:224
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "Avbryt sammanslagning?\n"
@@ -1096,12 +1125,13 @@ msgstr ""
 "\n"
 "Gå vidare med att avbryta den aktuella sammanslagningen?"
 
-#: lib/merge.tcl:230
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "Återställ ändringar?\n"
@@ -1111,58 +1141,63 @@ msgstr ""
 "\n"
 "Gå vidare med att återställa de aktuella ändringarna?"
 
-#: lib/merge.tcl:241
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "Avbryter"
 
-#: lib/merge.tcl:241
+#: lib/merge.tcl:245
 msgid "files reset"
 msgstr "filer återställda"
 
-#: lib/merge.tcl:269
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "Misslyckades avbryta."
 
-#: lib/merge.tcl:271
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "Avbrytning fullbordad. Redo."
 
-#: lib/tools.tcl:75
+#: lib/tools.tcl:76
 #, tcl-format
 msgid "Running %s requires a selected file."
 msgstr "För att starta %s måste du välja en fil."
 
-#: lib/tools.tcl:91
+#: lib/tools.tcl:92
 #, tcl-format
 msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
 msgstr "Är du säker på att du vill starta %1$s med filen \"%2$s\"?"
 
-#: lib/tools.tcl:95
+#: lib/tools.tcl:96
 #, tcl-format
 msgid "Are you sure you want to run %s?"
 msgstr "Är du säker på att du vill starta %s?"
 
-#: lib/tools.tcl:116
+#: lib/tools.tcl:118
 #, tcl-format
 msgid "Tool: %s"
 msgstr "Verktyg: %s"
 
-#: lib/tools.tcl:117
+#: lib/tools.tcl:119
 #, tcl-format
 msgid "Running: %s"
 msgstr "Exekverar: %s"
 
-#: lib/tools.tcl:155
+#: lib/tools.tcl:158
 #, tcl-format
 msgid "Tool completed successfully: %s"
 msgstr "Verktyget avslutades framgångsrikt: %s"
 
-#: lib/tools.tcl:157
+#: lib/tools.tcl:160
 #, tcl-format
 msgid "Tool failed: %s"
 msgstr "Verktyget misslyckades: %s"
 
-#: lib/branch_checkout.tcl:16 lib/branch_checkout.tcl:21
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Checka ut gren"
+
+#: lib/branch_checkout.tcl:21
 msgid "Checkout Branch"
 msgstr "Checka ut gren"
 
@@ -1225,15 +1260,15 @@ msgid "%s ... %*i of %*i %s (%3i%%)"
 msgstr "%s... %*i av %*i %s (%3i%%)"
 
 #: lib/diff.tcl:77
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
 "The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
+"the content within the file was not changed.\r\n"
+"\r\n"
 "A rescan will be automatically started to find other files which may have "
 "the same state."
 msgstr ""
@@ -1252,7 +1287,7 @@ msgstr ""
 msgid "Loading diff of %s..."
 msgstr "Läser differens för %s..."
 
-#: lib/diff.tcl:140
+#: lib/diff.tcl:143
 msgid ""
 "LOCAL: deleted\n"
 "REMOTE:\n"
@@ -1260,7 +1295,7 @@ msgstr ""
 "LOKAL: borttagen\n"
 "FJÄRR:\n"
 
-#: lib/diff.tcl:145
+#: lib/diff.tcl:148
 msgid ""
 "REMOTE: deleted\n"
 "LOCAL:\n"
@@ -1268,68 +1303,63 @@ msgstr ""
 "FJÄRR: borttagen\n"
 "LOKAL:\n"
 
-#: lib/diff.tcl:152
+#: lib/diff.tcl:155
 msgid "LOCAL:\n"
 msgstr "LOKAL:\n"
 
-#: lib/diff.tcl:155
+#: lib/diff.tcl:158
 msgid "REMOTE:\n"
 msgstr "FJÄRR:\n"
 
-#: lib/diff.tcl:217 lib/diff.tcl:355
+#: lib/diff.tcl:220 lib/diff.tcl:357
 #, tcl-format
 msgid "Unable to display %s"
 msgstr "Kan inte visa %s"
 
-#: lib/diff.tcl:218
+#: lib/diff.tcl:221
 msgid "Error loading file:"
 msgstr "Fel vid läsning av fil:"
 
-#: lib/diff.tcl:225
+#: lib/diff.tcl:227
 msgid "Git Repository (subproject)"
 msgstr "Gitarkiv (underprojekt)"
 
-#: lib/diff.tcl:237
+#: lib/diff.tcl:239
 msgid "* Binary file (not showing content)."
 msgstr "* Binärfil (visar inte innehållet)."
 
-#: lib/diff.tcl:242
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
+#: lib/diff.tcl:243
+msgid "\r"
 msgstr ""
-"* Den ospårade filen är %d byte.\n"
-"* Visar endast inledande %d byte.\n"
 
-#: lib/diff.tcl:248
-#, tcl-format
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
 msgstr ""
 "\n"
 "* Den ospårade filen klipptes här av %s.\n"
 "* För att se hela filen, använd ett externt redigeringsprogram.\n"
 
-#: lib/diff.tcl:356 lib/blame.tcl:1128
+#: lib/diff.tcl:358 lib/blame.tcl:1128
 msgid "Error loading diff:"
 msgstr "Fel vid inläsning av differens:"
 
-#: lib/diff.tcl:578
+#: lib/diff.tcl:580
 msgid "Failed to unstage selected hunk."
 msgstr "Kunde inte ta bort den valda delen från kön."
 
-#: lib/diff.tcl:585
+#: lib/diff.tcl:587
 msgid "Failed to stage selected hunk."
 msgstr "Kunde inte lägga till den valda delen till kön."
 
-#: lib/diff.tcl:664
+#: lib/diff.tcl:666
 msgid "Failed to unstage selected line."
 msgstr "Kunde inte ta bort den valda raden från kön."
 
-#: lib/diff.tcl:672
+#: lib/diff.tcl:674
 msgid "Failed to stage selected line."
 msgstr "Kunde inte lägga till den valda raden till kön."
 
@@ -1348,6 +1378,10 @@ msgstr "Ta bort från"
 #: lib/remote.tcl:228
 msgid "Fetch from"
 msgstr "Hämta från"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
 
 #: lib/choose_font.tcl:41
 msgid "Select"
@@ -1492,6 +1526,12 @@ msgstr "Visa ospårade filer"
 msgid "Tab spacing"
 msgstr "Blanksteg för tabulatortecken"
 
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
 #: lib/option.tcl:210
 msgid "Change"
 msgstr "Ändra"
@@ -1534,12 +1574,12 @@ msgid "Force resolution to the other branch?"
 msgstr "Tvinga lösning att använda den andra grenen?"
 
 #: lib/mergetool.tcl:14
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
 "This operation can be undone only by restarting the merge."
 msgstr ""
 "Observera att diffen endast visar de ändringar som står i konflikt.\n"
@@ -1609,7 +1649,8 @@ msgid "Merge tool failed."
 msgstr "Verktyget för sammanslagning misslyckades."
 
 #: lib/tools_dlg.tcl:22
-msgid "Add Tool"
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
 msgstr "Lägg till verktyg"
 
 #: lib/tools_dlg.tcl:28
@@ -1671,7 +1712,8 @@ msgstr ""
 "%s"
 
 #: lib/tools_dlg.tcl:187
-msgid "Remove Tool"
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
 msgstr "Ta bort verktyg"
 
 #: lib/tools_dlg.tcl:193
@@ -1685,6 +1727,11 @@ msgstr "Ta bort"
 #: lib/tools_dlg.tcl:231
 msgid "(Blue denotes repository-local tools)"
 msgstr "(Blått anger verktyg lokala för arkivet)"
+
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Systemets (%s)"
 
 #: lib/tools_dlg.tcl:292
 #, tcl-format
@@ -1719,7 +1766,25 @@ msgstr "Reg.uttr."
 msgid "Case"
 msgstr "Skiftläge"
 
-#: lib/branch_rename.tcl:15 lib/branch_rename.tcl:23
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Skapa skrivbordsikon"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Kan inte skriva genväg:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Kan inte skriva ikon:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Byt namn på gren"
+
+#: lib/branch_rename.tcl:23
 msgid "Rename Branch"
 msgstr "Byt namn på gren"
 
@@ -1753,7 +1818,12 @@ msgstr "\"%s\" kan inte användas som namn på grenen."
 msgid "Failed to rename '%s'."
 msgstr "Kunde inte byta namn på \"%s\"."
 
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Ta bort gren från fjärrarkiv"
+
+#: lib/remote_branch_delete.tcl:34
 msgid "Delete Branch Remotely"
 msgstr "Ta bort gren från fjärrarkiv"
 
@@ -1782,10 +1852,10 @@ msgid "A branch is required for 'Merged Into'."
 msgstr "En gren krävs för \"Sammanslagen i\"."
 
 #: lib/remote_branch_delete.tcl:185
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
 " - %s"
 msgstr ""
 "Följande grenar har inte helt slagits samman i %s:\n"
@@ -1833,7 +1903,7 @@ msgstr "Söker %s..."
 msgid "Git Gui"
 msgstr "Git Gui"
 
-#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:412
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
 msgid "Create New Repository"
 msgstr "Skapa nytt arkiv"
 
@@ -1841,7 +1911,7 @@ msgstr "Skapa nytt arkiv"
 msgid "New..."
 msgstr "Nytt..."
 
-#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:496
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
 msgid "Clone Existing Repository"
 msgstr "Klona befintligt arkiv"
 
@@ -1849,7 +1919,7 @@ msgstr "Klona befintligt arkiv"
 msgid "Clone..."
 msgstr "Klona..."
 
-#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1064
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
 msgid "Open Existing Repository"
 msgstr "Öppna befintligt arkiv"
 
@@ -1861,213 +1931,213 @@ msgstr "Öppna..."
 msgid "Recent Repositories"
 msgstr "Senaste arkiven"
 
-#: lib/choose_repository.tcl:148
+#: lib/choose_repository.tcl:152
 msgid "Open Recent Repository:"
 msgstr "Öppna tidigare arkiv:"
 
-#: lib/choose_repository.tcl:316 lib/choose_repository.tcl:323
-#: lib/choose_repository.tcl:330
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
 #, tcl-format
 msgid "Failed to create repository %s:"
 msgstr "Kunde inte skapa arkivet %s:"
 
-#: lib/choose_repository.tcl:407 lib/branch_create.tcl:33
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
 msgid "Create"
 msgstr "Skapa"
 
-#: lib/choose_repository.tcl:417
+#: lib/choose_repository.tcl:420
 msgid "Directory:"
 msgstr "Katalog:"
 
-#: lib/choose_repository.tcl:447 lib/choose_repository.tcl:573
-#: lib/choose_repository.tcl:1098
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
 msgid "Git Repository"
 msgstr "Gitarkiv"
 
-#: lib/choose_repository.tcl:472
+#: lib/choose_repository.tcl:475
 #, tcl-format
 msgid "Directory %s already exists."
 msgstr "Katalogen %s finns redan."
 
-#: lib/choose_repository.tcl:476
+#: lib/choose_repository.tcl:479
 #, tcl-format
 msgid "File %s already exists."
 msgstr "Filen %s finns redan."
 
-#: lib/choose_repository.tcl:491
+#: lib/choose_repository.tcl:494
 msgid "Clone"
 msgstr "Klona"
 
-#: lib/choose_repository.tcl:504
+#: lib/choose_repository.tcl:507
 msgid "Source Location:"
 msgstr "Plats för källkod:"
 
-#: lib/choose_repository.tcl:513
+#: lib/choose_repository.tcl:516
 msgid "Target Directory:"
 msgstr "Målkatalog:"
 
-#: lib/choose_repository.tcl:523
+#: lib/choose_repository.tcl:526
 msgid "Clone Type:"
 msgstr "Typ av klon:"
 
-#: lib/choose_repository.tcl:528
+#: lib/choose_repository.tcl:531
 msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
 msgstr "Standard (snabb, semiredundant, hårda länkar)"
 
-#: lib/choose_repository.tcl:533
+#: lib/choose_repository.tcl:536
 msgid "Full Copy (Slower, Redundant Backup)"
 msgstr "Full kopia (långsammare, redundant säkerhetskopia)"
 
-#: lib/choose_repository.tcl:538
+#: lib/choose_repository.tcl:541
 msgid "Shared (Fastest, Not Recommended, No Backup)"
 msgstr "Delad (snabbast, rekommenderas ej, ingen säkerhetskopia)"
 
-#: lib/choose_repository.tcl:545
+#: lib/choose_repository.tcl:548
 msgid "Recursively clone submodules too"
 msgstr "Klona även rekursivt undermoduler"
 
-#: lib/choose_repository.tcl:579 lib/choose_repository.tcl:626
-#: lib/choose_repository.tcl:772 lib/choose_repository.tcl:842
-#: lib/choose_repository.tcl:1104 lib/choose_repository.tcl:1112
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
 #, tcl-format
 msgid "Not a Git repository: %s"
 msgstr "Inte ett Gitarkiv: %s"
 
-#: lib/choose_repository.tcl:615
+#: lib/choose_repository.tcl:618
 msgid "Standard only available for local repository."
 msgstr "Standard är endast tillgängligt för lokala arkiv."
 
-#: lib/choose_repository.tcl:619
+#: lib/choose_repository.tcl:622
 msgid "Shared only available for local repository."
 msgstr "Delat är endast tillgängligt för lokala arkiv."
 
-#: lib/choose_repository.tcl:640
+#: lib/choose_repository.tcl:643
 #, tcl-format
 msgid "Location %s already exists."
 msgstr "Platsen %s finns redan."
 
-#: lib/choose_repository.tcl:651
+#: lib/choose_repository.tcl:654
 msgid "Failed to configure origin"
 msgstr "Kunde inte konfigurera ursprung"
 
-#: lib/choose_repository.tcl:663
+#: lib/choose_repository.tcl:666
 msgid "Counting objects"
 msgstr "Räknar objekt"
 
-#: lib/choose_repository.tcl:664
+#: lib/choose_repository.tcl:667
 msgid "buckets"
 msgstr "hinkar"
 
-#: lib/choose_repository.tcl:688
+#: lib/choose_repository.tcl:691
 #, tcl-format
 msgid "Unable to copy objects/info/alternates: %s"
 msgstr "Kunde inte kopiera objekt/info/alternativ: %s"
 
-#: lib/choose_repository.tcl:724
+#: lib/choose_repository.tcl:727
 #, tcl-format
 msgid "Nothing to clone from %s."
 msgstr "Ingenting att klona från %s."
 
-#: lib/choose_repository.tcl:726 lib/choose_repository.tcl:940
-#: lib/choose_repository.tcl:952
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
 msgid "The 'master' branch has not been initialized."
 msgstr "Grenen \"master\" har inte initierats."
 
-#: lib/choose_repository.tcl:739
+#: lib/choose_repository.tcl:742
 msgid "Hardlinks are unavailable.  Falling back to copying."
 msgstr "Hårda länkar är inte tillgängliga. Faller tillbaka på kopiering."
 
-#: lib/choose_repository.tcl:751
+#: lib/choose_repository.tcl:754
 #, tcl-format
 msgid "Cloning from %s"
 msgstr "Klonar från %s"
 
-#: lib/choose_repository.tcl:782
+#: lib/choose_repository.tcl:785
 msgid "Copying objects"
 msgstr "Kopierar objekt"
 
-#: lib/choose_repository.tcl:783
+#: lib/choose_repository.tcl:786
 msgid "KiB"
 msgstr "KiB"
 
-#: lib/choose_repository.tcl:807
+#: lib/choose_repository.tcl:810
 #, tcl-format
 msgid "Unable to copy object: %s"
 msgstr "Kunde inte kopiera objekt: %s"
 
-#: lib/choose_repository.tcl:817
+#: lib/choose_repository.tcl:820
 msgid "Linking objects"
 msgstr "Länkar objekt"
 
-#: lib/choose_repository.tcl:818
+#: lib/choose_repository.tcl:821
 msgid "objects"
 msgstr "objekt"
 
-#: lib/choose_repository.tcl:826
+#: lib/choose_repository.tcl:829
 #, tcl-format
 msgid "Unable to hardlink object: %s"
 msgstr "Kunde inte hårdlänka objekt: %s"
 
-#: lib/choose_repository.tcl:881
+#: lib/choose_repository.tcl:884
 msgid "Cannot fetch branches and objects.  See console output for details."
 msgstr "Kunde inte hämta grenar och objekt. Se konsolutdata för detaljer."
 
-#: lib/choose_repository.tcl:892
+#: lib/choose_repository.tcl:895
 msgid "Cannot fetch tags.  See console output for details."
 msgstr "Kunde inte hämta taggar. Se konsolutdata för detaljer."
 
-#: lib/choose_repository.tcl:916
+#: lib/choose_repository.tcl:919
 msgid "Cannot determine HEAD.  See console output for details."
 msgstr "Kunde inte avgöra HEAD. Se konsolutdata för detaljer."
 
-#: lib/choose_repository.tcl:925
+#: lib/choose_repository.tcl:928
 #, tcl-format
 msgid "Unable to cleanup %s"
 msgstr "Kunde inte städa upp %s"
 
-#: lib/choose_repository.tcl:931
+#: lib/choose_repository.tcl:934
 msgid "Clone failed."
 msgstr "Kloning misslyckades."
 
-#: lib/choose_repository.tcl:938
+#: lib/choose_repository.tcl:941
 msgid "No default branch obtained."
 msgstr "Hämtade ingen standardgren."
 
-#: lib/choose_repository.tcl:949
+#: lib/choose_repository.tcl:952
 #, tcl-format
 msgid "Cannot resolve %s as a commit."
 msgstr "Kunde inte slå upp %s till någon incheckning."
 
-#: lib/choose_repository.tcl:961
+#: lib/choose_repository.tcl:964
 msgid "Creating working directory"
 msgstr "Skapar arbetskatalog"
 
-#: lib/choose_repository.tcl:962 lib/index.tcl:70 lib/index.tcl:136
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
 #: lib/index.tcl:207
 msgid "files"
 msgstr "filer"
 
-#: lib/choose_repository.tcl:981
+#: lib/choose_repository.tcl:984
 msgid "Cannot clone submodules."
 msgstr "Kan inte klona undermoduler."
 
-#: lib/choose_repository.tcl:990
+#: lib/choose_repository.tcl:993
 msgid "Cloning submodules"
 msgstr "Klonar undermoduler"
 
-#: lib/choose_repository.tcl:1015
+#: lib/choose_repository.tcl:1018
 msgid "Initial file checkout failed."
 msgstr "Inledande filutcheckning misslyckades."
 
-#: lib/choose_repository.tcl:1059
+#: lib/choose_repository.tcl:1062
 msgid "Open"
 msgstr "Öppna"
 
-#: lib/choose_repository.tcl:1069
+#: lib/choose_repository.tcl:1072
 msgid "Repository:"
 msgstr "Arkiv:"
 
-#: lib/choose_repository.tcl:1118
+#: lib/choose_repository.tcl:1121
 #, tcl-format
 msgid "Failed to open repository %s:"
 msgstr "Kunde inte öppna arkivet %s:"
@@ -2077,7 +2147,8 @@ msgid "git-gui - a graphical user interface for Git."
 msgstr "git-gui - ett grafiskt användargränssnitt för Git."
 
 #: lib/blame.tcl:73
-msgid "File Viewer"
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
 msgstr "Filvisare"
 
 #: lib/blame.tcl:79
@@ -2231,7 +2302,8 @@ msgid "Your key is in: %s"
 msgstr "Din nyckel finns i: %s"
 
 #: lib/branch_create.tcl:23
-msgid "Create Branch"
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
 msgstr "Skapa gren"
 
 #: lib/branch_create.tcl:28
@@ -2275,13 +2347,364 @@ msgstr "Välj en gren att spåra."
 msgid "Tracking branch %s is not a branch in the remote repository."
 msgstr "Den spårade grenen %s är inte en gren i fjärrarkivet."
 
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "Kan inte skriva genväg:"
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Det finns ingenting att utöka.\n"
+"\n"
+"Du håller på att skapa den inledande incheckningen. Det finns ingen tidigare "
+"incheckning att utöka.\n"
 
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "Kan inte skriva ikon:"
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Kan inte utöka vid sammanslagning.\n"
+"\n"
+"Du är i mitten av en sammanslagning som inte är fullbordad. Du kan inte "
+"utöka tidigare incheckningar om du inte först avbryter den pågående "
+"sammanslagningen.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Fel vid inläsning av incheckningsdata för utökning:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Kunde inte hämta din identitet:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "Felaktig GIT_COMMITTER_IDENT:"
+
+#: lib/commit.tcl:132
+#, tcl-format
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "varning: Tcl stöder inte teckenkodningen \"%s\"."
+
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Det senaste inlästa tillståndet motsvarar inte tillståndet i arkivet.\n"
+"\n"
+"Ett annat Git-program har ändrat arkivet sedan senaste avsökningen. Du måste "
+"utföra en ny sökning innan du kan göra en ny incheckning.\n"
+"\n"
+"Sökningen kommer att startas automatiskt nu.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Osammanslagna filer kan inte checkas in.\n"
+"\n"
+"Filen %s har sammanslagningskonflikter. Du måste lösa dem och köa filen "
+"innan du checkar in den.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Okänd filstatus %s upptäckt.\n"
+"\n"
+"Filen %s kan inte checkas in av programmet.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Inga ändringar att checka in.\n"
+"\n"
+"Du måste köa åtminstone en fil innan du kan checka in.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Ange ett incheckningsmeddelande.\n"
+"\n"
+"Ett bra incheckningsmeddelande har följande format:\n"
+"\n"
+"- Första raden: Beskriv i en mening vad du gjorde.\n"
+"- Andra raden: Tom\n"
+"- Följande rader: Beskriv varför det här är en bra ändring.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Anropar kroken före incheckning (pre-commit)..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Incheckningen avvisades av kroken före incheckning (pre-commit)."
+
+#: lib/commit.tcl:272
+#, fuzzy
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+"Du är på väg att checka in på ett frånkopplat huvud. Det kan potentiellt "
+"vara farligt, eftersom du kommer förlora dina ändringar om du växlar till en "
+"annan gren och det kan vara svårt att hämta dem senare från ref-loggen. Du "
+"bör troligen avbryta incheckningen och skapa en ny gren för att fortsätta.\n"
+" \n"
+" Vill du verkligen fortsätta checka in?"
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Anropar kroken för incheckningsmeddelande (commit-msg)..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Incheckning avvisad av kroken för incheckningsmeddelande (commit-msg)."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Checkar in ändringar..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "write-tree misslyckades:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Incheckningen misslyckades."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "Incheckningen %s verkar vara trasig"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Inga ändringar att checka in.\n"
+"\n"
+"Inga filer ändrades av incheckningen och det var inte en sammanslagning.\n"
+"\n"
+"En sökning kommer att startas automatiskt nu.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Inga ändringar att checka in."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree misslyckades:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref misslyckades:"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "Skapade incheckningen %s: %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Ta bort gren"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Ta bort lokal gren"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Lokala grenar"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Ta bara bort om sammanslagen med"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "Följande grenar är inte till fullo sammanslagna med %s:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+"Kunde inte ta bort grenar:\n"
+"%s"
+
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Kunde inte låsa upp indexet."
+
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Indexfel"
+
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Misslyckades med att uppdatera Gitindexet. En omsökning kommer att startas "
+"automatiskt för att synkronisera om git-gui."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Fortsätt"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Lås upp index"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Tar bort %s för incheckningskön"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "Tar bort %s för incheckningskön"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Redo att checka in."
+
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Återställer valda filer"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "Lägger till %s"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr "Köa %d ospårade filer?"
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Återställ ändringarna i filen %s?"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Återställ ändringarna i dessa %i filer?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Alla oköade ändringar kommer permanent gå förlorade vid återställningen."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Gör ingenting"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Köa %d ospårade filer?"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Köa %d ospårade filer?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Ta bort"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Återställer valda filer"
+
+#: lib/index.tcl:532
+#, tcl-format
+msgid "Reverting %s"
+msgstr "Återställer %s"
+
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Standard"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr "Systemets (%s)"
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Annan"
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Ogiltigt datum från Git: %s"
 
 #: lib/choose_rev.tcl:52
 msgid "This Detached Checkout"
@@ -2324,316 +2747,6 @@ msgstr "Uppdaterad"
 msgid "URL"
 msgstr "Webbadress"
 
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"Det finns ingenting att utöka.\n"
-"\n"
-"Du håller på att skapa den inledande incheckningen. Det finns ingen tidigare "
-"incheckning att utöka.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Kan inte utöka vid sammanslagning.\n"
-"\n"
-"Du är i mitten av en sammanslagning som inte är fullbordad. Du kan inte "
-"utöka tidigare incheckningar om du inte först avbryter den pågående "
-"sammanslagningen.\n"
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Fel vid inläsning av incheckningsdata för utökning:"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Kunde inte hämta din identitet:"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "Felaktig GIT_COMMITTER_IDENT:"
-
-#: lib/commit.tcl:129
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "varning: Tcl stöder inte teckenkodningen \"%s\"."
-
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"Det senaste inlästa tillståndet motsvarar inte tillståndet i arkivet.\n"
-"\n"
-"Ett annat Git-program har ändrat arkivet sedan senaste avsökningen. Du måste "
-"utföra en ny sökning innan du kan göra en ny incheckning.\n"
-"\n"
-"Sökningen kommer att startas automatiskt nu.\n"
-
-#: lib/commit.tcl:173
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"Osammanslagna filer kan inte checkas in.\n"
-"\n"
-"Filen %s har sammanslagningskonflikter. Du måste lösa dem och köa filen "
-"innan du checkar in den.\n"
-
-#: lib/commit.tcl:181
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Okänd filstatus %s upptäckt.\n"
-"\n"
-"Filen %s kan inte checkas in av programmet.\n"
-
-#: lib/commit.tcl:189
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Inga ändringar att checka in.\n"
-"\n"
-"Du måste köa åtminstone en fil innan du kan checka in.\n"
-
-#: lib/commit.tcl:204
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Ange ett incheckningsmeddelande.\n"
-"\n"
-"Ett bra incheckningsmeddelande har följande format:\n"
-"\n"
-"- Första raden: Beskriv i en mening vad du gjorde.\n"
-"- Andra raden: Tom\n"
-"- Följande rader: Beskriv varför det här är en bra ändring.\n"
-
-#: lib/commit.tcl:235
-msgid "Calling pre-commit hook..."
-msgstr "Anropar kroken före incheckning (pre-commit)..."
-
-#: lib/commit.tcl:250
-msgid "Commit declined by pre-commit hook."
-msgstr "Incheckningen avvisades av kroken före incheckning (pre-commit)."
-
-#: lib/commit.tcl:269
-msgid ""
-"You are about to commit on a detached head. This is a potentially dangerous "
-"thing to do because if you switch to another branch you will lose your "
-"changes and it can be difficult to retrieve them later from the reflog. You "
-"should probably cancel this commit and create a new branch to continue.\n"
-" \n"
-" Do you really want to proceed with your Commit?"
-msgstr ""
-"Du är på väg att checka in på ett frånkopplat huvud. Det kan potentiellt "
-"vara farligt, eftersom du kommer förlora dina ändringar om du växlar till en "
-"annan gren och det kan vara svårt att hämta dem senare från ref-loggen. Du "
-"bör troligen avbryta incheckningen och skapa en ny gren för att fortsätta.\n"
-" \n"
-" Vill du verkligen fortsätta checka in?"
-
-#: lib/commit.tcl:290
-msgid "Calling commit-msg hook..."
-msgstr "Anropar kroken för incheckningsmeddelande (commit-msg)..."
-
-#: lib/commit.tcl:305
-msgid "Commit declined by commit-msg hook."
-msgstr "Incheckning avvisad av kroken för incheckningsmeddelande (commit-msg)."
-
-#: lib/commit.tcl:318
-msgid "Committing changes..."
-msgstr "Checkar in ändringar..."
-
-#: lib/commit.tcl:334
-msgid "write-tree failed:"
-msgstr "write-tree misslyckades:"
-
-#: lib/commit.tcl:335 lib/commit.tcl:379 lib/commit.tcl:400
-msgid "Commit failed."
-msgstr "Incheckningen misslyckades."
-
-#: lib/commit.tcl:352
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Incheckningen %s verkar vara trasig"
-
-#: lib/commit.tcl:357
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Inga ändringar att checka in.\n"
-"\n"
-"Inga filer ändrades av incheckningen och det var inte en sammanslagning.\n"
-"\n"
-"En sökning kommer att startas automatiskt nu.\n"
-
-#: lib/commit.tcl:364
-msgid "No changes to commit."
-msgstr "Inga ändringar att checka in."
-
-#: lib/commit.tcl:378
-msgid "commit-tree failed:"
-msgstr "commit-tree misslyckades:"
-
-#: lib/commit.tcl:399
-msgid "update-ref failed:"
-msgstr "update-ref misslyckades:"
-
-#: lib/commit.tcl:492
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Skapade incheckningen %s: %s"
-
-#: lib/branch_delete.tcl:16
-msgid "Delete Branch"
-msgstr "Ta bort gren"
-
-#: lib/branch_delete.tcl:21
-msgid "Delete Local Branch"
-msgstr "Ta bort lokal gren"
-
-#: lib/branch_delete.tcl:39
-msgid "Local Branches"
-msgstr "Lokala grenar"
-
-#: lib/branch_delete.tcl:51
-msgid "Delete Only If Merged Into"
-msgstr "Ta bara bort om sammanslagen med"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Följande grenar är inte till fullo sammanslagna med %s:"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-"Kunde inte ta bort grenar:\n"
-"%s"
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Kunde inte låsa upp indexet."
-
-#: lib/index.tcl:17
-msgid "Index Error"
-msgstr "Indexfel"
-
-#: lib/index.tcl:19
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"Misslyckades med att uppdatera Gitindexet. En omsökning kommer att startas "
-"automatiskt för att synkronisera om git-gui."
-
-#: lib/index.tcl:30
-msgid "Continue"
-msgstr "Fortsätt"
-
-#: lib/index.tcl:33
-msgid "Unlock Index"
-msgstr "Lås upp index"
-
-#: lib/index.tcl:298
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Tar bort %s för incheckningskön"
-
-#: lib/index.tcl:337
-msgid "Ready to commit."
-msgstr "Redo att checka in."
-
-#: lib/index.tcl:350
-#, tcl-format
-msgid "Adding %s"
-msgstr "Lägger till %s"
-
-#: lib/index.tcl:380
-#, tcl-format
-msgid "Stage %d untracked files?"
-msgstr "Köa %d ospårade filer?"
-
-#: lib/index.tcl:428
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Återställ ändringarna i filen %s?"
-
-#: lib/index.tcl:430
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Återställ ändringarna i dessa %i filer?"
-
-#: lib/index.tcl:438
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Alla oköade ändringar kommer permanent gå förlorade vid återställningen."
-
-#: lib/index.tcl:441
-msgid "Do Nothing"
-msgstr "Gör ingenting"
-
-#: lib/index.tcl:459
-msgid "Reverting selected files"
-msgstr "Återställer valda filer"
-
-#: lib/index.tcl:463
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Återställer %s"
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Standard"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Systemets (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Annan"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Ogiltigt datum från Git: %s"
-
 #: lib/database.tcl:42
 msgid "Number of loose objects"
 msgstr "Antal lösa objekt"
@@ -2662,6 +2775,11 @@ msgstr "Packade objekt som väntar på städning"
 msgid "Garbage files"
 msgstr "Skräpfiler"
 
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Databasstatistik"
+
 #: lib/database.tcl:72
 msgid "Compressing the object database"
 msgstr "Komprimerar objektdatabasen"
@@ -2671,13 +2789,13 @@ msgid "Verifying the object database with fsck-objects"
 msgstr "Verifierar objektdatabasen med fsck-objects"
 
 #: lib/database.tcl:107
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
 "To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
+"the database.\r\n"
+"\r\n"
 "Compress the database now?"
 msgstr ""
 "Arkivet har för närvarande omkring %i lösa objekt.\n"
@@ -2687,17 +2805,36 @@ msgstr ""
 "\n"
 "Komprimera databasen nu?"
 
-#: lib/error.tcl:20 lib/error.tcl:116
-msgid "error"
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
 msgstr "fel"
 
 #: lib/error.tcl:36
-msgid "warning"
+#, fuzzy, tcl-format
+msgid "%s: warning"
 msgstr "varning"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
+msgstr "Verktyget misslyckades: %s"
 
 #: lib/error.tcl:96
 msgid "You must correct the above errors before committing."
 msgstr "Du måste rätta till felen ovan innan du checkar in."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Den ospårade filen är %d byte.\n"
+#~ "* Visar endast inledande %d byte.\n"
 
 #~ msgid "Displaying only %s of %s files."
 #~ msgstr "Visar endast %s av %s filer."

--- a/po/vi.po
+++ b/po/vi.po
@@ -2,12 +2,12 @@
 # Bản dịch Tiếng Việt dành cho gói Git-gui.
 # This file is distributed under the same license as the git-core package.
 # First translated by Trần Ngọc Quân <vnwildman@gmail.com>, 2014.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui 0.19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-06-26 13:42+0700\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2014-06-27 07:48+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -21,42 +21,42 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Poedit-Basepath: ../\n"
 
-#: git-gui.sh:859
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Phông chữ không hợp lệ được đặc tả trong %s:"
 
-#: git-gui.sh:912
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "Phông chữ chính"
 
-#: git-gui.sh:913
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Phông chữ cho Bảng điều khiển hay Diff"
 
-#: git-gui.sh:928 git-gui.sh:942 git-gui.sh:955 git-gui.sh:1045
-#: git-gui.sh:1064 git-gui.sh:3119
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
 msgid "git-gui: fatal error"
 msgstr "git-gui: lỗi nghiêm trọng"
 
-#: git-gui.sh:929
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "Không tìm thấy git trong biến PATH."
 
-#: git-gui.sh:956
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "Không thể phân tích chuỗi phiên bản Git:"
 
-#: git-gui.sh:981
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "Không thể nhận ra phiên bản của Git.\n"
 "\n"
@@ -66,510 +66,515 @@ msgstr ""
 "\n"
 "Cọi '%s' có phiên bản là 1.5.0?\n"
 
-#: git-gui.sh:1278
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Không tìm thấy thư mục git:"
 
-#: git-gui.sh:1312
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "Không thể di chuyển đến đỉnh của thư mục làm việc:"
 
-#: git-gui.sh:1320
+#: git-gui.sh:1309
 msgid "Cannot use bare repository:"
 msgstr "Không thể dùng kho trần:"
 
-#: git-gui.sh:1328
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "Không có thư mục làm việc"
 
-#: git-gui.sh:1500 lib/checkout_op.tcl:306
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Cập nhật lại trạng thái tập tin..."
 
-#: git-gui.sh:1560
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "Đang quét đĩa tìm tập tin thay đổi..."
 
-#: git-gui.sh:1636
+#: git-gui.sh:1627
 msgid "Calling prepare-commit-msg hook..."
 msgstr "Đang gọi móc prepare-commit-msg..."
 
-#: git-gui.sh:1653
+#: git-gui.sh:1644
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "Lần chuyển giao bị chối từ do móc prepare-commit-msg."
 
-#: git-gui.sh:1811 lib/browser.tcl:252
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "Sẵn sàng."
 
-#: git-gui.sh:1969
+#: git-gui.sh:1966
 #, tcl-format
-msgid "Displaying only %s of %s files."
-msgstr "Chỉ hiển thị %s trong số %s tập tin."
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
 
-#: git-gui.sh:2095
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "Không thay đổi gì"
 
-#: git-gui.sh:2097
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "Đã sửa nhưng chưa đánh dấu để chuyển giao"
 
-#: git-gui.sh:2098 git-gui.sh:2110
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "Đánh dấu để chuyển giao"
 
-#: git-gui.sh:2099 git-gui.sh:2111
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "Các phần được đánh dấu là cần chuyển giao"
 
-#: git-gui.sh:2100 git-gui.sh:2112
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "Đã đánh dấu là cần chuyển giao, thiếu"
 
-#: git-gui.sh:2102
+#: git-gui.sh:2096
 msgid "File type changed, not staged"
 msgstr "Đã đổi kiểu tập tin nhưng chưa được đánh dấu cần chuyển giao"
 
-#: git-gui.sh:2103 git-gui.sh:2104
+#: git-gui.sh:2097 git-gui.sh:2098
 msgid "File type changed, old type staged for commit"
 msgstr "Đã đổi kiểu tập tin, kiểu cũ đã được đánh dấu cần chuyển giao"
 
-#: git-gui.sh:2105
+#: git-gui.sh:2099
 msgid "File type changed, staged"
 msgstr "Đã đổi kiểu tập tin, đã được đánh dấu cần chuyển giao"
 
-#: git-gui.sh:2106
+#: git-gui.sh:2100
 msgid "File type change staged, modification not staged"
 msgstr ""
 "Thay đổi kiểu tập tin đã được đánh dấu cần chuyển giao, nhưng các thay đổi "
 "thì chưa"
 
-#: git-gui.sh:2107
+#: git-gui.sh:2101
 msgid "File type change staged, file missing"
 msgstr ""
 "Thay đổi kiểu tập tin đã được đánh dấu cần chuyển giao, tập tin bị thiếu"
 
-#: git-gui.sh:2109
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "Chưa được theo dõi, chưa đánh dấu là cần chuyển giao"
 
-#: git-gui.sh:2114
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "Thiếu"
 
-#: git-gui.sh:2115
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "Đã đánh dấu là cần gỡ bỏ"
 
-#: git-gui.sh:2116
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "Đã đánh dấu là cần gỡ bỏ, nhưng vẫn hiện diện"
 
-#: git-gui.sh:2118 git-gui.sh:2119 git-gui.sh:2120 git-gui.sh:2121
-#: git-gui.sh:2122 git-gui.sh:2123
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "Các yêu cầu phân giải hòa trộn"
 
-#: git-gui.sh:2158
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "Đang khởi động gitk... vui lòng chờ..."
 
-#: git-gui.sh:2170
+#: git-gui.sh:2164
 msgid "Couldn't find gitk in PATH"
 msgstr "Không thể tìm thấy gitk trong PATH"
 
-#: git-gui.sh:2229
+#: git-gui.sh:2223
 msgid "Couldn't find git gui in PATH"
 msgstr "Không thể tìm thấy git gui trong PATH"
 
-#: git-gui.sh:2648 lib/choose_repository.tcl:40
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "Kho"
 
-#: git-gui.sh:2649
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "Chỉnh sửa"
 
-#: git-gui.sh:2651 lib/choose_rev.tcl:567
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "Nhánh"
 
-#: git-gui.sh:2654 lib/choose_rev.tcl:554
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "Chuyển giao@@noun"
 
-#: git-gui.sh:2657 lib/merge.tcl:123 lib/merge.tcl:152 lib/merge.tcl:170
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "Trộn"
 
-#: git-gui.sh:2658 lib/choose_rev.tcl:563
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "Máy chủ"
 
-#: git-gui.sh:2661
+#: git-gui.sh:2671
 msgid "Tools"
 msgstr "Công cụ"
 
-#: git-gui.sh:2670
+#: git-gui.sh:2680
 msgid "Explore Working Copy"
 msgstr "Quét dò thư mục làm việc"
 
-#: git-gui.sh:2676
+#: git-gui.sh:2686
 msgid "Git Bash"
 msgstr "Git Bash"
 
-#: git-gui.sh:2686
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "Duyệt các Tập tin ở nhánh hiện nay"
 
-#: git-gui.sh:2690
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "Duyệt các tập tin nhánh..."
 
-#: git-gui.sh:2695
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "Hiển thị trực quan lịch sử nhánh hiện nay"
 
-#: git-gui.sh:2699
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "Hiển thị trực quan lịch sử mọi nhánh"
 
-#: git-gui.sh:2706
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Duyệt tập tin của %s..."
 
-#: git-gui.sh:2708
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Duyệt lịch sử của %s trực quan"
 
-#: git-gui.sh:2713 lib/database.tcl:40 lib/database.tcl:66
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "Thống kê cơ sở dữ liệu"
 
-#: git-gui.sh:2716 lib/database.tcl:33
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "Nén cơ sở dữ liệu"
 
-#: git-gui.sh:2719
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "Thẩm tra cơ sở dữ liệu"
 
-#: git-gui.sh:2726 git-gui.sh:2730 git-gui.sh:2734 lib/shortcut.tcl:8
-#: lib/shortcut.tcl:40 lib/shortcut.tcl:72
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "Tạo lối tắt ở màn hình nền"
 
-#: git-gui.sh:2742 lib/choose_repository.tcl:192 lib/choose_repository.tcl:200
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "Thoát"
 
-#: git-gui.sh:2750
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "Hủy lệnh vừa rồi"
 
-#: git-gui.sh:2753
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "Làm lại"
 
-#: git-gui.sh:2757 git-gui.sh:3362
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "Cắt"
 
-#: git-gui.sh:2760 git-gui.sh:3365 git-gui.sh:3439 git-gui.sh:3524
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "Chép"
 
-#: git-gui.sh:2763 git-gui.sh:3368
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "Dán"
 
-#: git-gui.sh:2766 git-gui.sh:3371 lib/branch_delete.tcl:28
-#: lib/remote_branch_delete.tcl:39
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "Xóa bỏ"
 
-#: git-gui.sh:2770 git-gui.sh:3375 git-gui.sh:3528 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "Chọn tất cả"
 
-#: git-gui.sh:2779
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "Tạo..."
 
-#: git-gui.sh:2785
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Lấy ra..."
 
-#: git-gui.sh:2791
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "Đổi tên..."
 
-#: git-gui.sh:2796
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "Xóa..."
 
-#: git-gui.sh:2801
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "Đặt lại.."
 
-#: git-gui.sh:2811
+#: git-gui.sh:2821
 msgid "Done"
 msgstr "Xong"
 
-#: git-gui.sh:2813
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "Chuyển giao@@verb"
 
-#: git-gui.sh:2822 git-gui.sh:3303
+#: git-gui.sh:2832 git-gui.sh:3317
 msgid "New Commit"
 msgstr "Lần chuyển giao mới"
 
-#: git-gui.sh:2830 git-gui.sh:3310
+#: git-gui.sh:2840 git-gui.sh:3324
 msgid "Amend Last Commit"
 msgstr "Tu bổ lần chuyển giao cuối"
 
-#: git-gui.sh:2840 git-gui.sh:3264 lib/remote_branch_delete.tcl:101
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr "Quét lại"
 
-#: git-gui.sh:2846
+#: git-gui.sh:2856
 msgid "Stage To Commit"
 msgstr "Đưa lên bệ phóng để chuyển giao"
 
-#: git-gui.sh:2852
+#: git-gui.sh:2862
 msgid "Stage Changed Files To Commit"
 msgstr "Đánh dấu các tập tin đã thay đổi cần chuyển giao"
 
-#: git-gui.sh:2858
+#: git-gui.sh:2868
 msgid "Unstage From Commit"
 msgstr "Đưa ra khỏi bệ phóng để không chuyển giao"
 
-#: git-gui.sh:2864 lib/index.tcl:442
+#: git-gui.sh:2874 lib/index.tcl:454
 msgid "Revert Changes"
 msgstr "Hoàn nguyên các thay đổi"
 
-#: git-gui.sh:2872 git-gui.sh:3575 git-gui.sh:3606
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
 msgid "Show Less Context"
 msgstr "Hiện ít nội dung hơn"
 
-#: git-gui.sh:2876 git-gui.sh:3579 git-gui.sh:3610
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
 msgid "Show More Context"
 msgstr "Hiện chi tiết hơn"
 
-#: git-gui.sh:2883 git-gui.sh:3277 git-gui.sh:3386
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
 msgid "Sign Off"
 msgstr "Ký tên"
 
-#: git-gui.sh:2899
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "Trộn nội bộ..."
 
-#: git-gui.sh:2904
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "Hủy bỏ hòa trộn..."
 
-#: git-gui.sh:2916 git-gui.sh:2944
+#: git-gui.sh:2926 git-gui.sh:2954
 msgid "Add..."
 msgstr "Thêm..."
 
-#: git-gui.sh:2920
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "Đẩy lên..."
 
-#: git-gui.sh:2924
+#: git-gui.sh:2934
 msgid "Delete Branch..."
 msgstr "Xoá nhánh..."
 
-#: git-gui.sh:2934 git-gui.sh:3557
+#: git-gui.sh:2944 git-gui.sh:3577
 msgid "Options..."
 msgstr "Tùy chọn..."
 
-#: git-gui.sh:2945
+#: git-gui.sh:2955
 msgid "Remove..."
 msgstr "Gỡ bỏ..."
 
-#: git-gui.sh:2954 lib/choose_repository.tcl:54
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
 msgid "Help"
 msgstr "Trợ giúp"
 
-#: git-gui.sh:2958 git-gui.sh:2962 lib/about.tcl:14
-#: lib/choose_repository.tcl:48 lib/choose_repository.tcl:57
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "Giới thiệu về %s"
 
-#: git-gui.sh:2986
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "Đọc tài liệu trực tuyến"
 
-#: git-gui.sh:2989 lib/choose_repository.tcl:51 lib/choose_repository.tcl:60
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
 msgid "Show SSH Key"
 msgstr "Hiện khoá SSH"
 
-#: git-gui.sh:3008 git-gui.sh:3140
+#: git-gui.sh:3014 git-gui.sh:3146
+#, fuzzy
+msgid "usage:"
+msgstr "Cách dùng"
+
+#: git-gui.sh:3018 git-gui.sh:3150
 msgid "Usage"
 msgstr "Cách dùng"
 
-#: git-gui.sh:3089 lib/blame.tcl:573
+#: git-gui.sh:3099 lib/blame.tcl:573
 msgid "Error"
 msgstr "Lỗi"
 
-#: git-gui.sh:3120
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 "lỗi nghiêm trọng: không thể lấy thông tin về đường dẫn %s: Không có tập tin "
 "hoặc thư mục như vậy"
 
-#: git-gui.sh:3153
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "Nhánh hiện hành:"
 
-#: git-gui.sh:3179
-msgid "Staged Changes (Will Commit)"
-msgstr "Đánh dấu các thay đổi (Sẽ chuyển giao)"
-
-#: git-gui.sh:3199
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "Bỏ ra khỏi bệ phóng các thay đổi"
 
-#: git-gui.sh:3270
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "Đánh dấu các thay đổi (Sẽ chuyển giao)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "Đặt lên bệ phóng các thay đổi"
 
-#: git-gui.sh:3289 lib/transport.tcl:137 lib/transport.tcl:229
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "Đẩy lên"
 
-#: git-gui.sh:3324
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "Phần chú thích cho lần chuyển giao khởi tạo:"
 
-#: git-gui.sh:3325
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "Phần chú giải cho lần chuyển giao tu bổ:"
 
-#: git-gui.sh:3326
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "Phần chú giải cho lần chuyển giao tu bổ lần khởi tạo:"
 
-#: git-gui.sh:3327
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "Phần chú giải cho lần chuyển giao tu bổ lần hòa trộn"
 
-#: git-gui.sh:3328
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "Ghi chú của lần chuyển giao hòa trộn:"
 
-#: git-gui.sh:3329
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "Chú thích của lần chuyển giao:"
 
-#: git-gui.sh:3378 git-gui.sh:3532 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Chép tất cả"
 
-#: git-gui.sh:3402 lib/blame.tcl:105
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "Tập tin:"
 
-#: git-gui.sh:3520
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "Làm tươi lại"
 
-#: git-gui.sh:3541
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "Giảm kích cỡ phông"
 
-#: git-gui.sh:3545
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "Tăng kích cỡ phông"
 
-#: git-gui.sh:3553 lib/blame.tcl:294
+#: git-gui.sh:3573 lib/blame.tcl:294
 msgid "Encoding"
 msgstr "Bảng mã"
 
-#: git-gui.sh:3564
+#: git-gui.sh:3584
 msgid "Apply/Reverse Hunk"
 msgstr "Áp dụng hay đảo ngược cả khối"
 
-#: git-gui.sh:3569
+#: git-gui.sh:3589
 msgid "Apply/Reverse Line"
 msgstr "Áp dụng hay đảo ngược dòng"
 
-#: git-gui.sh:3588
+#: git-gui.sh:3608
 msgid "Run Merge Tool"
 msgstr "Chạy công cụ hòa trộn"
 
-#: git-gui.sh:3593
+#: git-gui.sh:3613
 msgid "Use Remote Version"
 msgstr "Dùng phiên bản ở máy chủ"
 
-#: git-gui.sh:3597
+#: git-gui.sh:3617
 msgid "Use Local Version"
 msgstr "Dùng phiên bản ở máy nội bộ"
 
-#: git-gui.sh:3601
+#: git-gui.sh:3621
 msgid "Revert To Base"
 msgstr "Trở lại cơ bản"
 
-#: git-gui.sh:3619
+#: git-gui.sh:3639
 msgid "Visualize These Changes In The Submodule"
 msgstr "Hiển thị trực quan các thay đổi trong mô-đun con"
 
-#: git-gui.sh:3623
+#: git-gui.sh:3643
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Hiển thị trực quan lịch sử nhánh hiện tại trong mô-đun con"
 
-#: git-gui.sh:3627
+#: git-gui.sh:3647
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Hiển thị trực quan lịch sử mọi nhánh trong mô-đun con"
 
-#: git-gui.sh:3632
+#: git-gui.sh:3652
 msgid "Start git gui In The Submodule"
 msgstr "Khởi chạy git gui trong mô-đun-con"
 
-#: git-gui.sh:3667
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "Bỏ đánh dấu đoạn cần chuyển giao"
 
-#: git-gui.sh:3669
+#: git-gui.sh:3689
 msgid "Unstage Lines From Commit"
 msgstr "Bỏ đánh dấu các dòng cần chuyển giao"
 
-#: git-gui.sh:3671
+#: git-gui.sh:3691
 msgid "Unstage Line From Commit"
 msgstr "Bỏ đánh dấu dòng cần chuyển giao"
 
-#: git-gui.sh:3674
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "Đánh dấu đoạn cần chuyển giao"
 
-#: git-gui.sh:3676
+#: git-gui.sh:3696
 msgid "Stage Lines For Commit"
 msgstr "Đánh dấu các dòng cần chuyển giao"
 
-#: git-gui.sh:3678
+#: git-gui.sh:3698
 msgid "Stage Line For Commit"
 msgstr "Đánh dấu dòng cần chuyển giao"
 
-#: git-gui.sh:3703
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "Đang khởi tạo..."
 
-#: git-gui.sh:3846
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "Gần như chắc chắn là môi trường tồn tại.\n"
 "\n"
@@ -577,25 +582,26 @@ msgstr ""
 "chạy bởi %s:\n"
 "\n"
 
-#: git-gui.sh:3875
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "Cái này có nguyên nhân bởi một lỗi phát ra từ\n"
 "Tcl phân phối bởi Cygwin."
 
-#: git-gui.sh:3880
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
@@ -604,318 +610,30 @@ msgstr ""
 "user.email thành tập tin cá nhân của bạn\n"
 "~/.gitconfig.\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - công cụ đồ họa dành cho Git."
-
-#: lib/blame.tcl:73
-msgid "File Viewer"
-msgstr "Bộ Xem Tập Tin"
-
-#: lib/blame.tcl:79
-msgid "Commit:"
-msgstr "Lần chuyển giao:"
-
-#: lib/blame.tcl:280
-msgid "Copy Commit"
-msgstr "Chép lần chuyển giao"
-
-#: lib/blame.tcl:284
-msgid "Find Text..."
-msgstr "Tìm chữ..."
-
-#: lib/blame.tcl:288
-msgid "Goto Line..."
-msgstr "Nhảy đến dòng..."
-
-#: lib/blame.tcl:297
-msgid "Do Full Copy Detection"
-msgstr "Thực hiện dò tìm chép toàn bộ"
-
-#: lib/blame.tcl:301
-msgid "Show History Context"
-msgstr "Hiển thị nội dung của lịch sử"
-
-#: lib/blame.tcl:304
-msgid "Blame Parent Commit"
-msgstr "Xem công trạng của lần chuyển giao cha mẹ"
-
-#: lib/blame.tcl:466
-#, tcl-format
-msgid "Reading %s..."
-msgstr "Đang đọc %s..."
-
-#: lib/blame.tcl:594
-msgid "Loading copy/move tracking annotations..."
-msgstr "Đang tải phần chú giải theo dõi chép/chuyển..."
-
-#: lib/blame.tcl:614
-msgid "lines annotated"
-msgstr "dòng chú giải"
-
-#: lib/blame.tcl:806
-msgid "Loading original location annotations..."
-msgstr "Đang tải các chú giải vị trí nguyên gốc..."
-
-#: lib/blame.tcl:809
-msgid "Annotation complete."
-msgstr "Chú giải hoàn tất."
-
-#: lib/blame.tcl:839
-msgid "Busy"
-msgstr "Bận"
-
-#: lib/blame.tcl:840
-msgid "Annotation process is already running."
-msgstr "Tiến trình chú giải đang diễn ra."
-
-#: lib/blame.tcl:879
-msgid "Running thorough copy detection..."
-msgstr "Đang chạy dò tìm sao chép toàn diện..."
-
-#: lib/blame.tcl:947
-msgid "Loading annotation..."
-msgstr "Đang tải phần chú giải..."
-
-#: lib/blame.tcl:1000
-msgid "Author:"
-msgstr "Tác giả:"
-
-#: lib/blame.tcl:1004
-msgid "Committer:"
-msgstr "Người chuyển giao:"
-
-#: lib/blame.tcl:1009
-msgid "Original File:"
-msgstr "Tập tin gốc:"
-
-#: lib/blame.tcl:1057
-msgid "Cannot find HEAD commit:"
-msgstr "Không thể tìm thấy HEAD của lần chuyển giao:"
-
-#: lib/blame.tcl:1112
-msgid "Cannot find parent commit:"
-msgstr "Không thể tìm thấy lần chuyển giao mẹ:"
-
-#: lib/blame.tcl:1127
-msgid "Unable to display parent"
-msgstr "Không thể hiển thị cha mẹ"
-
-#: lib/blame.tcl:1128 lib/diff.tcl:341
-msgid "Error loading diff:"
-msgstr "Gặp lỗi khi tải diff:"
-
-#: lib/blame.tcl:1269
-msgid "Originally By:"
-msgstr "Nguyên gốc bởi:"
-
-#: lib/blame.tcl:1275
-msgid "In File:"
-msgstr "Trong tập tin:"
-
-#: lib/blame.tcl:1280
-msgid "Copied Or Moved Here By:"
-msgstr "Đã chép hoặc Di chuyển đến đây bởi:"
-
-#: lib/branch_checkout.tcl:16 lib/branch_checkout.tcl:21
-msgid "Checkout Branch"
-msgstr "Lấy ra nhánh"
-
-#: lib/branch_checkout.tcl:26
-msgid "Checkout"
-msgstr "Lấy ra"
-
-#: lib/branch_checkout.tcl:30 lib/branch_create.tcl:37
-#: lib/branch_delete.tcl:34 lib/branch_rename.tcl:32 lib/browser.tcl:292
-#: lib/checkout_op.tcl:579 lib/choose_font.tcl:45 lib/merge.tcl:174
-#: lib/option.tcl:127 lib/remote_add.tcl:34 lib/remote_branch_delete.tcl:43
-#: lib/tools_dlg.tcl:41 lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345
-#: lib/transport.tcl:141
-msgid "Cancel"
-msgstr "Thôi"
-
-#: lib/branch_checkout.tcl:35 lib/browser.tcl:297 lib/tools_dlg.tcl:321
-msgid "Revision"
-msgstr "Điểm sửa đổi"
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:69 lib/option.tcl:309
-msgid "Options"
-msgstr "Tùy chọn"
-
-#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "Lấy về nhánh được theo dõi"
-
-#: lib/branch_checkout.tcl:47
-msgid "Detach From Local Branch"
-msgstr "Tách rời từ Nhánh nội bộ"
-
-#: lib/branch_create.tcl:23
-msgid "Create Branch"
-msgstr "Tạo nhánh"
-
-#: lib/branch_create.tcl:28
-msgid "Create New Branch"
-msgstr "Tạo nhánh mới"
-
-#: lib/branch_create.tcl:33 lib/choose_repository.tcl:391
-msgid "Create"
-msgstr "Tạo"
-
-#: lib/branch_create.tcl:42
-msgid "Branch Name"
-msgstr "Tên nhánh"
-
-#: lib/branch_create.tcl:44 lib/remote_add.tcl:41 lib/tools_dlg.tcl:51
-msgid "Name:"
-msgstr "Tên:"
-
-#: lib/branch_create.tcl:57
-msgid "Match Tracking Branch Name"
-msgstr "Khớp với tên nhánh được theo dõi"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "Điểm đầu"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "Cập nhật nhánh sẵn có:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "Không"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "Chỉ fast-forward"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:571
-msgid "Reset"
-msgstr "Đặt lại"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "Lấy ra sau khi tạo"
-
-#: lib/branch_create.tcl:132
-msgid "Please select a tracking branch."
-msgstr "Vui lòng chọn nhánh theo dõi."
-
-#: lib/branch_create.tcl:141
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "Nhánh theo dõi %s không phải là một nhánh trên kho chứa máy chủ."
-
-#: lib/branch_create.tcl:154 lib/branch_rename.tcl:92
-msgid "Please supply a branch name."
-msgstr "Hãy cung cấp tên nhánh."
-
-#: lib/branch_create.tcl:165 lib/branch_rename.tcl:112
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "'%s' không phải là một tên nhánh được chấp nhận."
-
-#: lib/branch_delete.tcl:16
-msgid "Delete Branch"
-msgstr "Xoá nhánh"
-
-#: lib/branch_delete.tcl:21
-msgid "Delete Local Branch"
-msgstr "Xóa nhánh nội bộ"
-
-#: lib/branch_delete.tcl:39
-msgid "Local Branches"
-msgstr "Nhánh nội bộ"
-
-#: lib/branch_delete.tcl:51
-msgid "Delete Only If Merged Into"
-msgstr "Chỉ xóa nếu đã hòa trộn vào"
-
-#: lib/branch_delete.tcl:53 lib/remote_branch_delete.tcl:120
-msgid "Always (Do not perform merge checks)"
-msgstr "Luôn (Không thực hiện kiểm tra hòa trộn)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "Các nhánh sau đây không được hòa trộn hoàn toàn vào %s:"
-
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:218
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr ""
-"Khôi phục các nhánh đã bị xóa là việc khó khăn.\n"
-"\n"
-"Xóa nhánh đã chọn chứ?"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-"Gặp lỗi khi xóa các nhánh:\n"
-"%s"
-
-#: lib/branch_rename.tcl:15 lib/branch_rename.tcl:23
-msgid "Rename Branch"
-msgstr "Đổi tên nhánh"
-
-#: lib/branch_rename.tcl:28
-msgid "Rename"
-msgstr "Đổi tên"
-
-#: lib/branch_rename.tcl:38
-msgid "Branch:"
-msgstr "Nhánh:"
-
-#: lib/branch_rename.tcl:46
-msgid "New Name:"
-msgstr "Tên mới:"
-
-#: lib/branch_rename.tcl:81
-msgid "Please select a branch to rename."
-msgstr "Hãy chọn nhánh cần đổi tên."
-
-#: lib/branch_rename.tcl:102 lib/checkout_op.tcl:202
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "Nhánh '%s' đã có rồi."
-
-#: lib/branch_rename.tcl:123
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "Gặp lỗi khi đổi tên '%s'."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "Đang khởi động..."
-
-#: lib/browser.tcl:27
-msgid "File Browser"
-msgstr "Bộ duyệt tập tin"
-
-#: lib/browser.tcl:132 lib/browser.tcl:149
-#, tcl-format
-msgid "Loading %s..."
-msgstr "Đang tải %s..."
-
-#: lib/browser.tcl:193
-msgid "[Up To Parent]"
-msgstr "[Tới cha mẹ]"
-
-#: lib/browser.tcl:275 lib/browser.tcl:282
-msgid "Browse Branch Files"
-msgstr "Duyệt các tập tin nhánh"
-
-#: lib/browser.tcl:288 lib/choose_repository.tcl:406
-#: lib/choose_repository.tcl:493 lib/choose_repository.tcl:502
-#: lib/choose_repository.tcl:1029
-msgid "Browse"
-msgstr "Tìm duyệt"
+#: lib/line.tcl:17
+msgid "Goto Line:"
+msgstr "Nhảy đến dòng:"
+
+#: lib/line.tcl:23
+msgid "Go"
+msgstr "Nhảy"
+
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "Đang chạy.. vui lòng đợi..."
+
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "Đóng"
+
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "Thành công"
+
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "Lỗi: Câu lệnh gặp lỗi"
 
 #: lib/checkout_op.tcl:85
 #, tcl-format
@@ -927,11 +645,6 @@ msgstr "Đang lấy về %s từ %s"
 msgid "fatal: Cannot resolve %s"
 msgstr "gặp lỗi nghiêm trọng: Không thể phân giải %s"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:30
-#: lib/sshkey.tcl:55
-msgid "Close"
-msgstr "Đóng"
-
 #: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
@@ -941,6 +654,11 @@ msgstr "Chưa có nhánh '%s'"
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Gặp lỗi khi cấu hình git-pull đơn giản dành cho '%s'."
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "Nhánh '%s' đã có rồi."
 
 #: lib/checkout_op.tcl:229
 #, tcl-format
@@ -970,13 +688,14 @@ msgid "Staging area (index) is already locked."
 msgstr "Vùng bệ phóng (chỉ mục) đã bị khóa rồi."
 
 #: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "Trạng thái quét không khớp với trạng thái kho.\n"
 "\n"
@@ -1009,9 +728,10 @@ msgid "Staying on branch '%s'."
 msgstr "Đang ở trên nhánh '%s'."
 
 #: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -1038,18 +758,31 @@ msgstr "Lấy lại những lần chuyển giao đã mất là không dễ."
 msgid "Reset '%s'?"
 msgstr "Đặt lại '%s'?"
 
-#: lib/checkout_op.tcl:567 lib/merge.tcl:166 lib/tools_dlg.tcl:336
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Trực quan"
 
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "Đặt lại"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "Thôi"
+
 #: lib/checkout_op.tcl:635
-#, tcl-format
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "Gặp lỗi khi đặt nhánh hiện hành.\n"
@@ -1058,6 +791,591 @@ msgstr ""
 "các tập tin của bạn, nhưng lại gặp lỗi khi cập nhật một tập tin của Git.\n"
 "\n"
 "Điều này đáng lẽ không thể xảy ra.  %s giờ sẽ đóng lại và đầu hàng."
+
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "lấy về %s"
+
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "Lấy các thay đổi mới từ %s"
+
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "xén bớt trên máy chủ %s"
+
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "Xén bớt các nhánh theo dõi bị xóa từ %s"
+
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
+msgstr "lấy về từ tất cả các máy chủ"
+
+#: lib/transport.tcl:26
+msgid "Fetching new changes from all remotes"
+msgstr "Đang lấy các thay đổi mới từ mọi máy chủ"
+
+#: lib/transport.tcl:40
+msgid "remote prune all remotes"
+msgstr "xén bớt mọi máy chủ"
+
+#: lib/transport.tcl:41
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "Xén tỉa các nhánh đã theo dõi bị xóa từ mọi máy chủ"
+
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
+#, tcl-format
+msgid "push %s"
+msgstr "đẩy %s lên máy chủ"
+
+#: lib/transport.tcl:55
+#, tcl-format
+msgid "Pushing changes to %s"
+msgstr "Đang đẩy các nhánh lên %s"
+
+#: lib/transport.tcl:93
+#, tcl-format
+msgid "Mirroring to %s"
+msgstr "Bản sao đến %s"
+
+#: lib/transport.tcl:111
+#, tcl-format
+msgid "Pushing %s %s to %s"
+msgstr "Đang (đẩy) %s %s lên %s"
+
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "Đẩy lên các nhánh"
+
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "Nhánh nguồn"
+
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "Kho chứa đích"
+
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Máy chủ:"
+
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
+msgid "Arbitrary Location:"
+msgstr "Địa điểm tùy ý:"
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "Tùy chọn truyền"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr "Ép buộc ghi đè nhánh sẵn có (có thể sẽ loại bỏ các thay đổi)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "Dùng gói mỏng (dành cho kết nối mạng chậm)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "Bao gồm các thẻ"
+
+#: lib/transport.tcl:229
+#, tcl-format
+msgid "%s (%s): Push"
+msgstr ""
+
+#: lib/remote_add.tcl:20
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr "Thêm máy chủ"
+
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr "Thêm máy chủ mới"
+
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr "Thêm vào"
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr "Chi tiết về máy chủ"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "Tên:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr "Vị trí:"
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr "Hành động thêm"
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr "Lấy về ngay lập tức"
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr "Khởi tạo Kho máy chủ và đẩy dữ liệu lên"
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr "Không làm gì cả"
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr "Hãy cung cấp tên máy chủ."
+
+#: lib/remote_add.tcl:113
+#, tcl-format
+msgid "'%s' is not an acceptable remote name."
+msgstr "'%s' không phải là tên máy chủ được chấp nhận."
+
+#: lib/remote_add.tcl:124
+#, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "Gặp lỗi khi thêm máy chủ '%s' của vị trí '%s'."
+
+#: lib/remote_add.tcl:133
+#, tcl-format
+msgid "Fetching the %s"
+msgstr "Đang lấy về %s"
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr "Không hiểu làm thế nào để khởi tạo kho chứa tại vị trí '%s'."
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr "Cài đặt '%s' (tại %s)"
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "Đang khởi động..."
+
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "Bộ duyệt tập tin"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr "Đang tải %s..."
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[Tới cha mẹ]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "Duyệt các tập tin nhánh"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "Duyệt các tập tin nhánh"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "Tìm duyệt"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "Điểm sửa đổi"
+
+#: lib/merge.tcl:13
+#, fuzzy
+msgid ""
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
+msgstr ""
+"Không thể hòa trộn trong khi tu bổ.\n"
+"\n"
+"Bạn phải hoàn tất việc tu bổ lần chuyển giao trước khi bắt đầu bất kỳ kiểu "
+"hòa trộn nào.\n"
+
+#: lib/merge.tcl:27
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Trạng thái quét không khớp với trạng thái kho.\n"
+"\n"
+"Có Git khác đã sửa kho này kể từ lần quét cuối. Cần quét lại trước khi thực "
+"hiện việc hòa trộn.\n"
+"\n"
+"Sẽ thực hiện việc quét lại ngay bây giời.\n"
+
+#: lib/merge.tcl:45
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
+"You must resolve them, stage the file, and commit to complete the current "
+"merge.  Only then can you begin another merge.\r\n"
+msgstr ""
+"Bạn đang ở giữa việc thay đổi.\n"
+"\n"
+"Tập tin %s đã bị sửa đổi.\n"
+"\n"
+"Bạn nên hoàn thiện lần chuyển giao hiện nay trước khi hòa trộn. Chỉ có thế "
+"bạn mới có thể bắt đầu hòa trộn cái .\n"
+
+#: lib/merge.tcl:55
+#, fuzzy, tcl-format
+msgid ""
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
+"You should complete the current commit before starting a merge.  Doing so "
+"will help you abort a failed merge, should the need arise.\r\n"
+msgstr ""
+"Bạn đang ở giữa việc thay đổi.\n"
+"\n"
+"Tập tin %s đã bị sửa đổi.\n"
+"\n"
+"Bạn nên hoàn thiện lần chuyển giao hiện nay trước khi hòa trộn.  Làm như vậy "
+"giúp bạn có thể loại bỏ việc lỗi trong hòa trộn.\n"
+
+#: lib/merge.tcl:108
+#, tcl-format
+msgid "%s of %s"
+msgstr "%s trên %s"
+
+#: lib/merge.tcl:126
+#, tcl-format
+msgid "Merging %s and %s..."
+msgstr "Đang hòa trộn %s và %s..."
+
+#: lib/merge.tcl:137
+msgid "Merge completed successfully."
+msgstr "Hòa trộn đã thực hiện thành công."
+
+#: lib/merge.tcl:139
+msgid "Merge failed.  Conflict resolution is required."
+msgstr "Hòa trộn gặp lỗi. Cần giải quyết các xung đột trước."
+
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
+#, tcl-format
+msgid "Merge Into %s"
+msgstr "Hòa trộn vào %s"
+
+#: lib/merge.tcl:183
+msgid "Revision To Merge"
+msgstr "Điểm cần hòa trộn"
+
+#: lib/merge.tcl:218
+#, fuzzy
+msgid ""
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
+msgstr ""
+"Không thể hủy bỏ trong khi đang tu bổ.\n"
+"\n"
+"Bạn cần phải hoàn tất việc tu bổ lần chuyển giao này.\n"
+
+#: lib/merge.tcl:228
+#, fuzzy
+msgid ""
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
+"Continue with aborting the current merge?"
+msgstr ""
+"Bãi bỏ hòa trộn?\n"
+"\n"
+"Bãi bỏ hòa trộn hiện nay sẽ làm *TẤT CẢ* các thay đổi chưa được chuyển giao "
+"bị mất.\n"
+"\n"
+"Tiếp tục bãi bỏ việc hòa trộn hiện tại?"
+
+#: lib/merge.tcl:234
+#, fuzzy
+msgid ""
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
+"Continue with resetting the current changes?"
+msgstr ""
+"Đặt lại mọi thay đổi?\n"
+"\n"
+"Việc đặt lại các thay đổi sẽ làm *MỌI* thay đổi chưa chuyển giao biến mất.\n"
+"\n"
+"Vẫn tiếp tục đặt lại các thay đổi hiện tại?"
+
+#: lib/merge.tcl:245
+msgid "Aborting"
+msgstr "Bãi bỏ"
+
+#: lib/merge.tcl:245
+msgid "files reset"
+msgstr "đặt lại các tập tin"
+
+#: lib/merge.tcl:273
+msgid "Abort failed."
+msgstr "Gặp lỗi khi bãi bỏ."
+
+#: lib/merge.tcl:275
+msgid "Abort completed.  Ready."
+msgstr "Đã bãi bỏ xong.  Sẵn sàng."
+
+#: lib/tools.tcl:76
+#, tcl-format
+msgid "Running %s requires a selected file."
+msgstr "Chạy %s yêu cầu cần phải chọn một tập tin."
+
+#: lib/tools.tcl:92
+#, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr "Bạn có chắc là muốn chạy %1$s trên tập tin \"%2$s\" không?"
+
+#: lib/tools.tcl:96
+#, tcl-format
+msgid "Are you sure you want to run %s?"
+msgstr "Bạn có chắc là muốn chạy %s không?"
+
+#: lib/tools.tcl:118
+#, tcl-format
+msgid "Tool: %s"
+msgstr "Công cụ: %s"
+
+#: lib/tools.tcl:119
+#, tcl-format
+msgid "Running: %s"
+msgstr "Đang chạy: %s"
+
+#: lib/tools.tcl:158
+#, tcl-format
+msgid "Tool completed successfully: %s"
+msgstr "Công cụ được biên dịch thành công: %s"
+
+#: lib/tools.tcl:160
+#, tcl-format
+msgid "Tool failed: %s"
+msgstr "Công cụ gặp lỗi: %s"
+
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Lấy ra nhánh"
+
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Lấy ra nhánh"
+
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Lấy ra"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "Tùy chọn"
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "Lấy về nhánh được theo dõi"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "Tách rời từ Nhánh nội bộ"
+
+#: lib/spellcheck.tcl:57
+msgid "Unsupported spell checker"
+msgstr "Không hỗ trợ kiểm tra chính tả"
+
+#: lib/spellcheck.tcl:65
+msgid "Spell checking is unavailable"
+msgstr "Kiểm tra chính tả không sẵn sàng"
+
+#: lib/spellcheck.tcl:68
+msgid "Invalid spell checking configuration"
+msgstr "Cấu hình bộ soát chính tả không hợp lệ"
+
+#: lib/spellcheck.tcl:70
+#, tcl-format
+msgid "Reverting dictionary to %s."
+msgstr "Đang hoàn nguyên từ điển thành %s."
+
+#: lib/spellcheck.tcl:73
+msgid "Spell checker silently failed on startup"
+msgstr "Phần kiểm tra chính tả đã gặp lỗi khi khởi động"
+
+#: lib/spellcheck.tcl:80
+msgid "Unrecognized spell checker"
+msgstr "Không chấp nhận bộ kiểm tra chính tả"
+
+#: lib/spellcheck.tcl:186
+msgid "No Suggestions"
+msgstr "Không có gợi ý"
+
+#: lib/spellcheck.tcl:388
+msgid "Unexpected EOF from spell checker"
+msgstr "Gặp kết thúc bất ngờ từ bộ kiểm tra chính tả"
+
+#: lib/spellcheck.tcl:392
+msgid "Spell Checker Failed"
+msgstr "Kiểm tra chính tả không thành công"
+
+#: lib/status_bar.tcl:87
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr "%s ... %*i trong %*i %s (%3i%%)"
+
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"Không tìm thấy khác biệt gì.\n"
+"\n"
+"%s không thay đổi.\n"
+"\n"
+"Thời gian sửa đổi của tập tin này được cập nhật bởi ứng dụng khác, nhưng nội "
+"dung bên trong tập tin thì không thay đổi.\n"
+"\n"
+"Sẽ thực hiện quét lại một cách tự động để tìm các tập tin khác cái mà có thể "
+"có cùng tình trạng."
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr "Đang tải diff của %s..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+"NỘIBỘ: đã xoá\n"
+"MÁYCHỦ:\n"
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+"MÁYCHỦ: đã xoá\n"
+"NỘIBỘ:\n"
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr "NỘI-BỘ:\n"
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr "MÁY-CHỦ:\n"
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
+#, tcl-format
+msgid "Unable to display %s"
+msgstr "Không thể hiển thị %s"
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "Lỗi khi tải tập tin:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Kho Git (dự án con)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* Tập tin nhị phân (không hiển thị nội dung)."
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, fuzzy, tcl-format
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
+"\n"
+"* Tập tin chưa theo dõi được cắt tại đây bởi %s.\n"
+"* Để xem toàn bộ tập tin, hãy dùng ứng dụng biên soạn bên ngoài.\n"
+
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "Gặp lỗi khi tải diff:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "Gặp lỗi khi bỏ ra khỏi bệ phóng khối đã chọn"
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "Gặp lỗi khi đưa lên bệ phóng khối đã chọn"
+
+#: lib/diff.tcl:666
+msgid "Failed to unstage selected line."
+msgstr "Gặp lỗi khi bỏ ra khỏi bệ phóng dòng đã chọn"
+
+#: lib/diff.tcl:674
+msgid "Failed to stage selected line."
+msgstr "Gặp lỗi khi đưa lên bệ phóng dòng đã chọn"
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "Đẩy lên"
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr "Gỡ bỏ Máy chủ"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "Xén từ"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "Lấy về từ"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
 
 #: lib/choose_font.tcl:41
 msgid "Select"
@@ -1082,984 +1400,6 @@ msgid ""
 msgstr ""
 "Đây là chữ mẫu.\n"
 "Nếu bạn thích chữ như thế này thì chọn phông chữ này."
-
-#: lib/choose_repository.tcl:32
-msgid "Git Gui"
-msgstr "Git Gui"
-
-#: lib/choose_repository.tcl:91 lib/choose_repository.tcl:396
-msgid "Create New Repository"
-msgstr "Tạo kho mới"
-
-#: lib/choose_repository.tcl:97
-msgid "New..."
-msgstr "Mới..."
-
-#: lib/choose_repository.tcl:104 lib/choose_repository.tcl:480
-msgid "Clone Existing Repository"
-msgstr "Nhân bản một kho sẵn có"
-
-#: lib/choose_repository.tcl:115
-msgid "Clone..."
-msgstr "Nhân bản..."
-
-#: lib/choose_repository.tcl:122 lib/choose_repository.tcl:1019
-msgid "Open Existing Repository"
-msgstr "Mở một kho đã có."
-
-#: lib/choose_repository.tcl:128
-msgid "Open..."
-msgstr "Mở..."
-
-#: lib/choose_repository.tcl:141
-msgid "Recent Repositories"
-msgstr "Các kho mới dùng"
-
-#: lib/choose_repository.tcl:147
-msgid "Open Recent Repository:"
-msgstr "Mở kho mới dùng:"
-
-#: lib/choose_repository.tcl:315 lib/choose_repository.tcl:322
-#: lib/choose_repository.tcl:329
-#, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "Gặp lỗi khi tạo kho %s:"
-
-#: lib/choose_repository.tcl:401
-msgid "Directory:"
-msgstr "Thư mục:"
-
-#: lib/choose_repository.tcl:431 lib/choose_repository.tcl:552
-#: lib/choose_repository.tcl:1053
-msgid "Git Repository"
-msgstr "Kho Git"
-
-#: lib/choose_repository.tcl:456
-#, tcl-format
-msgid "Directory %s already exists."
-msgstr "Thư mục %s đã sẵn có."
-
-#: lib/choose_repository.tcl:460
-#, tcl-format
-msgid "File %s already exists."
-msgstr "Tập tin %s đã có sẵn."
-
-#: lib/choose_repository.tcl:475
-msgid "Clone"
-msgstr "Nhân bản"
-
-#: lib/choose_repository.tcl:488
-msgid "Source Location:"
-msgstr "Vị trí nguồn:"
-
-#: lib/choose_repository.tcl:497
-msgid "Target Directory:"
-msgstr "Thư mục đích:"
-
-#: lib/choose_repository.tcl:507
-msgid "Clone Type:"
-msgstr "Kiểu nhân bản:"
-
-#: lib/choose_repository.tcl:512
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "Tiêu chuẩn (Nhanh, Semi-Redundant, Hardlinks)"
-
-#: lib/choose_repository.tcl:517
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "Sao chép toàn bộ (Chậm hơn, Redundant Backup)"
-
-#: lib/choose_repository.tcl:522
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "Chia sẻ (Nhanh nhất, Không nên dùng, No Backup)"
-
-#: lib/choose_repository.tcl:558 lib/choose_repository.tcl:605
-#: lib/choose_repository.tcl:751 lib/choose_repository.tcl:821
-#: lib/choose_repository.tcl:1059 lib/choose_repository.tcl:1067
-#, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "Không phải là kho git: %s"
-
-#: lib/choose_repository.tcl:594
-msgid "Standard only available for local repository."
-msgstr "Tiêu chuẩn chỉ sẵn sàng với kho nội bộ."
-
-#: lib/choose_repository.tcl:598
-msgid "Shared only available for local repository."
-msgstr "'Chia sẻ' chỉ sẵn sàng với kho nội bộ."
-
-#: lib/choose_repository.tcl:619
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "Miền địa phương %s đã sẵn có."
-
-#: lib/choose_repository.tcl:630
-msgid "Failed to configure origin"
-msgstr "Gặp lỗi khi cấu hình bản gốc"
-
-#: lib/choose_repository.tcl:642
-msgid "Counting objects"
-msgstr "Đang đếm số đối tượng"
-
-#: lib/choose_repository.tcl:643
-msgid "buckets"
-msgstr "xô"
-
-#: lib/choose_repository.tcl:667
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "Không thể sao chép objects/info/alternates: %s"
-
-#: lib/choose_repository.tcl:703
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "Không có gì để nhân bản từ %s"
-
-#: lib/choose_repository.tcl:705 lib/choose_repository.tcl:919
-#: lib/choose_repository.tcl:931
-msgid "The 'master' branch has not been initialized."
-msgstr "Nhánh 'master' chưa được khởi tạo."
-
-#: lib/choose_repository.tcl:718
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "Liên kết cứng không sẵn sàng. Trở lại chế độ sao chép."
-
-#: lib/choose_repository.tcl:730
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "Đang nhân bản từ %s"
-
-#: lib/choose_repository.tcl:761
-msgid "Copying objects"
-msgstr "Đang chép các đối tượng"
-
-#: lib/choose_repository.tcl:762
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:786
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "Không thể chép đối tượng: %s"
-
-#: lib/choose_repository.tcl:796
-msgid "Linking objects"
-msgstr "Đang liên kết các đối tượng"
-
-#: lib/choose_repository.tcl:797
-msgid "objects"
-msgstr "đối tượng"
-
-#: lib/choose_repository.tcl:805
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "Không thể tạo liên kết cứng đối tượng: %s"
-
-#: lib/choose_repository.tcl:860
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr ""
-"Không thể lấy các nhánh và đối tượng. Xem kết xuất từ bảng điều khiển để có "
-"thêm thông tin."
-
-#: lib/choose_repository.tcl:871
-msgid "Cannot fetch tags.  See console output for details."
-msgstr ""
-"Không thể lấy về các thẻ. Hãy xem kết xuất từ bảng điều khiển để có thêm "
-"thông tin chi tiết."
-
-#: lib/choose_repository.tcl:895
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr ""
-"Không thể dò tìm HEAD. Hãy xem kết xuất từ bảng điều khiển để có thêm thông "
-"tin chi tiết."
-
-#: lib/choose_repository.tcl:904
-#, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "Không thể dọn sạch %s"
-
-#: lib/choose_repository.tcl:910
-msgid "Clone failed."
-msgstr "Gặp lỗi khi nhân bản."
-
-#: lib/choose_repository.tcl:917
-msgid "No default branch obtained."
-msgstr "Không tìm thấy nhánh mặc định."
-
-#: lib/choose_repository.tcl:928
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "Không thể phân giải %s như là một lần chuyển giao."
-
-#: lib/choose_repository.tcl:940
-msgid "Creating working directory"
-msgstr "Đang tạo thư mục làm việc"
-
-#: lib/choose_repository.tcl:941 lib/index.tcl:70 lib/index.tcl:136
-#: lib/index.tcl:207
-msgid "files"
-msgstr "tập tin"
-
-#: lib/choose_repository.tcl:970
-msgid "Initial file checkout failed."
-msgstr "Lấy ra tập tin khởi tạo gặp lỗi."
-
-#: lib/choose_repository.tcl:1014
-msgid "Open"
-msgstr "Mở"
-
-#: lib/choose_repository.tcl:1024
-msgid "Repository:"
-msgstr "Kho:"
-
-#: lib/choose_repository.tcl:1073
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "Gặp lỗi khi mở kho %s:"
-
-#: lib/choose_rev.tcl:52
-msgid "This Detached Checkout"
-msgstr "Đây là việc lấy ra bị tách rời"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "Biểu thức điểm xét:"
-
-#: lib/choose_rev.tcl:72
-msgid "Local Branch"
-msgstr "Nhánh nội bộ"
-
-#: lib/choose_rev.tcl:77
-msgid "Tracking Branch"
-msgstr "Nhánh Theo dõi"
-
-#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
-msgid "Tag"
-msgstr "Thẻ"
-
-#: lib/choose_rev.tcl:321
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "Điểm xét duyệt không hợp lệ: %s"
-
-#: lib/choose_rev.tcl:342
-msgid "No revision selected."
-msgstr "Chưa chọn điểm xét duyệt."
-
-#: lib/choose_rev.tcl:350
-msgid "Revision expression is empty."
-msgstr "Biểu thức chính quy rỗng."
-
-#: lib/choose_rev.tcl:537
-msgid "Updated"
-msgstr "Đã cập nhật"
-
-#: lib/choose_rev.tcl:565
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"Ở đây chẳng có gì để tu bổ cả.\n"
-"\n"
-"Bạn đang tạo lần chuyển giao khởi tạo. Ở đây không có lần chuyển giao trước "
-"nào để mà tu bổ.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"Không thể tu bổ trong khi hòa trộn.\n"
-"\n"
-"Bạn hiện đang ở giữa quá trình hòa trôn, mà nó chưa hoàn tất. Bạn không thể "
-"tu bổ  lần chuyển giao tiền nhiệm trừ phi bạn bãi bỏ lần hòa trộn hiện đang "
-"kích hoạt.\n"
-
-#: lib/commit.tcl:48
-msgid "Error loading commit data for amend:"
-msgstr "Gặp lỗi khi tải dữ liệu chuyển giao cho lệnh tu bổ:"
-
-#: lib/commit.tcl:75
-msgid "Unable to obtain your identity:"
-msgstr "Không thể lấy được định danh của bạn:"
-
-#: lib/commit.tcl:80
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "GIT_COMMITTER_IDENT không hợp lệ:"
-
-#: lib/commit.tcl:129
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "cảnh báo: Tcl không hỗ trợ bảng mã '%s'."
-
-#: lib/commit.tcl:149
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"Trạng thái quét không khớp với trạng thái kho.\n"
-"\n"
-"Có Git khác đã sửa kho này kể từ lần quét cuối. Cần quét lại trước khi thực "
-"hiện việc chuyển giao khác.\n"
-"\n"
-"Sẽ thực hiện việc quét lại ngay bây giời.\n"
-
-#: lib/commit.tcl:173
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"Các tập tin chưa hòa trộn không thể được chuyển giao.\n"
-"\n"
-"Tập tin %s có xung đột hòa trộn. Bạn phải giải quyết chúng và đưa lên bệ "
-"phóng trước khi chuyển giao.\n"
-
-#: lib/commit.tcl:181
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"Tìm thấy trạng thái tập tim không hiểu %s.\n"
-"\n"
-"Tập tin %s không thể được chuyển giao bởi chương trình này.\n"
-
-#: lib/commit.tcl:189
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"Không có thay đổi nào cần chuyển giao.\n"
-"\n"
-"Bạn phải đưa lên bệ phóng ít nhất là một tập tin trước khi có thể chuyển "
-"giao.\n"
-
-#: lib/commit.tcl:204
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"Hãy cung cấp lời chú giải cho lần chuyển giao.\n"
-"\n"
-"Lời chú giải tốt nhất nên có định dạng sau:\n"
-"\n"
-"- Dòng đầu tiên: Mô tả những gì bạn đã làm.\n"
-"- Dòng thứ hai: Để trống\n"
-"- Các dòng còn lại: Mô tả xem vì sao những thay đổi này là cần thiết.\n"
-
-#: lib/commit.tcl:235
-msgid "Calling pre-commit hook..."
-msgstr "Đang gọi móc (hook) pre-commit..."
-
-#: lib/commit.tcl:250
-msgid "Commit declined by pre-commit hook."
-msgstr "Lần chuyển giao bị khước từ do móc pre-commit."
-
-#: lib/commit.tcl:269
-msgid ""
-"You are about to commit on a detached head. This is a potentially dangerous "
-"thing to do because if you switch to another branch you will lose your "
-"changes and it can be difficult to retrieve them later from the reflog. You "
-"should probably cancel this commit and create a new branch to continue.\n"
-" \n"
-" Do you really want to proceed with your Commit?"
-msgstr ""
-"Bạn thực hiện chuyển giao ở chỗ đã tách rời khỏi các đầu. Điều này là nguy "
-"hiểm bởi nếu bạn chuyển sang nhánh khác thì bạn sẽ mất những thay đổi này và "
-"việc lấy lại chúng từ reflog cũng khó khăn. Bạn gần như chắc chắn là nên hủy "
-"bỏ lần chuyển giao này và tạo một nhánh mới trước khi tiếp tục.\n"
-" \n"
-" Bạn có thực sự muốn tiếp tục chuyển giao?"
-
-#: lib/commit.tcl:290
-msgid "Calling commit-msg hook..."
-msgstr "Đang gọi móc commit-msg..."
-
-#: lib/commit.tcl:305
-msgid "Commit declined by commit-msg hook."
-msgstr "Lần chuyển giao bị khước từ do móc commit-msg."
-
-#: lib/commit.tcl:318
-msgid "Committing changes..."
-msgstr "Chuyển giao các thay đổi..."
-
-#: lib/commit.tcl:334
-msgid "write-tree failed:"
-msgstr "gặp lỗi khi write-tree:"
-
-#: lib/commit.tcl:335 lib/commit.tcl:379 lib/commit.tcl:400
-msgid "Commit failed."
-msgstr "Gặp lỗi khi chuyển giao."
-
-#: lib/commit.tcl:352
-#, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "Lần chuyển giao %s có vẻ đã hư hỏng"
-
-#: lib/commit.tcl:357
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"Không có thay đổi nào để chuyển giao.\n"
-"\n"
-"Không có tập tin nào được sửa bởi lần chuyển giao này và nó không phải là "
-"lần chuyển giao hòa trộn.\n"
-"\n"
-"Sẽ thực hiện việc quét lại ngay bây giờ.\n"
-
-#: lib/commit.tcl:364
-msgid "No changes to commit."
-msgstr "Không có thay đổi nào để chuyển giao."
-
-#: lib/commit.tcl:378
-msgid "commit-tree failed:"
-msgstr "commit-tree gặp lỗi:"
-
-#: lib/commit.tcl:399
-msgid "update-ref failed:"
-msgstr "cập nhật tham chiếu thất bại:"
-
-#: lib/commit.tcl:492
-#, tcl-format
-msgid "Created commit %s: %s"
-msgstr "Lần chuyển giao đã tạo %s: %s"
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "Đang chạy.. vui lòng đợi..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "Thành công"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "Lỗi: Câu lệnh gặp lỗi"
-
-#: lib/database.tcl:42
-msgid "Number of loose objects"
-msgstr "Số lượng đối tượng bị mất"
-
-#: lib/database.tcl:43
-msgid "Disk space used by loose objects"
-msgstr "Dung lượng đĩa được dùng bởi các đối tượng bị mất"
-
-#: lib/database.tcl:44
-msgid "Number of packed objects"
-msgstr "Số lượng đối tượng được đóng gói"
-
-#: lib/database.tcl:45
-msgid "Number of packs"
-msgstr "Số lượng gói"
-
-#: lib/database.tcl:46
-msgid "Disk space used by packed objects"
-msgstr "Dung lượng đĩa được dùng bởi các đối tượng gói"
-
-#: lib/database.tcl:47
-msgid "Packed objects waiting for pruning"
-msgstr "Các đối tượng gói chờ xén bớt"
-
-#: lib/database.tcl:48
-msgid "Garbage files"
-msgstr "Các tập tin rác"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "Nén cơ sở dữ liệu đối tượng"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "Đang kiểm tra cơ sở dữ liệu đối tượng bằng lệnh fsck"
-
-#: lib/database.tcl:107
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"Hiện kho này mất ước chừng khoảng %i đối tượng.\n"
-"\n"
-"Để tối ưu hóa hiệu suất, khuyến nghị bạn nên nén cơ sở dữ liệu của mình "
-"lại.\n"
-"\n"
-"Nén cơ sở dữ liệu chứ?"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "Ngày tháng không hợp lệ từ Git: %s"
-
-#: lib/diff.tcl:64
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"Không tìm thấy khác biệt gì.\n"
-"\n"
-"%s không thay đổi.\n"
-"\n"
-"Thời gian sửa đổi của tập tin này được cập nhật bởi ứng dụng khác, nhưng nội "
-"dung bên trong tập tin thì không thay đổi.\n"
-"\n"
-"Sẽ thực hiện quét lại một cách tự động để tìm các tập tin khác cái mà có thể "
-"có cùng tình trạng."
-
-#: lib/diff.tcl:104
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr "Đang tải diff của %s..."
-
-#: lib/diff.tcl:125
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-"NỘIBỘ: đã xoá\n"
-"MÁYCHỦ:\n"
-
-#: lib/diff.tcl:130
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-"MÁYCHỦ: đã xoá\n"
-"NỘIBỘ:\n"
-
-#: lib/diff.tcl:137
-msgid "LOCAL:\n"
-msgstr "NỘI-BỘ:\n"
-
-#: lib/diff.tcl:140
-msgid "REMOTE:\n"
-msgstr "MÁY-CHỦ:\n"
-
-#: lib/diff.tcl:202 lib/diff.tcl:340
-#, tcl-format
-msgid "Unable to display %s"
-msgstr "Không thể hiển thị %s"
-
-#: lib/diff.tcl:203
-msgid "Error loading file:"
-msgstr "Lỗi khi tải tập tin:"
-
-#: lib/diff.tcl:210
-msgid "Git Repository (subproject)"
-msgstr "Kho Git (dự án con)"
-
-#: lib/diff.tcl:222
-msgid "* Binary file (not showing content)."
-msgstr "* Tập tin nhị phân (không hiển thị nội dung)."
-
-#: lib/diff.tcl:227
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-"* Tập tin chưa theo dõi là %d byte.\n"
-"* Chỉ hiển thị %d byte đầu .\n"
-
-#: lib/diff.tcl:233
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-"\n"
-"* Tập tin chưa theo dõi được cắt tại đây bởi %s.\n"
-"* Để xem toàn bộ tập tin, hãy dùng ứng dụng biên soạn bên ngoài.\n"
-
-#: lib/diff.tcl:560
-msgid "Failed to unstage selected hunk."
-msgstr "Gặp lỗi khi bỏ ra khỏi bệ phóng khối đã chọn"
-
-#: lib/diff.tcl:567
-msgid "Failed to stage selected hunk."
-msgstr "Gặp lỗi khi đưa lên bệ phóng khối đã chọn"
-
-#: lib/diff.tcl:646
-msgid "Failed to unstage selected line."
-msgstr "Gặp lỗi khi bỏ ra khỏi bệ phóng dòng đã chọn"
-
-#: lib/diff.tcl:654
-msgid "Failed to stage selected line."
-msgstr "Gặp lỗi khi đưa lên bệ phóng dòng đã chọn"
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr "Mặc định"
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr "Hệ thống (%s)"
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr "Khác"
-
-#: lib/error.tcl:20 lib/error.tcl:116
-msgid "error"
-msgstr "lỗi"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "cảnh báo"
-
-#: lib/error.tcl:96
-msgid "You must correct the above errors before committing."
-msgstr "Bạn phải sửa các lỗi trên trước khi chuyển giao."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "Không thể bỏ khóa bảng mục lục"
-
-#: lib/index.tcl:17
-msgid "Index Error"
-msgstr "Lỗi mục lục"
-
-#: lib/index.tcl:19
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-"Cập nhật mục lục cho Git gặp lỗi. Việc quét lại sẽ tự động được khởi chạy để "
-"đồng hóa lại với git-gui."
-
-#: lib/index.tcl:30
-msgid "Continue"
-msgstr "Tiếp tục"
-
-#: lib/index.tcl:33
-msgid "Unlock Index"
-msgstr "Bỏ khóa mục lục"
-
-#: lib/index.tcl:298
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "Bỏ %s ra khỏi việc chuyển giao"
-
-#: lib/index.tcl:337
-msgid "Ready to commit."
-msgstr "Đã chuyển giao rồi."
-
-#: lib/index.tcl:350
-#, tcl-format
-msgid "Adding %s"
-msgstr "Đang thêm %s"
-
-#: lib/index.tcl:380
-#, tcl-format
-msgid "Stage %d untracked files?"
-msgstr "Đưa %d tập tin chưa theo dõi lên bệ phóng để chuyển giao?"
-
-#: lib/index.tcl:428
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "Hoàn nguyên các thay đổi trong tập tin %s?"
-
-#: lib/index.tcl:430
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "Hoàn nguyên các thay đổi trong %i tập tin?"
-
-#: lib/index.tcl:438
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-"Mọi thay đổi chưa được đưa lên bệ phóng sẽ mất vĩnh viễn do lệnh revert."
-
-#: lib/index.tcl:441
-msgid "Do Nothing"
-msgstr "Không làm gì"
-
-#: lib/index.tcl:459
-msgid "Reverting selected files"
-msgstr "Đang hoàn nguyên các tập tin đã chọn"
-
-#: lib/index.tcl:463
-#, tcl-format
-msgid "Reverting %s"
-msgstr "Đang hoàn nguyên %s"
-
-#: lib/line.tcl:17
-msgid "Goto Line:"
-msgstr "Nhảy đến dòng:"
-
-#: lib/line.tcl:23
-msgid "Go"
-msgstr "Nhảy"
-
-#: lib/merge.tcl:13
-msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
-msgstr ""
-"Không thể hòa trộn trong khi tu bổ.\n"
-"\n"
-"Bạn phải hoàn tất việc tu bổ lần chuyển giao trước khi bắt đầu bất kỳ kiểu "
-"hòa trộn nào.\n"
-
-#: lib/merge.tcl:27
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"Trạng thái quét không khớp với trạng thái kho.\n"
-"\n"
-"Có Git khác đã sửa kho này kể từ lần quét cuối. Cần quét lại trước khi thực "
-"hiện việc hòa trộn.\n"
-"\n"
-"Sẽ thực hiện việc quét lại ngay bây giời.\n"
-
-#: lib/merge.tcl:45
-#, tcl-format
-msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
-"You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
-msgstr ""
-"Bạn đang ở giữa việc thay đổi.\n"
-"\n"
-"Tập tin %s đã bị sửa đổi.\n"
-"\n"
-"Bạn nên hoàn thiện lần chuyển giao hiện nay trước khi hòa trộn. Chỉ có thế "
-"bạn mới có thể bắt đầu hòa trộn cái .\n"
-
-#: lib/merge.tcl:55
-#, tcl-format
-msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
-"You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
-msgstr ""
-"Bạn đang ở giữa việc thay đổi.\n"
-"\n"
-"Tập tin %s đã bị sửa đổi.\n"
-"\n"
-"Bạn nên hoàn thiện lần chuyển giao hiện nay trước khi hòa trộn.  Làm như vậy "
-"giúp bạn có thể loại bỏ việc lỗi trong hòa trộn.\n"
-
-#: lib/merge.tcl:108
-#, tcl-format
-msgid "%s of %s"
-msgstr "%s trên %s"
-
-#: lib/merge.tcl:122
-#, tcl-format
-msgid "Merging %s and %s..."
-msgstr "Đang hòa trộn %s và %s..."
-
-#: lib/merge.tcl:133
-msgid "Merge completed successfully."
-msgstr "Hòa trộn đã thực hiện thành công."
-
-#: lib/merge.tcl:135
-msgid "Merge failed.  Conflict resolution is required."
-msgstr "Hòa trộn gặp lỗi. Cần giải quyết các xung đột trước."
-
-#: lib/merge.tcl:160
-#, tcl-format
-msgid "Merge Into %s"
-msgstr "Hòa trộn vào %s"
-
-#: lib/merge.tcl:179
-msgid "Revision To Merge"
-msgstr "Điểm cần hòa trộn"
-
-#: lib/merge.tcl:214
-msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
-msgstr ""
-"Không thể hủy bỏ trong khi đang tu bổ.\n"
-"\n"
-"Bạn cần phải hoàn tất việc tu bổ lần chuyển giao này.\n"
-
-#: lib/merge.tcl:224
-msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with aborting the current merge?"
-msgstr ""
-"Bãi bỏ hòa trộn?\n"
-"\n"
-"Bãi bỏ hòa trộn hiện nay sẽ làm *TẤT CẢ* các thay đổi chưa được chuyển giao "
-"bị mất.\n"
-"\n"
-"Tiếp tục bãi bỏ việc hòa trộn hiện tại?"
-
-#: lib/merge.tcl:230
-msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
-"Continue with resetting the current changes?"
-msgstr ""
-"Đặt lại mọi thay đổi?\n"
-"\n"
-"Việc đặt lại các thay đổi sẽ làm *MỌI* thay đổi chưa chuyển giao biến mất.\n"
-"\n"
-"Vẫn tiếp tục đặt lại các thay đổi hiện tại?"
-
-#: lib/merge.tcl:241
-msgid "Aborting"
-msgstr "Bãi bỏ"
-
-#: lib/merge.tcl:241
-msgid "files reset"
-msgstr "đặt lại các tập tin"
-
-#: lib/merge.tcl:269
-msgid "Abort failed."
-msgstr "Gặp lỗi khi bãi bỏ."
-
-#: lib/merge.tcl:271
-msgid "Abort completed.  Ready."
-msgstr "Đã bãi bỏ xong.  Sẵn sàng."
-
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr "Buộc phân giải thành nhánh cơ sở?"
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr "Buộc phân giải thành nhánh này?"
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr "Buộc phân giải thành nhánh khác?"
-
-#: lib/mergetool.tcl:14
-#, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-"Chú ý là diff chỉ hiển thị những thay đổi xung đột.\n"
-"\n"
-"%s sẽ bị ghi đè.\n"
-"\n"
-"Thao tác này chỉ có thể bỏ dở bằng cách khởi động lại việc hòa trộn."
-
-#: lib/mergetool.tcl:45
-#, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-"Tập tin %s có vẻ chưa được giải quyết xung đột, vẫn đánh dấu là cần chuyển "
-"giao?"
-
-#: lib/mergetool.tcl:60
-#, tcl-format
-msgid "Adding resolution for %s"
-msgstr "Đang phân giải cho %s"
-
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr "Không thể phân giải xung đột xóa hay liên kết dùng một công cụ"
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr "Tập tin xung đột không tồn tại"
-
-#: lib/mergetool.tcl:246
-#, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr "Không phải là một công cụ hòa trộn GUI: '%s'"
-
-#: lib/mergetool.tcl:275
-#, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr "Không hỗ trợ công cụ trộn '%s'"
-
-#: lib/mergetool.tcl:310
-msgid "Merge tool is already running, terminate it?"
-msgstr "Công cụ hòa trộn đang chạy rồi, chấm dứt nó?"
-
-#: lib/mergetool.tcl:330
-#, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-"Gặp lỗi khi truy lại phiên bản:\n"
-"%s"
-
-#: lib/mergetool.tcl:350
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-"Không thể khởi chạy công cụ hòa trộn:\n"
-"\n"
-"%s"
-
-#: lib/mergetool.tcl:354
-msgid "Running merge tool..."
-msgstr "Đang chạy công cụ trộn..."
-
-#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
-msgid "Merge tool failed."
-msgstr "Công cụ trộn gặp lỗi."
 
 #: lib/option.tcl:11
 #, tcl-format
@@ -2176,318 +1516,137 @@ msgstr "Đánh dấu những tập tin chưa được theo dõi là cần chuy�
 msgid "Show untracked files"
 msgstr "Hiện các tập tin chưa được theo dõi"
 
-#: lib/option.tcl:209
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
+#: lib/option.tcl:210
 msgid "Change"
 msgstr "Thay đổi"
 
-#: lib/option.tcl:253
+#: lib/option.tcl:254
 msgid "Spelling Dictionary:"
 msgstr "Từ điển chính tả:"
 
-#: lib/option.tcl:283
+#: lib/option.tcl:284
 msgid "Change Font"
 msgstr "Đổi phông chữ"
 
-#: lib/option.tcl:287
+#: lib/option.tcl:288
 #, tcl-format
 msgid "Choose %s"
 msgstr "Chọn %s"
 
-#: lib/option.tcl:293
+#: lib/option.tcl:294
 msgid "pt."
 msgstr "pt."
 
-#: lib/option.tcl:307
+#: lib/option.tcl:308
 msgid "Preferences"
 msgstr "Cá nhân hóa"
 
-#: lib/option.tcl:344
+#: lib/option.tcl:345
 msgid "Failed to completely save options:"
 msgstr "Gặp lỗi khi hoàn tất ghi lại các tùy chọn:"
 
-#: lib/remote_add.tcl:20
-msgid "Add Remote"
-msgstr "Thêm máy chủ"
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr "Buộc phân giải thành nhánh cơ sở?"
 
-#: lib/remote_add.tcl:25
-msgid "Add New Remote"
-msgstr "Thêm máy chủ mới"
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr "Buộc phân giải thành nhánh này?"
 
-#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
-msgid "Add"
-msgstr "Thêm vào"
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr "Buộc phân giải thành nhánh khác?"
 
-#: lib/remote_add.tcl:39
-msgid "Remote Details"
-msgstr "Chi tiết về máy chủ"
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr "Vị trí:"
-
-#: lib/remote_add.tcl:60
-msgid "Further Action"
-msgstr "Hành động thêm"
-
-#: lib/remote_add.tcl:63
-msgid "Fetch Immediately"
-msgstr "Lấy về ngay lập tức"
-
-#: lib/remote_add.tcl:69
-msgid "Initialize Remote Repository and Push"
-msgstr "Khởi tạo Kho máy chủ và đẩy dữ liệu lên"
-
-#: lib/remote_add.tcl:75
-msgid "Do Nothing Else Now"
-msgstr "Không làm gì cả"
-
-#: lib/remote_add.tcl:100
-msgid "Please supply a remote name."
-msgstr "Hãy cung cấp tên máy chủ."
-
-#: lib/remote_add.tcl:113
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr "'%s' không phải là tên máy chủ được chấp nhận."
-
-#: lib/remote_add.tcl:124
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr "Gặp lỗi khi thêm máy chủ '%s' của vị trí '%s'."
-
-#: lib/remote_add.tcl:132 lib/transport.tcl:6
-#, tcl-format
-msgid "fetch %s"
-msgstr "lấy về %s"
-
-#: lib/remote_add.tcl:133
-#, tcl-format
-msgid "Fetching the %s"
-msgstr "Đang lấy về %s"
-
-#: lib/remote_add.tcl:156
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr "Không hiểu làm thế nào để khởi tạo kho chứa tại vị trí '%s'."
-
-#: lib/remote_add.tcl:162 lib/transport.tcl:54 lib/transport.tcl:92
-#: lib/transport.tcl:110
-#, tcl-format
-msgid "push %s"
-msgstr "đẩy %s lên máy chủ"
-
-#: lib/remote_add.tcl:163
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr "Cài đặt '%s' (tại %s)"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr "Xóa nhánh trên máy chủ"
-
-#: lib/remote_branch_delete.tcl:48
-msgid "From Repository"
-msgstr "Từ Kho"
-
-#: lib/remote_branch_delete.tcl:51 lib/transport.tcl:165
-msgid "Remote:"
-msgstr "Máy chủ:"
-
-#: lib/remote_branch_delete.tcl:72 lib/transport.tcl:187
-msgid "Arbitrary Location:"
-msgstr "Địa điểm tùy ý:"
-
-#: lib/remote_branch_delete.tcl:88
-msgid "Branches"
-msgstr "Nhánh"
-
-#: lib/remote_branch_delete.tcl:110
-msgid "Delete Only If"
-msgstr "Chỉ xoá Nếu"
-
-#: lib/remote_branch_delete.tcl:112
-msgid "Merged Into:"
-msgstr "Đã trộn vào:"
-
-#: lib/remote_branch_delete.tcl:153
-msgid "A branch is required for 'Merged Into'."
-msgstr "Cần một nhánh cho 'Hòa trộn vào'."
-
-#: lib/remote_branch_delete.tcl:185
-#, tcl-format
+#: lib/mergetool.tcl:14
+#, fuzzy, tcl-format
 msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
 msgstr ""
-"Các nhánh sau đây không được hòa trộn hoàn toàn vào %s:\n"
+"Chú ý là diff chỉ hiển thị những thay đổi xung đột.\n"
 "\n"
-" - %s"
+"%s sẽ bị ghi đè.\n"
+"\n"
+"Thao tác này chỉ có thể bỏ dở bằng cách khởi động lại việc hòa trộn."
 
-#: lib/remote_branch_delete.tcl:190
+#: lib/mergetool.tcl:45
 #, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
+msgid "File %s seems to have unresolved conflicts, still stage?"
 msgstr ""
-"Một hay nhiều hơn kiểm tra hòa trộn không đạt bởi vì bạn đã không lấy về "
-"những lần chuyển giao cần thiết. Hãy lấy về từ %s trước đã."
+"Tập tin %s có vẻ chưa được giải quyết xung đột, vẫn đánh dấu là cần chuyển "
+"giao?"
 
-#: lib/remote_branch_delete.tcl:208
-msgid "Please select one or more branches to delete."
-msgstr "Xin hãy chọn một hay nhiều nhánh cần xóa."
-
-#: lib/remote_branch_delete.tcl:227
+#: lib/mergetool.tcl:60
 #, tcl-format
-msgid "Deleting branches from %s"
-msgstr "Đang xoá các nhánh từ %s"
+msgid "Adding resolution for %s"
+msgstr "Đang phân giải cho %s"
 
-#: lib/remote_branch_delete.tcl:300
-msgid "No repository selected."
-msgstr "Chưa chọn kho."
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr "Không thể phân giải xung đột xóa hay liên kết dùng một công cụ"
 
-#: lib/remote_branch_delete.tcl:305
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr "Tập tin xung đột không tồn tại"
+
+#: lib/mergetool.tcl:246
 #, tcl-format
-msgid "Scanning %s..."
-msgstr "Đang quét: %s..."
+msgid "Not a GUI merge tool: '%s'"
+msgstr "Không phải là một công cụ hòa trộn GUI: '%s'"
 
-#: lib/remote.tcl:200
-msgid "Push to"
-msgstr "Đẩy lên"
-
-#: lib/remote.tcl:218
-msgid "Remove Remote"
-msgstr "Gỡ bỏ Máy chủ"
-
-#: lib/remote.tcl:223
-msgid "Prune from"
-msgstr "Xén từ"
-
-#: lib/remote.tcl:228
-msgid "Fetch from"
-msgstr "Lấy về từ"
-
-#: lib/search.tcl:48
-msgid "Find:"
-msgstr "Tìm:"
-
-#: lib/search.tcl:50
-msgid "Next"
-msgstr "Tiếp"
-
-#: lib/search.tcl:51
-msgid "Prev"
-msgstr "Trước"
-
-#: lib/search.tcl:52
-msgid "RegExp"
-msgstr "BTCQ"
-
-#: lib/search.tcl:54
-msgid "Case"
-msgstr "Hoa"
-
-#: lib/shortcut.tcl:21 lib/shortcut.tcl:62
-msgid "Cannot write shortcut:"
-msgstr "Không thể ghi lối tắt:"
-
-#: lib/shortcut.tcl:137
-msgid "Cannot write icon:"
-msgstr "Không thể ghi biểu tượng:"
-
-#: lib/spellcheck.tcl:57
-msgid "Unsupported spell checker"
-msgstr "Không hỗ trợ kiểm tra chính tả"
-
-#: lib/spellcheck.tcl:65
-msgid "Spell checking is unavailable"
-msgstr "Kiểm tra chính tả không sẵn sàng"
-
-#: lib/spellcheck.tcl:68
-msgid "Invalid spell checking configuration"
-msgstr "Cấu hình bộ soát chính tả không hợp lệ"
-
-#: lib/spellcheck.tcl:70
+#: lib/mergetool.tcl:275
 #, tcl-format
-msgid "Reverting dictionary to %s."
-msgstr "Đang hoàn nguyên từ điển thành %s."
+msgid "Unsupported merge tool '%s'"
+msgstr "Không hỗ trợ công cụ trộn '%s'"
 
-#: lib/spellcheck.tcl:73
-msgid "Spell checker silently failed on startup"
-msgstr "Phần kiểm tra chính tả đã gặp lỗi khi khởi động"
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr "Công cụ hòa trộn đang chạy rồi, chấm dứt nó?"
 
-#: lib/spellcheck.tcl:80
-msgid "Unrecognized spell checker"
-msgstr "Không chấp nhận bộ kiểm tra chính tả"
-
-#: lib/spellcheck.tcl:186
-msgid "No Suggestions"
-msgstr "Không có gợi ý"
-
-#: lib/spellcheck.tcl:388
-msgid "Unexpected EOF from spell checker"
-msgstr "Gặp kết thúc bất ngờ từ bộ kiểm tra chính tả"
-
-#: lib/spellcheck.tcl:392
-msgid "Spell Checker Failed"
-msgstr "Kiểm tra chính tả không thành công"
-
-#: lib/sshkey.tcl:31
-msgid "No keys found."
-msgstr "Không tìm thấy khóa nào."
-
-#: lib/sshkey.tcl:34
-#, tcl-format
-msgid "Found a public key in: %s"
-msgstr "Tìm thấy khoá công khai trong: %s"
-
-#: lib/sshkey.tcl:40
-msgid "Generate Key"
-msgstr "Tạo khoá"
-
-#: lib/sshkey.tcl:58
-msgid "Copy To Clipboard"
-msgstr "Chép vào clipboard"
-
-#: lib/sshkey.tcl:72
-msgid "Your OpenSSH Public Key"
-msgstr "Khóa công OpenSSH của bạn"
-
-#: lib/sshkey.tcl:80
-msgid "Generating..."
-msgstr "Đang tạo..."
-
-#: lib/sshkey.tcl:86
+#: lib/mergetool.tcl:330
 #, tcl-format
 msgid ""
-"Could not start ssh-keygen:\n"
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+"Gặp lỗi khi truy lại phiên bản:\n"
+"%s"
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
 "\n"
 "%s"
 msgstr ""
-"Không thể chạy ssh-keygen:\n"
+"Không thể khởi chạy công cụ hòa trộn:\n"
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:113
-msgid "Generation failed."
-msgstr "Việc tạo khoá đã thất bại."
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr "Đang chạy công cụ trộn..."
 
-#: lib/sshkey.tcl:120
-msgid "Generation succeeded, but no keys found."
-msgstr "Việc tạo thành công nhưng lại không tìm thấy khóa."
-
-#: lib/sshkey.tcl:123
-#, tcl-format
-msgid "Your key is in: %s"
-msgstr "Khóa của bạn trong: %s"
-
-#: lib/status_bar.tcl:87
-#, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr "%s ... %*i trong %*i %s (%3i%%)"
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr "Công cụ trộn gặp lỗi."
 
 #: lib/tools_dlg.tcl:22
-msgid "Add Tool"
+#, fuzzy, tcl-format
+msgid "%s (%s): Add Tool"
 msgstr "Thêm công cụ"
 
 #: lib/tools_dlg.tcl:28
@@ -2549,7 +1708,8 @@ msgstr ""
 "%s"
 
 #: lib/tools_dlg.tcl:187
-msgid "Remove Tool"
+#, fuzzy, tcl-format
+msgid "%s (%s): Remove Tool"
 msgstr "Gỡ bỏ công cụ"
 
 #: lib/tools_dlg.tcl:193
@@ -2564,6 +1724,11 @@ msgstr "Gỡ bỏ"
 msgid "(Blue denotes repository-local tools)"
 msgstr "(Các công cụ chỉ thị kho-nội-bộ xanh)"
 
+#: lib/tools_dlg.tcl:283
+#, fuzzy, tcl-format
+msgid "%s (%s):"
+msgstr "Hệ thống (%s)"
+
 #: lib/tools_dlg.tcl:292
 #, tcl-format
 msgid "Run Command: %s"
@@ -2577,114 +1742,1107 @@ msgstr "Đối số"
 msgid "OK"
 msgstr "Đồng ý"
 
-#: lib/tools.tcl:75
-#, tcl-format
-msgid "Running %s requires a selected file."
-msgstr "Chạy %s yêu cầu cần phải chọn một tập tin."
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr "Tìm:"
 
-#: lib/tools.tcl:91
-#, tcl-format
-msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
-msgstr "Bạn có chắc là muốn chạy %1$s trên tập tin \"%2$s\" không?"
+#: lib/search.tcl:50
+msgid "Next"
+msgstr "Tiếp"
 
-#: lib/tools.tcl:95
-#, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr "Bạn có chắc là muốn chạy %s không?"
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr "Trước"
 
-#: lib/tools.tcl:116
-#, tcl-format
-msgid "Tool: %s"
-msgstr "Công cụ: %s"
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr "BTCQ"
 
-#: lib/tools.tcl:117
-#, tcl-format
-msgid "Running: %s"
-msgstr "Đang chạy: %s"
+#: lib/search.tcl:54
+msgid "Case"
+msgstr "Hoa"
 
-#: lib/tools.tcl:155
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr "Công cụ được biên dịch thành công: %s"
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "Tạo lối tắt ở màn hình nền"
 
-#: lib/tools.tcl:157
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "Không thể ghi lối tắt:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "Không thể ghi biểu tượng:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "Đổi tên nhánh"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "Đổi tên nhánh"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "Đổi tên"
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "Nhánh:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "Tên mới:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "Hãy chọn nhánh cần đổi tên."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "Hãy cung cấp tên nhánh."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
 #, tcl-format
-msgid "Tool failed: %s"
+msgid "'%s' is not an acceptable branch name."
+msgstr "'%s' không phải là một tên nhánh được chấp nhận."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "Gặp lỗi khi đổi tên '%s'."
+
+#: lib/remote_branch_delete.tcl:29
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr "Xóa nhánh trên máy chủ"
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr "Xóa nhánh trên máy chủ"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "Từ Kho"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "Nhánh"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "Chỉ xoá Nếu"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "Đã trộn vào:"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "Luôn (Không thực hiện kiểm tra hòa trộn)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "Cần một nhánh cho 'Hòa trộn vào'."
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"Các nhánh sau đây không được hòa trộn hoàn toàn vào %s:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"Một hay nhiều hơn kiểm tra hòa trộn không đạt bởi vì bạn đã không lấy về "
+"những lần chuyển giao cần thiết. Hãy lấy về từ %s trước đã."
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "Xin hãy chọn một hay nhiều nhánh cần xóa."
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"Khôi phục các nhánh đã bị xóa là việc khó khăn.\n"
+"\n"
+"Xóa nhánh đã chọn chứ?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "Đang xoá các nhánh từ %s"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "Chưa chọn kho."
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "Đang quét: %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "Tạo kho mới"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "Mới..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "Nhân bản một kho sẵn có"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "Nhân bản..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "Mở một kho đã có."
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "Mở..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "Các kho mới dùng"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "Mở kho mới dùng:"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "Gặp lỗi khi tạo kho %s:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "Tạo"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "Thư mục:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Kho Git"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "Thư mục %s đã sẵn có."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "Tập tin %s đã có sẵn."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "Nhân bản"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr "Vị trí nguồn:"
+
+#: lib/choose_repository.tcl:516
+msgid "Target Directory:"
+msgstr "Thư mục đích:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "Kiểu nhân bản:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "Tiêu chuẩn (Nhanh, Semi-Redundant, Hardlinks)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "Sao chép toàn bộ (Chậm hơn, Redundant Backup)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "Chia sẻ (Nhanh nhất, Không nên dùng, No Backup)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "Không phải là kho git: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "Tiêu chuẩn chỉ sẵn sàng với kho nội bộ."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "'Chia sẻ' chỉ sẵn sàng với kho nội bộ."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "Miền địa phương %s đã sẵn có."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "Gặp lỗi khi cấu hình bản gốc"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "Đang đếm số đối tượng"
+
+#: lib/choose_repository.tcl:667
+msgid "buckets"
+msgstr "xô"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "Không thể sao chép objects/info/alternates: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "Không có gì để nhân bản từ %s"
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "Nhánh 'master' chưa được khởi tạo."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "Liên kết cứng không sẵn sàng. Trở lại chế độ sao chép."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "Đang nhân bản từ %s"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "Đang chép các đối tượng"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "Không thể chép đối tượng: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "Đang liên kết các đối tượng"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "đối tượng"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "Không thể tạo liên kết cứng đối tượng: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr ""
+"Không thể lấy các nhánh và đối tượng. Xem kết xuất từ bảng điều khiển để có "
+"thêm thông tin."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr ""
+"Không thể lấy về các thẻ. Hãy xem kết xuất từ bảng điều khiển để có thêm "
+"thông tin chi tiết."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr ""
+"Không thể dò tìm HEAD. Hãy xem kết xuất từ bảng điều khiển để có thêm thông "
+"tin chi tiết."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "Không thể dọn sạch %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "Gặp lỗi khi nhân bản."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "Không tìm thấy nhánh mặc định."
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "Không thể phân giải %s như là một lần chuyển giao."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "Đang tạo thư mục làm việc"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "tập tin"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "Đang nhân bản từ %s"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "Lấy ra tập tin khởi tạo gặp lỗi."
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "Mở"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "Kho:"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "Gặp lỗi khi mở kho %s:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - công cụ đồ họa dành cho Git."
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "Bộ Xem Tập Tin"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "Lần chuyển giao:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "Chép lần chuyển giao"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr "Tìm chữ..."
+
+#: lib/blame.tcl:288
+msgid "Goto Line..."
+msgstr "Nhảy đến dòng..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr "Thực hiện dò tìm chép toàn bộ"
+
+#: lib/blame.tcl:301
+msgid "Show History Context"
+msgstr "Hiển thị nội dung của lịch sử"
+
+#: lib/blame.tcl:304
+msgid "Blame Parent Commit"
+msgstr "Xem công trạng của lần chuyển giao cha mẹ"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "Đang đọc %s..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "Đang tải phần chú giải theo dõi chép/chuyển..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "dòng chú giải"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "Đang tải các chú giải vị trí nguyên gốc..."
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "Chú giải hoàn tất."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr "Bận"
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr "Tiến trình chú giải đang diễn ra."
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr "Đang chạy dò tìm sao chép toàn diện..."
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "Đang tải phần chú giải..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "Tác giả:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "Người chuyển giao:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "Tập tin gốc:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr "Không thể tìm thấy HEAD của lần chuyển giao:"
+
+#: lib/blame.tcl:1112
+msgid "Cannot find parent commit:"
+msgstr "Không thể tìm thấy lần chuyển giao mẹ:"
+
+#: lib/blame.tcl:1127
+msgid "Unable to display parent"
+msgstr "Không thể hiển thị cha mẹ"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "Nguyên gốc bởi:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "Trong tập tin:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "Đã chép hoặc Di chuyển đến đây bởi:"
+
+#: lib/sshkey.tcl:31
+msgid "No keys found."
+msgstr "Không tìm thấy khóa nào."
+
+#: lib/sshkey.tcl:34
+#, tcl-format
+msgid "Found a public key in: %s"
+msgstr "Tìm thấy khoá công khai trong: %s"
+
+#: lib/sshkey.tcl:40
+msgid "Generate Key"
+msgstr "Tạo khoá"
+
+#: lib/sshkey.tcl:58
+msgid "Copy To Clipboard"
+msgstr "Chép vào clipboard"
+
+#: lib/sshkey.tcl:72
+msgid "Your OpenSSH Public Key"
+msgstr "Khóa công OpenSSH của bạn"
+
+#: lib/sshkey.tcl:80
+msgid "Generating..."
+msgstr "Đang tạo..."
+
+#: lib/sshkey.tcl:86
+#, tcl-format
+msgid ""
+"Could not start ssh-keygen:\n"
+"\n"
+"%s"
+msgstr ""
+"Không thể chạy ssh-keygen:\n"
+"\n"
+"%s"
+
+#: lib/sshkey.tcl:113
+msgid "Generation failed."
+msgstr "Việc tạo khoá đã thất bại."
+
+#: lib/sshkey.tcl:120
+msgid "Generation succeeded, but no keys found."
+msgstr "Việc tạo thành công nhưng lại không tìm thấy khóa."
+
+#: lib/sshkey.tcl:123
+#, tcl-format
+msgid "Your key is in: %s"
+msgstr "Khóa của bạn trong: %s"
+
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "Tạo nhánh"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "Tạo nhánh mới"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "Tên nhánh"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "Khớp với tên nhánh được theo dõi"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "Điểm đầu"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "Cập nhật nhánh sẵn có:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "Không"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "Chỉ fast-forward"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "Lấy ra sau khi tạo"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "Vui lòng chọn nhánh theo dõi."
+
+#: lib/branch_create.tcl:141
+#, tcl-format
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "Nhánh theo dõi %s không phải là một nhánh trên kho chứa máy chủ."
+
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"Ở đây chẳng có gì để tu bổ cả.\n"
+"\n"
+"Bạn đang tạo lần chuyển giao khởi tạo. Ở đây không có lần chuyển giao trước "
+"nào để mà tu bổ.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"Không thể tu bổ trong khi hòa trộn.\n"
+"\n"
+"Bạn hiện đang ở giữa quá trình hòa trôn, mà nó chưa hoàn tất. Bạn không thể "
+"tu bổ  lần chuyển giao tiền nhiệm trừ phi bạn bãi bỏ lần hòa trộn hiện đang "
+"kích hoạt.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "Gặp lỗi khi tải dữ liệu chuyển giao cho lệnh tu bổ:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "Không thể lấy được định danh của bạn:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "GIT_COMMITTER_IDENT không hợp lệ:"
+
+#: lib/commit.tcl:132
+#, tcl-format
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "cảnh báo: Tcl không hỗ trợ bảng mã '%s'."
+
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"Trạng thái quét không khớp với trạng thái kho.\n"
+"\n"
+"Có Git khác đã sửa kho này kể từ lần quét cuối. Cần quét lại trước khi thực "
+"hiện việc chuyển giao khác.\n"
+"\n"
+"Sẽ thực hiện việc quét lại ngay bây giời.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"Các tập tin chưa hòa trộn không thể được chuyển giao.\n"
+"\n"
+"Tập tin %s có xung đột hòa trộn. Bạn phải giải quyết chúng và đưa lên bệ "
+"phóng trước khi chuyển giao.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"Tìm thấy trạng thái tập tim không hiểu %s.\n"
+"\n"
+"Tập tin %s không thể được chuyển giao bởi chương trình này.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"Không có thay đổi nào cần chuyển giao.\n"
+"\n"
+"Bạn phải đưa lên bệ phóng ít nhất là một tập tin trước khi có thể chuyển "
+"giao.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"Hãy cung cấp lời chú giải cho lần chuyển giao.\n"
+"\n"
+"Lời chú giải tốt nhất nên có định dạng sau:\n"
+"\n"
+"- Dòng đầu tiên: Mô tả những gì bạn đã làm.\n"
+"- Dòng thứ hai: Để trống\n"
+"- Các dòng còn lại: Mô tả xem vì sao những thay đổi này là cần thiết.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr "Đang gọi móc (hook) pre-commit..."
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr "Lần chuyển giao bị khước từ do móc pre-commit."
+
+#: lib/commit.tcl:272
+#, fuzzy
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+"Bạn thực hiện chuyển giao ở chỗ đã tách rời khỏi các đầu. Điều này là nguy "
+"hiểm bởi nếu bạn chuyển sang nhánh khác thì bạn sẽ mất những thay đổi này và "
+"việc lấy lại chúng từ reflog cũng khó khăn. Bạn gần như chắc chắn là nên hủy "
+"bỏ lần chuyển giao này và tạo một nhánh mới trước khi tiếp tục.\n"
+" \n"
+" Bạn có thực sự muốn tiếp tục chuyển giao?"
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr "Đang gọi móc commit-msg..."
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr "Lần chuyển giao bị khước từ do móc commit-msg."
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr "Chuyển giao các thay đổi..."
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "gặp lỗi khi write-tree:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+msgid "Commit failed."
+msgstr "Gặp lỗi khi chuyển giao."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "Lần chuyển giao %s có vẻ đã hư hỏng"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"Không có thay đổi nào để chuyển giao.\n"
+"\n"
+"Không có tập tin nào được sửa bởi lần chuyển giao này và nó không phải là "
+"lần chuyển giao hòa trộn.\n"
+"\n"
+"Sẽ thực hiện việc quét lại ngay bây giờ.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "Không có thay đổi nào để chuyển giao."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree gặp lỗi:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "cập nhật tham chiếu thất bại:"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "Lần chuyển giao đã tạo %s: %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "Xoá nhánh"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "Xóa nhánh nội bộ"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "Nhánh nội bộ"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "Chỉ xóa nếu đã hòa trộn vào"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "Các nhánh sau đây không được hòa trộn hoàn toàn vào %s:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+"Gặp lỗi khi xóa các nhánh:\n"
+"%s"
+
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "Không thể bỏ khóa bảng mục lục"
+
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "Lỗi mục lục"
+
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+"Cập nhật mục lục cho Git gặp lỗi. Việc quét lại sẽ tự động được khởi chạy để "
+"đồng hóa lại với git-gui."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "Tiếp tục"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "Bỏ khóa mục lục"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "Bỏ %s ra khỏi việc chuyển giao"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "Bỏ %s ra khỏi việc chuyển giao"
+
+#: lib/index.tcl:337
+msgid "Ready to commit."
+msgstr "Đã chuyển giao rồi."
+
+#: lib/index.tcl:346
+#, fuzzy
+msgid "Adding selected files"
+msgstr "Đang hoàn nguyên các tập tin đã chọn"
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "Đang thêm %s"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr "Đưa %d tập tin chưa theo dõi lên bệ phóng để chuyển giao?"
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "Hoàn nguyên các thay đổi trong tập tin %s?"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "Hoàn nguyên các thay đổi trong %i tập tin?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+"Mọi thay đổi chưa được đưa lên bệ phóng sẽ mất vĩnh viễn do lệnh revert."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "Không làm gì"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "Đưa %d tập tin chưa theo dõi lên bệ phóng để chuyển giao?"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "Đưa %d tập tin chưa theo dõi lên bệ phóng để chuyển giao?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "Xóa bỏ"
+
+#: lib/index.tcl:528
+msgid "Reverting selected files"
+msgstr "Đang hoàn nguyên các tập tin đã chọn"
+
+#: lib/index.tcl:532
+#, tcl-format
+msgid "Reverting %s"
+msgstr "Đang hoàn nguyên %s"
+
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr "Mặc định"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr "Hệ thống (%s)"
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr "Khác"
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "Ngày tháng không hợp lệ từ Git: %s"
+
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "Đây là việc lấy ra bị tách rời"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "Biểu thức điểm xét:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "Nhánh nội bộ"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "Nhánh Theo dõi"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "Thẻ"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "Điểm xét duyệt không hợp lệ: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "Chưa chọn điểm xét duyệt."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "Biểu thức chính quy rỗng."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "Đã cập nhật"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "Số lượng đối tượng bị mất"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "Dung lượng đĩa được dùng bởi các đối tượng bị mất"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "Số lượng đối tượng được đóng gói"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "Số lượng gói"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "Dung lượng đĩa được dùng bởi các đối tượng gói"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "Các đối tượng gói chờ xén bớt"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "Các tập tin rác"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "Thống kê cơ sở dữ liệu"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "Nén cơ sở dữ liệu đối tượng"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "Đang kiểm tra cơ sở dữ liệu đối tượng bằng lệnh fsck"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"Hiện kho này mất ước chừng khoảng %i đối tượng.\n"
+"\n"
+"Để tối ưu hóa hiệu suất, khuyến nghị bạn nên nén cơ sở dữ liệu của mình "
+"lại.\n"
+"\n"
+"Nén cơ sở dữ liệu chứ?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "lỗi"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "cảnh báo"
+
+#: lib/error.tcl:80
+#, fuzzy, tcl-format
+msgid "%s hook failed:"
 msgstr "Công cụ gặp lỗi: %s"
 
-#: lib/transport.tcl:7
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "Bạn phải sửa các lỗi trên trước khi chuyển giao."
+
+#: lib/error.tcl:116
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "Lấy các thay đổi mới từ %s"
+msgid "%s (%s): error"
+msgstr ""
 
-#: lib/transport.tcl:18
-#, tcl-format
-msgid "remote prune %s"
-msgstr "xén bớt trên máy chủ %s"
+#~ msgid "Displaying only %s of %s files."
+#~ msgstr "Chỉ hiển thị %s trong số %s tập tin."
 
-#: lib/transport.tcl:19
-#, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "Xén bớt các nhánh theo dõi bị xóa từ %s"
-
-#: lib/transport.tcl:25
-msgid "fetch all remotes"
-msgstr "lấy về từ tất cả các máy chủ"
-
-#: lib/transport.tcl:26
-msgid "Fetching new changes from all remotes"
-msgstr "Đang lấy các thay đổi mới từ mọi máy chủ"
-
-#: lib/transport.tcl:40
-msgid "remote prune all remotes"
-msgstr "xén bớt mọi máy chủ"
-
-#: lib/transport.tcl:41
-msgid "Pruning tracking branches deleted from all remotes"
-msgstr "Xén tỉa các nhánh đã theo dõi bị xóa từ mọi máy chủ"
-
-#: lib/transport.tcl:55
-#, tcl-format
-msgid "Pushing changes to %s"
-msgstr "Đang đẩy các nhánh lên %s"
-
-#: lib/transport.tcl:93
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr "Bản sao đến %s"
-
-#: lib/transport.tcl:111
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "Đang (đẩy) %s %s lên %s"
-
-#: lib/transport.tcl:132
-msgid "Push Branches"
-msgstr "Đẩy lên các nhánh"
-
-#: lib/transport.tcl:147
-msgid "Source Branches"
-msgstr "Nhánh nguồn"
-
-#: lib/transport.tcl:162
-msgid "Destination Repository"
-msgstr "Kho chứa đích"
-
-#: lib/transport.tcl:205
-msgid "Transfer Options"
-msgstr "Tùy chọn truyền"
-
-#: lib/transport.tcl:207
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr "Ép buộc ghi đè nhánh sẵn có (có thể sẽ loại bỏ các thay đổi)"
-
-#: lib/transport.tcl:211
-msgid "Use thin pack (for slow network connections)"
-msgstr "Dùng gói mỏng (dành cho kết nối mạng chậm)"
-
-#: lib/transport.tcl:215
-msgid "Include tags"
-msgstr "Bao gồm các thẻ"
+#~ msgid ""
+#~ "* Untracked file is %d bytes.\n"
+#~ "* Showing only first %d bytes.\n"
+#~ msgstr ""
+#~ "* Tập tin chưa theo dõi là %d byte.\n"
+#~ "* Chỉ hiển thị %d byte đầu .\n"
 
 #~ msgid "Case-Sensitive"
 #~ msgstr "Có phân biệt HOA/thường"

--- a/po/zh_cn.po
+++ b/po/zh_cn.po
@@ -2,9 +2,9 @@
 # Copyright (C) 2007 Shawn Pearce
 # This file is distributed under the same license as the git-gui package.
 # Xudong Guan <xudong.guan@gmail.com>, 2007.
-#
+# 
 # Please use the following translation throughout the file for consistence:
-#
+# 
 # 	repository	版本库
 # 	commit		提交
 # 	revision	版本
@@ -16,59 +16,60 @@
 # 	stage		缓存 (译自 index/cache)
 # 	amend		修正
 # 	reset		复位
-#
+# 
 # 2008-01-06 Eric Miao <eric.y.miao@gmail.com>
 # FIXME: checkout 的标准翻译
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: git-gui\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-03-14 07:18+0100\n"
+"POT-Creation-Date: 2019-10-25 00:20-0500\n"
 "PO-Revision-Date: 2007-07-21 01:23-0700\n"
 "Last-Translator: Eric Miao <eric.y.miao@gmail.com>\n"
 "Language-Team: Chinese\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:41 git-gui.sh:634 git-gui.sh:648 git-gui.sh:661 git-gui.sh:744
-#: git-gui.sh:763
-msgid "git-gui: fatal error"
-msgstr "git-gui: 致命错误"
-
-#: git-gui.sh:593
+#: git-gui.sh:847
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "%s 中指定的字体无效:"
 
-#: git-gui.sh:620
+#: git-gui.sh:901
 msgid "Main Font"
 msgstr "主要字体"
 
-#: git-gui.sh:621
+#: git-gui.sh:902
 msgid "Diff/Console Font"
 msgstr "Diff/控制终端字体"
 
-#: git-gui.sh:635
+#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
+#: git-gui.sh:3129
+msgid "git-gui: fatal error"
+msgstr "git-gui: 致命错误"
+
+#: git-gui.sh:918
 msgid "Cannot find git in PATH."
 msgstr "PATH 中没有找到 git"
 
-#: git-gui.sh:662
+#: git-gui.sh:945
 msgid "Cannot parse Git version string:"
 msgstr "无法解析 Git 的版本信息:"
 
-#: git-gui.sh:680
-#, tcl-format
+#: git-gui.sh:970
+#, fuzzy, tcl-format
 msgid ""
-"Git version cannot be determined.\n"
-"\n"
-"%s claims it is version '%s'.\n"
-"\n"
-"%s requires at least Git 1.5.0 or later.\n"
-"\n"
-"Assume '%s' is version 1.5.0?\n"
+"Git version cannot be determined.\r\n"
+"\r\n"
+"%s claims it is version '%s'.\r\n"
+"\r\n"
+"%s requires at least Git 1.5.0 or later.\r\n"
+"\r\n"
+"Assume '%s' is version 1.5.0?\r\n"
 msgstr ""
 "无法确定 Git 的版本.\n"
 "\n"
@@ -78,690 +79,607 @@ msgstr ""
 "\n"
 "是否假定 '%s' 为版本 1.5.0?\n"
 
-#: git-gui.sh:918
+#: git-gui.sh:1267
 msgid "Git directory not found:"
 msgstr "Git 目录无法找到:"
 
-#: git-gui.sh:925
+#: git-gui.sh:1301
 msgid "Cannot move to top of working directory:"
 msgstr "无法移动到工作根目录:"
 
-#: git-gui.sh:932
-msgid "Cannot use funny .git directory:"
-msgstr "无法使用 .git 目录:"
+#: git-gui.sh:1309
+#, fuzzy
+msgid "Cannot use bare repository:"
+msgstr "创建新的版本库"
 
-#: git-gui.sh:937
+#: git-gui.sh:1317
 msgid "No working directory"
 msgstr "没有工作目录"
 
-#: git-gui.sh:1084 lib/checkout_op.tcl:283
+#: git-gui.sh:1489 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "更新文件状态..."
 
-#: git-gui.sh:1149
+#: git-gui.sh:1549
 msgid "Scanning for modified files ..."
 msgstr "扫描修改过的文件 ..."
 
-#: git-gui.sh:1324 lib/browser.tcl:246
+#: git-gui.sh:1627
+msgid "Calling prepare-commit-msg hook..."
+msgstr ""
+
+#: git-gui.sh:1644
+msgid "Commit declined by prepare-commit-msg hook."
+msgstr ""
+
+#: git-gui.sh:1802 lib/browser.tcl:252
 msgid "Ready."
 msgstr "就绪"
 
-#: git-gui.sh:1590
+#: git-gui.sh:1966
+#, tcl-format
+msgid ""
+"Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
+msgstr ""
+
+#: git-gui.sh:2089
 msgid "Unmodified"
 msgstr "未修改"
 
-#: git-gui.sh:1592
+#: git-gui.sh:2091
 msgid "Modified, not staged"
 msgstr "修改但未缓存"
 
-#: git-gui.sh:1593 git-gui.sh:1598
+#: git-gui.sh:2092 git-gui.sh:2104
 msgid "Staged for commit"
 msgstr "缓存为提交"
 
-#: git-gui.sh:1594 git-gui.sh:1599
+#: git-gui.sh:2093 git-gui.sh:2105
 msgid "Portions staged for commit"
 msgstr "部分缓存为提交"
 
-#: git-gui.sh:1595 git-gui.sh:1600
+#: git-gui.sh:2094 git-gui.sh:2106
 msgid "Staged for commit, missing"
 msgstr "缓存为提交, 不存在"
 
-#: git-gui.sh:1597
+#: git-gui.sh:2096
+#, fuzzy
+msgid "File type changed, not staged"
+msgstr "未跟踪, 未缓存"
+
+#: git-gui.sh:2097 git-gui.sh:2098
+msgid "File type changed, old type staged for commit"
+msgstr ""
+
+#: git-gui.sh:2099
+msgid "File type changed, staged"
+msgstr ""
+
+#: git-gui.sh:2100
+msgid "File type change staged, modification not staged"
+msgstr ""
+
+#: git-gui.sh:2101
+msgid "File type change staged, file missing"
+msgstr ""
+
+#: git-gui.sh:2103
 msgid "Untracked, not staged"
 msgstr "未跟踪, 未缓存"
 
-#: git-gui.sh:1602
+#: git-gui.sh:2108
 msgid "Missing"
 msgstr "不存在"
 
-#: git-gui.sh:1603
+#: git-gui.sh:2109
 msgid "Staged for removal"
 msgstr "缓存为删除"
 
-#: git-gui.sh:1604
+#: git-gui.sh:2110
 msgid "Staged for removal, still present"
 msgstr "缓存为删除, 但仍存在"
 
-#: git-gui.sh:1606 git-gui.sh:1607 git-gui.sh:1608 git-gui.sh:1609
+#: git-gui.sh:2112 git-gui.sh:2113 git-gui.sh:2114 git-gui.sh:2115
+#: git-gui.sh:2116 git-gui.sh:2117
 msgid "Requires merge resolution"
 msgstr "需要解决合并冲突"
 
-#: git-gui.sh:1644
+#: git-gui.sh:2152
 msgid "Starting gitk... please wait..."
 msgstr "启动 gitk... 请等待..."
 
-#: git-gui.sh:1653
-#, tcl-format
-msgid ""
-"Unable to start gitk:\n"
-"\n"
-"%s does not exist"
-msgstr ""
-"无法启动 gitk:\n"
-"\n"
-"%s 不存在"
+#: git-gui.sh:2164
+#, fuzzy
+msgid "Couldn't find gitk in PATH"
+msgstr "PATH 中没有找到 git"
 
-#: git-gui.sh:1860 lib/choose_repository.tcl:36
+#: git-gui.sh:2223
+#, fuzzy
+msgid "Couldn't find git gui in PATH"
+msgstr "PATH 中没有找到 git"
+
+#: git-gui.sh:2658 lib/choose_repository.tcl:41
 msgid "Repository"
 msgstr "版本库(repository)"
 
-#: git-gui.sh:1861
+#: git-gui.sh:2659
 msgid "Edit"
 msgstr "编辑"
 
-#: git-gui.sh:1863 lib/choose_rev.tcl:561
+#: git-gui.sh:2661 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr "分支(branch)"
 
-#: git-gui.sh:1866 lib/choose_rev.tcl:548
+#: git-gui.sh:2664 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr "提交(commit)"
 
-#: git-gui.sh:1869 lib/merge.tcl:120 lib/merge.tcl:149 lib/merge.tcl:167
+#: git-gui.sh:2667 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr "合并(merge)"
 
-#: git-gui.sh:1870 lib/choose_rev.tcl:557
+#: git-gui.sh:2668 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr "远端(remote)"
 
-#: git-gui.sh:1879
+#: git-gui.sh:2671
+msgid "Tools"
+msgstr ""
+
+#: git-gui.sh:2680
+msgid "Explore Working Copy"
+msgstr ""
+
+#: git-gui.sh:2686
+msgid "Git Bash"
+msgstr ""
+
+#: git-gui.sh:2696
 msgid "Browse Current Branch's Files"
 msgstr "浏览当前分支上的文件"
 
-#: git-gui.sh:1883
+#: git-gui.sh:2700
 msgid "Browse Branch Files..."
 msgstr "浏览分支上的文件..."
 
-#: git-gui.sh:1888
+#: git-gui.sh:2705
 msgid "Visualize Current Branch's History"
 msgstr "图示当前分支的历史"
 
-#: git-gui.sh:1892
+#: git-gui.sh:2709
 msgid "Visualize All Branch History"
 msgstr "图示所有分支的历史"
 
-#: git-gui.sh:1899
+#: git-gui.sh:2716
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "浏览 %s 上的文件"
 
-#: git-gui.sh:1901
+#: git-gui.sh:2718
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "图示 %s 分支的历史"
 
-#: git-gui.sh:1906 lib/database.tcl:27 lib/database.tcl:67
+#: git-gui.sh:2723 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr "数据库统计信息"
 
-#: git-gui.sh:1909 lib/database.tcl:34
+#: git-gui.sh:2726 lib/database.tcl:33
 msgid "Compress Database"
 msgstr "压缩数据库"
 
-#: git-gui.sh:1912
+#: git-gui.sh:2729
 msgid "Verify Database"
 msgstr "验证数据库"
 
-#: git-gui.sh:1919 git-gui.sh:1923 git-gui.sh:1927 lib/shortcut.tcl:7
-#: lib/shortcut.tcl:39 lib/shortcut.tcl:71
+#: git-gui.sh:2736 git-gui.sh:2740 git-gui.sh:2744
 msgid "Create Desktop Icon"
 msgstr "创建桌面图标"
 
-#: git-gui.sh:1932 lib/choose_repository.tcl:177 lib/choose_repository.tcl:185
+#: git-gui.sh:2752 lib/choose_repository.tcl:197 lib/choose_repository.tcl:205
 msgid "Quit"
 msgstr "退出"
 
-#: git-gui.sh:1939
+#: git-gui.sh:2760
 msgid "Undo"
 msgstr "撤销"
 
-#: git-gui.sh:1942
+#: git-gui.sh:2763
 msgid "Redo"
 msgstr "重做"
 
-#: git-gui.sh:1946 git-gui.sh:2443
+#: git-gui.sh:2767 git-gui.sh:3381
 msgid "Cut"
 msgstr "剪切"
 
-#: git-gui.sh:1949 git-gui.sh:2446 git-gui.sh:2520 git-gui.sh:2614
+#: git-gui.sh:2770 git-gui.sh:3384 git-gui.sh:3458 git-gui.sh:3544
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr "复制"
 
-#: git-gui.sh:1952 git-gui.sh:2449
+#: git-gui.sh:2773 git-gui.sh:3387
 msgid "Paste"
 msgstr "粘贴"
 
-#: git-gui.sh:1955 git-gui.sh:2452 lib/branch_delete.tcl:26
-#: lib/remote_branch_delete.tcl:38
+#: git-gui.sh:2776 git-gui.sh:3390 lib/remote_branch_delete.tcl:39
+#: lib/branch_delete.tcl:28
 msgid "Delete"
 msgstr "删除"
 
-#: git-gui.sh:1959 git-gui.sh:2456 git-gui.sh:2618 lib/console.tcl:71
+#: git-gui.sh:2780 git-gui.sh:3394 git-gui.sh:3548 lib/console.tcl:71
 msgid "Select All"
 msgstr "全选"
 
-#: git-gui.sh:1968
+#: git-gui.sh:2789
 msgid "Create..."
 msgstr "新建..."
 
-#: git-gui.sh:1974
+#: git-gui.sh:2795
 msgid "Checkout..."
 msgstr "Checkout..."
 
-#: git-gui.sh:1980
+#: git-gui.sh:2801
 msgid "Rename..."
 msgstr "更名..."
 
-#: git-gui.sh:1985 git-gui.sh:2085
+#: git-gui.sh:2806
 msgid "Delete..."
 msgstr "删除..."
 
-#: git-gui.sh:1990
+#: git-gui.sh:2811
 msgid "Reset..."
 msgstr "复位(Reset)..."
 
-#: git-gui.sh:2002 git-gui.sh:2389
-msgid "New Commit"
-msgstr "新建提交"
+#: git-gui.sh:2821
+msgid "Done"
+msgstr ""
 
-#: git-gui.sh:2010 git-gui.sh:2396
-msgid "Amend Last Commit"
-msgstr "修正上次提交"
-
-#: git-gui.sh:2019 git-gui.sh:2356 lib/remote_branch_delete.tcl:99
-msgid "Rescan"
-msgstr "重新扫描"
-
-#: git-gui.sh:2025
-msgid "Stage To Commit"
-msgstr "缓存为提交"
-
-#: git-gui.sh:2031
-msgid "Stage Changed Files To Commit"
-msgstr "缓存修改的文件为提交"
-
-#: git-gui.sh:2037
-msgid "Unstage From Commit"
-msgstr "从本次提交撤除"
-
-#: git-gui.sh:2042 lib/index.tcl:395
-msgid "Revert Changes"
-msgstr "撤销修改"
-
-#: git-gui.sh:2049 git-gui.sh:2368 git-gui.sh:2467
-msgid "Sign Off"
-msgstr "签名(Sign Off)"
-
-#: git-gui.sh:2053 git-gui.sh:2372
+#: git-gui.sh:2823
 msgid "Commit@@verb"
 msgstr "提交"
 
-#: git-gui.sh:2064
+#: git-gui.sh:2832 git-gui.sh:3317
+msgid "New Commit"
+msgstr "新建提交"
+
+#: git-gui.sh:2840 git-gui.sh:3324
+msgid "Amend Last Commit"
+msgstr "修正上次提交"
+
+#: git-gui.sh:2850 git-gui.sh:3278 lib/remote_branch_delete.tcl:101
+msgid "Rescan"
+msgstr "重新扫描"
+
+#: git-gui.sh:2856
+msgid "Stage To Commit"
+msgstr "缓存为提交"
+
+#: git-gui.sh:2862
+msgid "Stage Changed Files To Commit"
+msgstr "缓存修改的文件为提交"
+
+#: git-gui.sh:2868
+msgid "Unstage From Commit"
+msgstr "从本次提交撤除"
+
+#: git-gui.sh:2874 lib/index.tcl:454
+msgid "Revert Changes"
+msgstr "撤销修改"
+
+#: git-gui.sh:2882 git-gui.sh:3595 git-gui.sh:3626
+msgid "Show Less Context"
+msgstr "显示更少上下文"
+
+#: git-gui.sh:2886 git-gui.sh:3599 git-gui.sh:3630
+msgid "Show More Context"
+msgstr "显示更多上下文"
+
+#: git-gui.sh:2893 git-gui.sh:3291 git-gui.sh:3405
+msgid "Sign Off"
+msgstr "签名(Sign Off)"
+
+#: git-gui.sh:2909
 msgid "Local Merge..."
 msgstr "本地合并..."
 
-#: git-gui.sh:2069
+#: git-gui.sh:2914
 msgid "Abort Merge..."
 msgstr "中止合并..."
 
-#: git-gui.sh:2081
+#: git-gui.sh:2926 git-gui.sh:2954
+msgid "Add..."
+msgstr ""
+
+#: git-gui.sh:2930
 msgid "Push..."
 msgstr "上传..."
 
-#: git-gui.sh:2092 lib/choose_repository.tcl:41
-msgid "Apple"
-msgstr "苹果"
+#: git-gui.sh:2934
+#, fuzzy
+msgid "Delete Branch..."
+msgstr "删除分支"
 
-#: git-gui.sh:2095 git-gui.sh:2117 lib/about.tcl:14
-#: lib/choose_repository.tcl:44 lib/choose_repository.tcl:50
+#: git-gui.sh:2944 git-gui.sh:3577
+msgid "Options..."
+msgstr "选项..."
+
+#: git-gui.sh:2955
+#, fuzzy
+msgid "Remove..."
+msgstr "更名..."
+
+#: git-gui.sh:2964 lib/choose_repository.tcl:55
+msgid "Help"
+msgstr "帮助"
+
+#: git-gui.sh:2968 git-gui.sh:2972 lib/choose_repository.tcl:49
+#: lib/choose_repository.tcl:58 lib/about.tcl:14
 #, tcl-format
 msgid "About %s"
 msgstr "关于 %s"
 
-#: git-gui.sh:2099
-msgid "Preferences..."
-msgstr "首选项..."
-
-#: git-gui.sh:2107 git-gui.sh:2639
-msgid "Options..."
-msgstr "选项..."
-
-#: git-gui.sh:2113 lib/choose_repository.tcl:47
-msgid "Help"
-msgstr "帮助"
-
-#: git-gui.sh:2154
+#: git-gui.sh:2996
 msgid "Online Documentation"
 msgstr "在线文档"
 
-#: git-gui.sh:2238
+#: git-gui.sh:2999 lib/choose_repository.tcl:52 lib/choose_repository.tcl:61
+msgid "Show SSH Key"
+msgstr ""
+
+#: git-gui.sh:3014 git-gui.sh:3146
+msgid "usage:"
+msgstr ""
+
+#: git-gui.sh:3018 git-gui.sh:3150
+msgid "Usage"
+msgstr ""
+
+#: git-gui.sh:3099 lib/blame.tcl:573
+#, fuzzy
+msgid "Error"
+msgstr "错误"
+
+#: git-gui.sh:3130
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr "致命错误: 无法获取路径 %s 的信息: 该文件或目录不存在"
 
-#: git-gui.sh:2271
+#: git-gui.sh:3163
 msgid "Current Branch:"
 msgstr "当前分支:"
 
-#: git-gui.sh:2292
-msgid "Staged Changes (Will Commit)"
-msgstr "已缓存的改动 (将被提交)"
-
-#: git-gui.sh:2312
+#: git-gui.sh:3188
 msgid "Unstaged Changes"
 msgstr "未缓存的改动"
 
-#: git-gui.sh:2362
+#: git-gui.sh:3210
+msgid "Staged Changes (Will Commit)"
+msgstr "已缓存的改动 (将被提交)"
+
+#: git-gui.sh:3284
 msgid "Stage Changed"
 msgstr "缓存改动"
 
-#: git-gui.sh:2378 lib/transport.tcl:93 lib/transport.tcl:182
+#: git-gui.sh:3303 lib/transport.tcl:137
 msgid "Push"
 msgstr "上传"
 
-#: git-gui.sh:2408
+#: git-gui.sh:3338
 msgid "Initial Commit Message:"
 msgstr "初始的提交描述:"
 
-#: git-gui.sh:2409
+#: git-gui.sh:3339
 msgid "Amended Commit Message:"
 msgstr "修正的提交描述:"
 
-#: git-gui.sh:2410
+#: git-gui.sh:3340
 msgid "Amended Initial Commit Message:"
 msgstr "修正的初始提交描述:"
 
-#: git-gui.sh:2411
+#: git-gui.sh:3341
 msgid "Amended Merge Commit Message:"
 msgstr "修正的合并提交描述:"
 
-#: git-gui.sh:2412
+#: git-gui.sh:3342
 msgid "Merge Commit Message:"
 msgstr "合并提交描述:"
 
-#: git-gui.sh:2413
+#: git-gui.sh:3343
 msgid "Commit Message:"
 msgstr "提交描述:"
 
-#: git-gui.sh:2459 git-gui.sh:2622 lib/console.tcl:73
+#: git-gui.sh:3397 git-gui.sh:3552 lib/console.tcl:73
 msgid "Copy All"
 msgstr "全部复制"
 
-#: git-gui.sh:2483 lib/blame.tcl:107
+#: git-gui.sh:3421 lib/blame.tcl:105
 msgid "File:"
 msgstr "文件:"
 
-#: git-gui.sh:2589
-msgid "Apply/Reverse Hunk"
-msgstr "应用/撤消此修改块"
-
-#: git-gui.sh:2595
-msgid "Show Less Context"
-msgstr "显示更少上下文"
-
-#: git-gui.sh:2602
-msgid "Show More Context"
-msgstr "显示更多上下文"
-
-#: git-gui.sh:2610
+#: git-gui.sh:3540
 msgid "Refresh"
 msgstr "刷新"
 
-#: git-gui.sh:2631
+#: git-gui.sh:3561
 msgid "Decrease Font Size"
 msgstr "缩小字体"
 
-#: git-gui.sh:2635
+#: git-gui.sh:3565
 msgid "Increase Font Size"
 msgstr "放大字体"
 
-#: git-gui.sh:2646
+#: git-gui.sh:3573 lib/blame.tcl:294
+msgid "Encoding"
+msgstr ""
+
+#: git-gui.sh:3584
+msgid "Apply/Reverse Hunk"
+msgstr "应用/撤消此修改块"
+
+#: git-gui.sh:3589
+#, fuzzy
+msgid "Apply/Reverse Line"
+msgstr "应用/撤消此修改块"
+
+#: git-gui.sh:3608
+msgid "Run Merge Tool"
+msgstr ""
+
+#: git-gui.sh:3613
+msgid "Use Remote Version"
+msgstr ""
+
+#: git-gui.sh:3617
+msgid "Use Local Version"
+msgstr ""
+
+#: git-gui.sh:3621
+#, fuzzy
+msgid "Revert To Base"
+msgstr "撤销修改"
+
+#: git-gui.sh:3639
+msgid "Visualize These Changes In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3643
+#, fuzzy
+msgid "Visualize Current Branch History In The Submodule"
+msgstr "图示当前分支的历史"
+
+#: git-gui.sh:3647
+#, fuzzy
+msgid "Visualize All Branch History In The Submodule"
+msgstr "图示所有分支的历史"
+
+#: git-gui.sh:3652
+msgid "Start git gui In The Submodule"
+msgstr ""
+
+#: git-gui.sh:3687
 msgid "Unstage Hunk From Commit"
 msgstr "从提交中撤除修改块"
 
-#: git-gui.sh:2648
+#: git-gui.sh:3689
+#, fuzzy
+msgid "Unstage Lines From Commit"
+msgstr "从本次提交撤除"
+
+#: git-gui.sh:3691
+#, fuzzy
+msgid "Unstage Line From Commit"
+msgstr "从本次提交撤除"
+
+#: git-gui.sh:3694
 msgid "Stage Hunk For Commit"
 msgstr "缓存修改块为提交"
 
-#: git-gui.sh:2667
+#: git-gui.sh:3696
+#, fuzzy
+msgid "Stage Lines For Commit"
+msgstr "缓存修改块为提交"
+
+#: git-gui.sh:3698
+#, fuzzy
+msgid "Stage Line For Commit"
+msgstr "缓存修改块为提交"
+
+#: git-gui.sh:3723
 msgid "Initializing..."
 msgstr "初始化..."
 
-#: git-gui.sh:2762
-#, tcl-format
+#: git-gui.sh:3868
+#, fuzzy, tcl-format
 msgid ""
-"Possible environment issues exist.\n"
-"\n"
-"The following environment variables are probably\n"
-"going to be ignored by any Git subprocess run\n"
-"by %s:\n"
-"\n"
+"Possible environment issues exist.\r\n"
+"\r\n"
+"The following environment variables are probably\r\n"
+"going to be ignored by any Git subprocess run\r\n"
+"by %s:\r\n"
+"\r\n"
 msgstr ""
 "可能存在环境变量的问题.\n"
 "\n"
 "由 %s 执行的 Git 子进程可能忽略下列环境变量:\n"
 "\n"
 
-#: git-gui.sh:2792
+#: git-gui.sh:3897
+#, fuzzy
 msgid ""
-"\n"
-"This is due to a known issue with the\n"
+"\r\n"
+"This is due to a known issue with the\r\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 "\n"
 "这是由 Cygwin 发布的 Tcl 代码中一个\n"
 "已知问题所引起."
 
-#: git-gui.sh:2797
-#, tcl-format
+#: git-gui.sh:3902
+#, fuzzy, tcl-format
 msgid ""
-"\n"
-"\n"
-"A good replacement for %s\n"
-"is placing values for the user.name and\n"
-"user.email settings into your personal\n"
-"~/.gitconfig file.\n"
+"\r\n"
+"\r\n"
+"A good replacement for %s\r\n"
+"is placing values for the user.name and\r\n"
+"user.email settings into your personal\r\n"
+"~/.gitconfig file.\r\n"
 msgstr ""
 "\n"
 "\n"
 "%s 的一个很好的替代方案是将 user.name 以及\n"
 "user.email 设置放在你的个人 ~/.gitconfig 文件中.\n"
 
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr "git-gui - Git 的图形化用户界面"
-
-#: lib/blame.tcl:77
-msgid "File Viewer"
-msgstr "文件查看器"
-
-#: lib/blame.tcl:81
-msgid "Commit:"
-msgstr "提交:"
-
-#: lib/blame.tcl:264
-msgid "Copy Commit"
-msgstr "复制提交"
-
-#: lib/blame.tcl:384
-#, tcl-format
-msgid "Reading %s..."
-msgstr "读取 %s..."
-
-#: lib/blame.tcl:488
-msgid "Loading copy/move tracking annotations..."
-msgstr "装载复制/移动跟踪标注..."
-
-#: lib/blame.tcl:508
-msgid "lines annotated"
-msgstr "标注行"
-
-#: lib/blame.tcl:689
-msgid "Loading original location annotations..."
-msgstr "装载原始位置标注..."
-
-#: lib/blame.tcl:692
-msgid "Annotation complete."
-msgstr "标注完成."
-
-#: lib/blame.tcl:746
-msgid "Loading annotation..."
-msgstr "裝載标注..."
-
-#: lib/blame.tcl:802
-msgid "Author:"
-msgstr "作者:"
-
-#: lib/blame.tcl:806
-msgid "Committer:"
-msgstr "提交者:"
-
-#: lib/blame.tcl:811
-msgid "Original File:"
-msgstr "原始文件:"
-
-#: lib/blame.tcl:925
-msgid "Originally By:"
-msgstr "最初由:"
-
-#: lib/blame.tcl:931
-msgid "In File:"
-msgstr "在文件:"
-
-#: lib/blame.tcl:936
-msgid "Copied Or Moved Here By:"
-msgstr "由复制或移动至此:"
-
-#: lib/branch_checkout.tcl:14 lib/branch_checkout.tcl:19
-msgid "Checkout Branch"
-msgstr "Checkout 分支"
-
-#: lib/branch_checkout.tcl:23
-msgid "Checkout"
-msgstr "Checkout"
-
-#: lib/branch_checkout.tcl:27 lib/branch_create.tcl:35
-#: lib/branch_delete.tcl:32 lib/branch_rename.tcl:30 lib/browser.tcl:282
-#: lib/checkout_op.tcl:522 lib/choose_font.tcl:43 lib/merge.tcl:171
-#: lib/option.tcl:103 lib/remote_branch_delete.tcl:42 lib/transport.tcl:97
-msgid "Cancel"
-msgstr "取消"
-
-#: lib/branch_checkout.tcl:32 lib/browser.tcl:287
-msgid "Revision"
-msgstr "版本"
-
-#: lib/branch_checkout.tcl:36 lib/branch_create.tcl:69 lib/option.tcl:242
-msgid "Options"
-msgstr "选项..."
-
-#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr "获取跟踪分支"
-
-#: lib/branch_checkout.tcl:44
-msgid "Detach From Local Branch"
-msgstr "从本地分支脱离"
-
-#: lib/branch_create.tcl:22
-msgid "Create Branch"
-msgstr "创建分支"
-
-#: lib/branch_create.tcl:27
-msgid "Create New Branch"
-msgstr "新建分支"
-
-#: lib/branch_create.tcl:31 lib/choose_repository.tcl:371
-msgid "Create"
-msgstr "新建"
-
-#: lib/branch_create.tcl:40
-msgid "Branch Name"
-msgstr "分支名"
-
-#: lib/branch_create.tcl:43
-msgid "Name:"
-msgstr "名字:"
-
-#: lib/branch_create.tcl:58
-msgid "Match Tracking Branch Name"
-msgstr "匹配跟踪分支名字"
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr "起始版本"
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr "更新已有分支:"
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr "号码"
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr "仅快速合并"
-
-#: lib/branch_create.tcl:85 lib/checkout_op.tcl:514
-msgid "Reset"
-msgstr "复位"
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr "在创建后Checkout"
-
-#: lib/branch_create.tcl:131
-msgid "Please select a tracking branch."
-msgstr "请选择某个跟踪分支."
-
-#: lib/branch_create.tcl:140
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr "跟踪分支 %s 并不是远端版本库中的一个分支"
-
-#: lib/branch_create.tcl:153 lib/branch_rename.tcl:86
-msgid "Please supply a branch name."
-msgstr "请提供分支名字."
-
-#: lib/branch_create.tcl:164 lib/branch_rename.tcl:106
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr "'%s'不是一个可接受的分支名."
-
-#: lib/branch_delete.tcl:15
-msgid "Delete Branch"
-msgstr "删除分支"
-
-#: lib/branch_delete.tcl:20
-msgid "Delete Local Branch"
-msgstr "删除本地分支"
-
-#: lib/branch_delete.tcl:37
-msgid "Local Branches"
-msgstr "本地分支"
-
-#: lib/branch_delete.tcl:52
-msgid "Delete Only If Merged Into"
-msgstr "仅在合并后删除"
-
-#: lib/branch_delete.tcl:54
-msgid "Always (Do not perform merge test.)"
-msgstr "总是合并 (不作合并测试.)"
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr "下列分支没有完全被合并到 %s:"
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
+#: lib/line.tcl:17
+msgid "Goto Line:"
 msgstr ""
-"无法删除分支:\n"
-"%s"
 
-#: lib/branch_rename.tcl:14 lib/branch_rename.tcl:22
-msgid "Rename Branch"
-msgstr "更改分支名:"
+#: lib/line.tcl:23
+msgid "Go"
+msgstr ""
 
-#: lib/branch_rename.tcl:26
-msgid "Rename"
-msgstr "更名..."
+#: lib/console.tcl:59
+msgid "Working... please wait..."
+msgstr "工作中... 请等待..."
 
-#: lib/branch_rename.tcl:36
-msgid "Branch:"
-msgstr "分支:"
+#: lib/console.tcl:81 lib/checkout_op.tcl:146 lib/sshkey.tcl:55
+#: lib/database.tcl:30
+msgid "Close"
+msgstr "关闭"
 
-#: lib/branch_rename.tcl:39
-msgid "New Name:"
-msgstr "新名字:"
+#: lib/console.tcl:186
+msgid "Success"
+msgstr "成功"
 
-#: lib/branch_rename.tcl:75
-msgid "Please select a branch to rename."
-msgstr "请选择分支更名."
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
+msgstr "错误: 命令失败"
 
-#: lib/branch_rename.tcl:96 lib/checkout_op.tcl:179
-#, tcl-format
-msgid "Branch '%s' already exists."
-msgstr "分支 '%s' 已经存在."
-
-#: lib/branch_rename.tcl:117
-#, tcl-format
-msgid "Failed to rename '%s'."
-msgstr "无法更名 '%s'."
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr "开始..."
-
-#: lib/browser.tcl:26
-msgid "File Browser"
-msgstr "文件浏览器"
-
-#: lib/browser.tcl:126 lib/browser.tcl:143
-#, tcl-format
-msgid "Loading %s..."
-msgstr "装载 %s..."
-
-#: lib/browser.tcl:187
-msgid "[Up To Parent]"
-msgstr "[上层目录]"
-
-#: lib/browser.tcl:267 lib/browser.tcl:273
-msgid "Browse Branch Files"
-msgstr "浏览分支文件"
-
-#: lib/browser.tcl:278 lib/choose_repository.tcl:387
-#: lib/choose_repository.tcl:474 lib/choose_repository.tcl:484
-#: lib/choose_repository.tcl:987
-msgid "Browse"
-msgstr "浏览"
-
-#: lib/checkout_op.tcl:79
+#: lib/checkout_op.tcl:85
 #, tcl-format
 msgid "Fetching %s from %s"
 msgstr "获取 %s 自 %s"
 
-#: lib/checkout_op.tcl:127
+#: lib/checkout_op.tcl:133
 #, tcl-format
 msgid "fatal: Cannot resolve %s"
 msgstr "致命错误: 无法解决 %s"
 
-#: lib/checkout_op.tcl:140 lib/console.tcl:81 lib/database.tcl:31
-msgid "Close"
-msgstr "关闭"
-
-#: lib/checkout_op.tcl:169
+#: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
 msgstr "分支 '%s' 并不存在."
 
-#: lib/checkout_op.tcl:206
+#: lib/checkout_op.tcl:194
+#, fuzzy, tcl-format
+msgid "Failed to configure simplified git-pull for '%s'."
+msgstr "无法配置 origin"
+
+#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr "分支 '%s' 已经存在."
+
+#: lib/checkout_op.tcl:229
 #, tcl-format
 msgid ""
 "Branch '%s' already exists.\n"
@@ -774,28 +692,29 @@ msgstr ""
 "无法快速合并到 %s.\n"
 "需要普通合并."
 
-#: lib/checkout_op.tcl:220
+#: lib/checkout_op.tcl:243
 #, tcl-format
 msgid "Merge strategy '%s' not supported."
 msgstr "合并策略 '%s' 不支持."
 
-#: lib/checkout_op.tcl:239
+#: lib/checkout_op.tcl:262
 #, tcl-format
 msgid "Failed to update '%s'."
 msgstr "无法更新 '%s'."
 
-#: lib/checkout_op.tcl:251
+#: lib/checkout_op.tcl:274
 msgid "Staging area (index) is already locked."
 msgstr "缓存区域 (index) 已被锁定."
 
-#: lib/checkout_op.tcl:266
+#: lib/checkout_op.tcl:289
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before the current branch can be changed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before the current branch can be changed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "最后一次扫描的状态和当前版本库状态不符.\n"
 "\n"
@@ -804,33 +723,34 @@ msgstr ""
 "\n"
 "重新扫描将自动开始.\n"
 
-#: lib/checkout_op.tcl:322
+#: lib/checkout_op.tcl:345
 #, tcl-format
 msgid "Updating working directory to '%s'..."
 msgstr "更新工作目录到 '%s'..."
 
-#: lib/checkout_op.tcl:323
+#: lib/checkout_op.tcl:346
 msgid "files checked out"
 msgstr ""
 
-#: lib/checkout_op.tcl:353
+#: lib/checkout_op.tcl:376
 #, tcl-format
 msgid "Aborted checkout of '%s' (file level merging is required)."
 msgstr "中止 '%s' 的 checkout 操作 (需要做文件级合并)."
 
-#: lib/checkout_op.tcl:354
+#: lib/checkout_op.tcl:377
 msgid "File level merge required."
 msgstr "需要文件级合并."
 
-#: lib/checkout_op.tcl:358
+#: lib/checkout_op.tcl:381
 #, tcl-format
 msgid "Staying on branch '%s'."
 msgstr "停留在分支 '%s'."
 
-#: lib/checkout_op.tcl:429
+#: lib/checkout_op.tcl:452
+#, fuzzy
 msgid ""
-"You are no longer on a local branch.\n"
-"\n"
+"You are no longer on a local branch.\r\n"
+"\r\n"
 "If you wanted to be on a branch, create one now starting from 'This Detached "
 "Checkout'."
 msgstr ""
@@ -838,37 +758,50 @@ msgstr ""
 "\n"
 "如果你想位于某分支上, 从当前脱节的Checkout中创建一个新分支."
 
-#: lib/checkout_op.tcl:446 lib/checkout_op.tcl:450
+#: lib/checkout_op.tcl:503 lib/checkout_op.tcl:507
 #, tcl-format
 msgid "Checked out '%s'."
 msgstr "'%s' 已被 checkout"
 
-#: lib/checkout_op.tcl:478
+#: lib/checkout_op.tcl:535
 #, tcl-format
 msgid "Resetting '%s' to '%s' will lose the following commits:"
 msgstr "复位 '%s' 到 '%s' 将导致下列提交的丢失:"
 
-#: lib/checkout_op.tcl:500
+#: lib/checkout_op.tcl:557
 msgid "Recovering lost commits may not be easy."
 msgstr "恢复丢失的提交是比较困难的."
 
-#: lib/checkout_op.tcl:505
+#: lib/checkout_op.tcl:562
 #, tcl-format
 msgid "Reset '%s'?"
 msgstr "复位 '%s'?"
 
-#: lib/checkout_op.tcl:510 lib/merge.tcl:163
+#: lib/checkout_op.tcl:567 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "图示"
 
-#: lib/checkout_op.tcl:578
-#, tcl-format
+#: lib/checkout_op.tcl:571 lib/branch_create.tcl:85
+msgid "Reset"
+msgstr "复位"
+
+#: lib/checkout_op.tcl:579 lib/transport.tcl:141 lib/remote_add.tcl:34
+#: lib/browser.tcl:292 lib/merge.tcl:178 lib/branch_checkout.tcl:30
+#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/branch_rename.tcl:32
+#: lib/remote_branch_delete.tcl:43 lib/branch_create.tcl:37
+#: lib/branch_delete.tcl:34
+msgid "Cancel"
+msgstr "取消"
+
+#: lib/checkout_op.tcl:635
+#, fuzzy, tcl-format
 msgid ""
-"Failed to set current branch.\n"
-"\n"
+"Failed to set current branch.\r\n"
+"\r\n"
 "This working directory is only partially switched.  We successfully updated "
-"your files, but failed to update an internal Git file.\n"
-"\n"
+"your files, but failed to update an internal Git file.\r\n"
+"\r\n"
 "This should not have occurred.  %s will now close and give up."
 msgstr ""
 "无法设定当前分支.\n"
@@ -878,675 +811,239 @@ msgstr ""
 "\n"
 "这本不该发生, %s 将关闭并放弃."
 
-#: lib/choose_font.tcl:39
-msgid "Select"
-msgstr "选择"
+#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#, tcl-format
+msgid "fetch %s"
+msgstr "获取(fetch)"
 
-#: lib/choose_font.tcl:53
-msgid "Font Family"
-msgstr "字体族"
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr "从 %s 处获取新的改动"
 
-#: lib/choose_font.tcl:74
-msgid "Font Size"
-msgstr "字体大小"
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr "清除远端 %s"
 
-#: lib/choose_font.tcl:91
-msgid "Font Example"
-msgstr "字体样例"
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr "清除"
 
-#: lib/choose_font.tcl:103
-msgid ""
-"This is example text.\n"
-"If you like this text, it can be your font."
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
 msgstr ""
-"这是样例文本.\n"
-"如果你喜欢, 你可以设置该字体."
 
-#: lib/choose_repository.tcl:28
-msgid "Git Gui"
-msgstr "Git Gui"
-
-#: lib/choose_repository.tcl:81 lib/choose_repository.tcl:376
-msgid "Create New Repository"
-msgstr "创建新的版本库"
-
-#: lib/choose_repository.tcl:87
-msgid "New..."
-msgstr "新建..."
-
-#: lib/choose_repository.tcl:94 lib/choose_repository.tcl:460
-msgid "Clone Existing Repository"
-msgstr "克隆已有版本库"
-
-#: lib/choose_repository.tcl:100
-msgid "Clone..."
-msgstr "克隆..."
-
-#: lib/choose_repository.tcl:107 lib/choose_repository.tcl:976
-msgid "Open Existing Repository"
-msgstr "打开已有版本库"
-
-#: lib/choose_repository.tcl:113
-msgid "Open..."
-msgstr "打开..."
-
-#: lib/choose_repository.tcl:126
-msgid "Recent Repositories"
-msgstr "最近版本库"
-
-#: lib/choose_repository.tcl:132
-msgid "Open Recent Repository:"
-msgstr "打开最近版本库"
-
-#: lib/choose_repository.tcl:296 lib/choose_repository.tcl:303
-#: lib/choose_repository.tcl:310
-#, tcl-format
-msgid "Failed to create repository %s:"
-msgstr "无法创建版本库 %s:"
-
-#: lib/choose_repository.tcl:381 lib/choose_repository.tcl:478
-msgid "Directory:"
-msgstr "目录:"
-
-#: lib/choose_repository.tcl:412 lib/choose_repository.tcl:537
-#: lib/choose_repository.tcl:1011
-msgid "Git Repository"
-msgstr "Git 版本库"
-
-#: lib/choose_repository.tcl:437
-#, tcl-format
-msgid "Directory %s already exists."
-msgstr "目录 %s 已经存在."
-
-#: lib/choose_repository.tcl:441
-#, tcl-format
-msgid "File %s already exists."
-msgstr "文件 %s 已经存在."
-
-#: lib/choose_repository.tcl:455
-msgid "Clone"
-msgstr "克隆"
-
-#: lib/choose_repository.tcl:468
-msgid "URL:"
-msgstr "URL:"
-
-#: lib/choose_repository.tcl:489
-msgid "Clone Type:"
-msgstr "克隆类型:"
-
-#: lib/choose_repository.tcl:495
-msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
-msgstr "标准方式 (快速, 部分备份, 作硬连接)"
-
-#: lib/choose_repository.tcl:501
-msgid "Full Copy (Slower, Redundant Backup)"
-msgstr "全部复制 (较慢, 做备份)"
-
-#: lib/choose_repository.tcl:507
-msgid "Shared (Fastest, Not Recommended, No Backup)"
-msgstr "共享方式 (最快, 不推荐, 不做备份)"
-
-#: lib/choose_repository.tcl:543 lib/choose_repository.tcl:590
-#: lib/choose_repository.tcl:736 lib/choose_repository.tcl:806
-#: lib/choose_repository.tcl:1017 lib/choose_repository.tcl:1025
-#, tcl-format
-msgid "Not a Git repository: %s"
-msgstr "不是一个 Git 版本库: %s"
-
-#: lib/choose_repository.tcl:579
-msgid "Standard only available for local repository."
-msgstr "标准方式仅当是本地版本库时有效."
-
-#: lib/choose_repository.tcl:583
-msgid "Shared only available for local repository."
-msgstr "共享方式仅当是本地版本库时有效."
-
-#: lib/choose_repository.tcl:604
-#, tcl-format
-msgid "Location %s already exists."
-msgstr "位置 %s 已经存在."
-
-#: lib/choose_repository.tcl:615
-msgid "Failed to configure origin"
-msgstr "无法配置 origin"
-
-#: lib/choose_repository.tcl:627
-msgid "Counting objects"
-msgstr "清点对象"
-
-#: lib/choose_repository.tcl:628
+#: lib/transport.tcl:26
 #, fuzzy
-msgid "buckets"
-msgstr "水桶??"
+msgid "Fetching new changes from all remotes"
+msgstr "从 %s 处获取新的改动"
 
-#: lib/choose_repository.tcl:652
-#, tcl-format
-msgid "Unable to copy objects/info/alternates: %s"
-msgstr "无法复制 objects/info/alternates: %s"
-
-#: lib/choose_repository.tcl:688
-#, tcl-format
-msgid "Nothing to clone from %s."
-msgstr "没有东西可从 %s 克隆."
-
-#: lib/choose_repository.tcl:690 lib/choose_repository.tcl:904
-#: lib/choose_repository.tcl:916
-msgid "The 'master' branch has not been initialized."
-msgstr "'master'分支尚未初始化."
-
-#: lib/choose_repository.tcl:703
-msgid "Hardlinks are unavailable.  Falling back to copying."
-msgstr "硬连接不可用. 使用复制."
-
-#: lib/choose_repository.tcl:715
-#, tcl-format
-msgid "Cloning from %s"
-msgstr "从 %s 克隆"
-
-#: lib/choose_repository.tcl:746
-msgid "Copying objects"
-msgstr "复制 objects"
-
-#: lib/choose_repository.tcl:747
-msgid "KiB"
-msgstr "KiB"
-
-#: lib/choose_repository.tcl:771
-#, tcl-format
-msgid "Unable to copy object: %s"
-msgstr "无法复制 object: %s"
-
-#: lib/choose_repository.tcl:781
-msgid "Linking objects"
-msgstr "链接 objects"
-
-#: lib/choose_repository.tcl:782
-msgid "objects"
-msgstr "objects"
-
-#: lib/choose_repository.tcl:790
-#, tcl-format
-msgid "Unable to hardlink object: %s"
-msgstr "无法硬链接 object: %s"
-
-#: lib/choose_repository.tcl:845
-msgid "Cannot fetch branches and objects.  See console output for details."
-msgstr "无法获取分支和对象. 请查看控制终端的输出."
-
-#: lib/choose_repository.tcl:856
-msgid "Cannot fetch tags.  See console output for details."
-msgstr "无法获取标签. 请查看控制终端的输出."
-
-#: lib/choose_repository.tcl:880
-msgid "Cannot determine HEAD.  See console output for details."
-msgstr "无法确定 HEAD. 请查看控制终端的输出."
-
-#: lib/choose_repository.tcl:889
-#, tcl-format
-msgid "Unable to cleanup %s"
-msgstr "无法清理 %s"
-
-#: lib/choose_repository.tcl:895
-msgid "Clone failed."
-msgstr "克隆失败."
-
-#: lib/choose_repository.tcl:902
-msgid "No default branch obtained."
-msgstr "没有获取缺省分支"
-
-#: lib/choose_repository.tcl:913
-#, tcl-format
-msgid "Cannot resolve %s as a commit."
-msgstr "无法解析 %s 为提交."
-
-#: lib/choose_repository.tcl:925
-msgid "Creating working directory"
-msgstr "创建工作目录"
-
-#: lib/choose_repository.tcl:926 lib/index.tcl:65 lib/index.tcl:127
-#: lib/index.tcl:193
-msgid "files"
-msgstr "文件"
-
-#: lib/choose_repository.tcl:955
-msgid "Initial file checkout failed."
-msgstr "初始的文件checkout失败"
-
-#: lib/choose_repository.tcl:971
-msgid "Open"
-msgstr "打开"
-
-#: lib/choose_repository.tcl:981
-msgid "Repository:"
-msgstr "版本库"
-
-#: lib/choose_repository.tcl:1031
-#, tcl-format
-msgid "Failed to open repository %s:"
-msgstr "无法打开版本库 %s:"
-
-#: lib/choose_rev.tcl:53
-msgid "This Detached Checkout"
-msgstr "该脱节的Checkout"
-
-#: lib/choose_rev.tcl:60
-msgid "Revision Expression:"
-msgstr "版本表达式:"
-
-#: lib/choose_rev.tcl:74
-msgid "Local Branch"
-msgstr "本地分支"
-
-#: lib/choose_rev.tcl:79
-msgid "Tracking Branch"
-msgstr "跟踪分支:"
-
-#: lib/choose_rev.tcl:84 lib/choose_rev.tcl:538
-msgid "Tag"
-msgstr "标签"
-
-#: lib/choose_rev.tcl:317
-#, tcl-format
-msgid "Invalid revision: %s"
-msgstr "无效版本: %s"
-
-#: lib/choose_rev.tcl:338
-msgid "No revision selected."
-msgstr "没有选择版本."
-
-#: lib/choose_rev.tcl:346
-msgid "Revision expression is empty."
-msgstr "版本表达式为空."
-
-#: lib/choose_rev.tcl:531
-msgid "Updated"
-msgstr "已更新"
-
-#: lib/choose_rev.tcl:559
-msgid "URL"
-msgstr "URL"
-
-#: lib/commit.tcl:9
-msgid ""
-"There is nothing to amend.\n"
-"\n"
-"You are about to create the initial commit.  There is no commit before this "
-"to amend.\n"
-msgstr ""
-"没有改动需要修正.\n"
-"\n"
-"你正在创建最初的提交. 在此之前没有提交可以修正.\n"
-
-#: lib/commit.tcl:18
-msgid ""
-"Cannot amend while merging.\n"
-"\n"
-"You are currently in the middle of a merge that has not been fully "
-"completed.  You cannot amend the prior commit unless you first abort the "
-"current merge activity.\n"
-msgstr ""
-"在合并时无法修正.\n"
-"\n"
-"你当前正在一次尚未完成的合并操作过程中. 除非中止当前合并活动,\n"
-"否则无法修正之前的提交.\n"
-
-#: lib/commit.tcl:49
-msgid "Error loading commit data for amend:"
-msgstr "为修正装载提交数据出错:"
-
-#: lib/commit.tcl:76
-msgid "Unable to obtain your identity:"
-msgstr "无法获知你的身份:"
-
-#: lib/commit.tcl:81
-msgid "Invalid GIT_COMMITTER_IDENT:"
-msgstr "无效的 GIT_COMMITTER_IDENT"
-
-#: lib/commit.tcl:133
-msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
-"Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before another commit can be created.\n"
-"\n"
-"The rescan will be automatically started now.\n"
-msgstr ""
-"最后一次扫描的状态和当前版本库状态不符.\n"
-"\n"
-"另一 Git 程序自上次扫描后修改了本版本库. 在修改当前分支之前需要重新做一次扫"
-"描.\n"
-"\n"
-"重新扫描将自动开始.\n"
-
-#: lib/commit.tcl:154
-#, tcl-format
-msgid ""
-"Unmerged files cannot be committed.\n"
-"\n"
-"File %s has merge conflicts.  You must resolve them and stage the file "
-"before committing.\n"
-msgstr ""
-"尚未合并的文件没有办法提交.\n"
-"\n"
-"文件 %s 有合并冲突, 你必须解决这些冲突并缓存该文件作提交.\n"
-
-#: lib/commit.tcl:162
-#, tcl-format
-msgid ""
-"Unknown file state %s detected.\n"
-"\n"
-"File %s cannot be committed by this program.\n"
-msgstr ""
-"检测到未知文件状态 %s.\n"
-"\n"
-"文件 %s 无法由该程序提交.\n"
-
-#: lib/commit.tcl:170
-msgid ""
-"No changes to commit.\n"
-"\n"
-"You must stage at least 1 file before you can commit.\n"
-msgstr ""
-"没有需要提交的变动.\n"
-"\n"
-"提交前你必须首先缓存至少一个文件.\n"
-
-#: lib/commit.tcl:183
-msgid ""
-"Please supply a commit message.\n"
-"\n"
-"A good commit message has the following format:\n"
-"\n"
-"- First line: Describe in one sentence what you did.\n"
-"- Second line: Blank\n"
-"- Remaining lines: Describe why this change is good.\n"
-msgstr ""
-"请提供一条提交信息.\n"
-"\n"
-"一条好的提交信息有下列格式:\n"
-"\n"
-"- 第一行: 一句话概括你做的修改.\n"
-"- 第二行: 空行\n"
-"- 剩余行: 请描述为什么你做的这些改动是好的.\n"
-
-#: lib/commit.tcl:207
-#, tcl-format
-msgid "warning: Tcl does not support encoding '%s'."
-msgstr "警告: Tcl 不支持编码方式 '%s'."
-
-#: lib/commit.tcl:221
-msgid "Calling pre-commit hook..."
-msgstr ""
-
-#: lib/commit.tcl:236
-msgid "Commit declined by pre-commit hook."
-msgstr ""
-
-#: lib/commit.tcl:259
-msgid "Calling commit-msg hook..."
-msgstr ""
-
-#: lib/commit.tcl:274
-msgid "Commit declined by commit-msg hook."
-msgstr ""
-
-#: lib/commit.tcl:287
-msgid "Committing changes..."
-msgstr ""
-
-#: lib/commit.tcl:303
-msgid "write-tree failed:"
-msgstr "write-tree 失败:"
-
-#: lib/commit.tcl:304 lib/commit.tcl:348 lib/commit.tcl:368
+#: lib/transport.tcl:40
 #, fuzzy
-msgid "Commit failed."
-msgstr "克隆失败."
+msgid "remote prune all remotes"
+msgstr "清除远端 %s"
 
-#: lib/commit.tcl:321
+#: lib/transport.tcl:41
+#, fuzzy
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr "清除"
+
+#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
+#: lib/remote_add.tcl:162
 #, tcl-format
-msgid "Commit %s appears to be corrupt"
-msgstr "提交 %s 似乎已损坏"
+msgid "push %s"
+msgstr "上传 %s"
 
-#: lib/commit.tcl:326
-msgid ""
-"No changes to commit.\n"
-"\n"
-"No files were modified by this commit and it was not a merge commit.\n"
-"\n"
-"A rescan will be automatically started now.\n"
-msgstr ""
-"没有改动提交.\n"
-"\n"
-"该提交没有改动任何文件也不是一个合并提交.\n"
-"\n"
-"重新扫描将自动开始.\n"
-
-#: lib/commit.tcl:333
-msgid "No changes to commit."
-msgstr "没有改动要提交."
-
-#: lib/commit.tcl:347
-msgid "commit-tree failed:"
-msgstr "commit-tree 失败:"
-
-#: lib/commit.tcl:367
-msgid "update-ref failed:"
-msgstr "update-ref 失败:"
-
-#: lib/commit.tcl:454
+#: lib/transport.tcl:55
 #, tcl-format
-msgid "Created commit %s: %s"
-msgstr "创建了 commit %s: %s"
+msgid "Pushing changes to %s"
+msgstr "上传改动到 %s"
 
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr "工作中... 请等待..."
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr "成功"
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr "错误: 命令失败"
-
-#: lib/database.tcl:43
-msgid "Number of loose objects"
-msgstr "松散对象的数量"
-
-#: lib/database.tcl:44
-msgid "Disk space used by loose objects"
-msgstr "松散对象所使用的磁盘空间"
-
-#: lib/database.tcl:45
-msgid "Number of packed objects"
-msgstr "压缩对象数量"
-
-#: lib/database.tcl:46
-msgid "Number of packs"
-msgstr "压缩包数量"
-
-#: lib/database.tcl:47
-msgid "Disk space used by packed objects"
-msgstr "压缩对象所使用的磁盘空间"
-
-#: lib/database.tcl:48
-msgid "Packed objects waiting for pruning"
-msgstr "压缩对象等待清理"
-
-#: lib/database.tcl:49
-msgid "Garbage files"
-msgstr "垃圾文件"
-
-#: lib/database.tcl:72
-msgid "Compressing the object database"
-msgstr "压缩对象数据库"
-
-#: lib/database.tcl:83
-msgid "Verifying the object database with fsck-objects"
-msgstr "使用 fsck-objects 验证对象数据库"
-
-#: lib/database.tcl:108
-#, tcl-format
-msgid ""
-"This repository currently has approximately %i loose objects.\n"
-"\n"
-"To maintain optimal performance it is strongly recommended that you compress "
-"the database when more than %i loose objects exist.\n"
-"\n"
-"Compress the database now?"
-msgstr ""
-"该版本库当前约有 %i 个松散对象.\n"
-"\n"
-"为达到较优的性能，强烈建议你在松散对象多于 %i 时压缩数据库.\n"
-"\n"
-"现在就压缩数据库么?"
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
-msgstr "无效的日期: %s"
-
-#: lib/diff.tcl:42
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-"未检测到改动.\n"
-"\n"
-"该文件的修改日期被另一个程序所更新, 但其内容并没有变化.\n"
-"\n"
-"对于类似情况的其他文件的重新扫描将自动开始."
-
-#: lib/diff.tcl:81
+#: lib/transport.tcl:93
 #, fuzzy, tcl-format
-msgid "Loading diff of %s..."
-msgstr "装载 %s 的 diff ..."
+msgid "Mirroring to %s"
+msgstr "合并到 %s"
 
-#: lib/diff.tcl:114 lib/diff.tcl:184
+#: lib/transport.tcl:111
 #, tcl-format
-msgid "Unable to display %s"
-msgstr "无法显示 %s"
+msgid "Pushing %s %s to %s"
+msgstr "上传 %s %s 到 %s"
 
-#: lib/diff.tcl:115
-msgid "Error loading file:"
-msgstr "装载文件出错:"
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr "上传分支"
 
-#: lib/diff.tcl:122
-msgid "Git Repository (subproject)"
-msgstr "Git 版本库 (子项目)"
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr "源端分支:"
 
-#: lib/diff.tcl:134
-msgid "* Binary file (not showing content)."
-msgstr "* 二进制文件 (不显示内容)."
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr "目标版本库"
 
-#: lib/diff.tcl:185
-msgid "Error loading diff:"
-msgstr "装载 diff 错误:"
+#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
+msgid "Remote:"
+msgstr "Remote:"
 
-#: lib/diff.tcl:303
-msgid "Failed to unstage selected hunk."
-msgstr "无法将选择的代码段从缓存中删除."
-
-#: lib/diff.tcl:310
-msgid "Failed to stage selected hunk."
-msgstr "无法缓存所选代码段."
-
-#: lib/error.tcl:20 lib/error.tcl:114
-msgid "error"
-msgstr "错误"
-
-#: lib/error.tcl:36
-msgid "warning"
-msgstr "警告"
-
-#: lib/error.tcl:94
-msgid "You must correct the above errors before committing."
-msgstr "你必须在提交前修正上述错误."
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr "无法解锁缓存 (index)"
-
-#: lib/index.tcl:15
-msgid "Index Error"
-msgstr "缓存(Index)错误"
-
-#: lib/index.tcl:21
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr "更新 Git 缓存(Index)失败, 重新扫描将自动开始以重新同步 git-gui."
-
-#: lib/index.tcl:27
-msgid "Continue"
-msgstr "继续"
-
-#: lib/index.tcl:31
-msgid "Unlock Index"
-msgstr "解锁 Index"
-
-#: lib/index.tcl:282
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr "从提交缓存中删除 %s"
-
-#: lib/index.tcl:313
+#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
 #, fuzzy
-msgid "Ready to commit."
-msgstr "缓存为提交"
+msgid "Arbitrary Location:"
+msgstr "任意 URL:"
 
-#: lib/index.tcl:326
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr "传输选项"
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr "强制覆盖已有的分支 (可能会丢失改动)"
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr "使用 thin pack (适用于低速网络连接)"
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr "包含标签"
+
+#: lib/transport.tcl:229
 #, tcl-format
-msgid "Adding %s"
-msgstr "添加 %s"
+msgid "%s (%s): Push"
+msgstr ""
 
-#: lib/index.tcl:381
+#: lib/remote_add.tcl:20
 #, tcl-format
-msgid "Revert changes in file %s?"
-msgstr "撤销文件 %s 中的改动?"
+msgid "%s (%s): Add Remote"
+msgstr ""
 
-#: lib/index.tcl:383
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr "撤销这些 (%i个) 文件的改动?"
+#: lib/remote_add.tcl:25
+#, fuzzy
+msgid "Add New Remote"
+msgstr "远端(remote)"
 
-#: lib/index.tcl:391
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr "任何未缓存的改动将在这次撤销中永久丢失."
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr ""
 
-#: lib/index.tcl:394
-msgid "Do Nothing"
+#: lib/remote_add.tcl:39
+#, fuzzy
+msgid "Remote Details"
+msgstr "恢复默认值"
+
+#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
+msgid "Name:"
+msgstr "名字:"
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr ""
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr ""
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr ""
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr ""
+
+#: lib/remote_add.tcl:75
+#, fuzzy
+msgid "Do Nothing Else Now"
 msgstr "不做操作"
 
+#: lib/remote_add.tcl:100
+#, fuzzy
+msgid "Please supply a remote name."
+msgstr "请提供分支名字."
+
+#: lib/remote_add.tcl:113
+#, fuzzy, tcl-format
+msgid "'%s' is not an acceptable remote name."
+msgstr "'%s'不是一个可接受的分支名."
+
+#: lib/remote_add.tcl:124
+#, fuzzy, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr "无法更名 '%s'."
+
+#: lib/remote_add.tcl:133
+#, fuzzy, tcl-format
+msgid "Fetching the %s"
+msgstr "获取 %s 自 %s"
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr ""
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr ""
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr "开始..."
+
+#: lib/browser.tcl:27
+#, fuzzy, tcl-format
+msgid "%s (%s): File Browser"
+msgstr "文件浏览器"
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr "装载 %s..."
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr "[上层目录]"
+
+#: lib/browser.tcl:275
+#, fuzzy, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr "浏览分支文件"
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr "浏览分支文件"
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:425
+#: lib/choose_repository.tcl:512 lib/choose_repository.tcl:521
+#: lib/choose_repository.tcl:1077
+msgid "Browse"
+msgstr "浏览"
+
+#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
+msgid "Revision"
+msgstr "版本"
+
 #: lib/merge.tcl:13
+#, fuzzy
 msgid ""
-"Cannot merge while amending.\n"
-"\n"
-"You must finish amending this commit before starting any type of merge.\n"
+"Cannot merge while amending.\r\n"
+"\r\n"
+"You must finish amending this commit before starting any type of merge.\r\n"
 msgstr ""
 "修正时无法做合并.\n"
 "\n"
 "你必须完成对该提交的修正才能继续任何类型的合并操作.\n"
 
 #: lib/merge.tcl:27
+#, fuzzy
 msgid ""
-"Last scanned state does not match repository state.\n"
-"\n"
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
 "Another Git program has modified this repository since the last scan.  A "
-"rescan must be performed before a merge can be performed.\n"
-"\n"
-"The rescan will be automatically started now.\n"
+"rescan must be performed before a merge can be performed.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
 msgstr ""
 "最后一次扫描的状态和当前版本库状态不符.\n"
 "\n"
@@ -1555,15 +1052,15 @@ msgstr ""
 "\n"
 "重新扫描将自动开始.\n"
 
-#: lib/merge.tcl:44
-#, tcl-format
+#: lib/merge.tcl:45
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a conflicted merge.\n"
-"\n"
-"File %s has merge conflicts.\n"
-"\n"
+"You are in the middle of a conflicted merge.\r\n"
+"\r\n"
+"File %s has merge conflicts.\r\n"
+"\r\n"
 "You must resolve them, stage the file, and commit to complete the current "
-"merge.  Only then can you begin another merge.\n"
+"merge.  Only then can you begin another merge.\r\n"
 msgstr ""
 "你正处在一个有冲突的合并操作中.\n"
 "\n"
@@ -1572,15 +1069,15 @@ msgstr ""
 "你必须解决这些冲突, 缓存该文件, 并提交来完成当前的合并.仅当这样后才能开始下一"
 "个合并操作.\n"
 
-#: lib/merge.tcl:54
-#, tcl-format
+#: lib/merge.tcl:55
+#, fuzzy, tcl-format
 msgid ""
-"You are in the middle of a change.\n"
-"\n"
-"File %s is modified.\n"
-"\n"
+"You are in the middle of a change.\r\n"
+"\r\n"
+"File %s is modified.\r\n"
+"\r\n"
 "You should complete the current commit before starting a merge.  Doing so "
-"will help you abort a failed merge, should the need arise.\n"
+"will help you abort a failed merge, should the need arise.\r\n"
 msgstr ""
 "你正处在一个改动当中.\n"
 "\n"
@@ -1589,49 +1086,57 @@ msgstr ""
 "你必须完成当前的提交后才能开始合并. 如果需要, 这么做将有助于中止一次失败的合"
 "并.\n"
 
-#: lib/merge.tcl:106
+#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr ""
 
-#: lib/merge.tcl:119
+#: lib/merge.tcl:126
 #, fuzzy, tcl-format
 msgid "Merging %s and %s..."
 msgstr "合并 %s 和 %s"
 
-#: lib/merge.tcl:130
+#: lib/merge.tcl:137
 msgid "Merge completed successfully."
 msgstr "合并成功完成."
 
-#: lib/merge.tcl:132
+#: lib/merge.tcl:139
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "合并失败. 需要解决冲突."
 
-#: lib/merge.tcl:157
+#: lib/merge.tcl:156
+#, tcl-format
+msgid "%s (%s): Merge"
+msgstr ""
+
+#: lib/merge.tcl:164
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "合并到 %s"
 
-#: lib/merge.tcl:176
+#: lib/merge.tcl:183
 msgid "Revision To Merge"
 msgstr "要合并的版本"
 
-#: lib/merge.tcl:211
+#: lib/merge.tcl:218
+#, fuzzy
 msgid ""
-"Cannot abort while amending.\n"
-"\n"
-"You must finish amending this commit.\n"
+"Cannot abort while amending.\r\n"
+"\r\n"
+"You must finish amending this commit.\r\n"
 msgstr ""
 "修正操作中无法中止.\n"
 "\n"
 "你必须先完成本次修正操作.\n"
 
-#: lib/merge.tcl:221
+#: lib/merge.tcl:228
+#, fuzzy
 msgid ""
-"Abort merge?\n"
-"\n"
-"Aborting the current merge will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Abort merge?\r\n"
+"\r\n"
+"Aborting the current merge will cause *ALL* uncommitted changes to be lost."
+"\r\n"
+"\r\n"
 "Continue with aborting the current merge?"
 msgstr ""
 "中止合并?\n"
@@ -1640,12 +1145,13 @@ msgstr ""
 "\n"
 "是否要继续中止当前的合并操作?"
 
-#: lib/merge.tcl:227
+#: lib/merge.tcl:234
+#, fuzzy
 msgid ""
-"Reset changes?\n"
-"\n"
-"Resetting the changes will cause *ALL* uncommitted changes to be lost.\n"
-"\n"
+"Reset changes?\r\n"
+"\r\n"
+"Resetting the changes will cause *ALL* uncommitted changes to be lost.\r\n"
+"\r\n"
 "Continue with resetting the current changes?"
 msgstr ""
 "是否复位当前改动?\n"
@@ -1654,212 +1160,82 @@ msgstr ""
 "\n"
 "是否要继续复位当前的改动?"
 
-#: lib/merge.tcl:238
+#: lib/merge.tcl:245
 msgid "Aborting"
 msgstr "中止"
 
-#: lib/merge.tcl:238
+#: lib/merge.tcl:245
 #, fuzzy
 msgid "files reset"
 msgstr "文件"
 
-#: lib/merge.tcl:265
+#: lib/merge.tcl:273
 msgid "Abort failed."
 msgstr "中止失败"
 
-#: lib/merge.tcl:267
+#: lib/merge.tcl:275
 msgid "Abort completed.  Ready."
 msgstr "中止完成. 就绪."
 
-#: lib/option.tcl:95
-msgid "Restore Defaults"
-msgstr "恢复默认值"
-
-#: lib/option.tcl:99
-msgid "Save"
-msgstr "保存"
-
-#: lib/option.tcl:109
+#: lib/tools.tcl:76
 #, tcl-format
-msgid "%s Repository"
-msgstr "%s 版本库"
-
-#: lib/option.tcl:110
-msgid "Global (All Repositories)"
-msgstr "全局 (所有版本库)"
-
-#: lib/option.tcl:116
-msgid "User Name"
-msgstr "用户名"
-
-#: lib/option.tcl:117
-msgid "Email Address"
-msgstr "Email 地址"
-
-#: lib/option.tcl:119
-msgid "Summarize Merge Commits"
-msgstr "概述合并提交:"
-
-#: lib/option.tcl:120
-msgid "Merge Verbosity"
-msgstr "合并冗余度"
-
-#: lib/option.tcl:121
-msgid "Show Diffstat After Merge"
-msgstr "在合并后显示 Diffstat"
-
-#: lib/option.tcl:123
-msgid "Trust File Modification Timestamps"
-msgstr "相信文件的改动时间"
-
-#: lib/option.tcl:124
-msgid "Prune Tracking Branches During Fetch"
-msgstr "获取时清除跟踪分支"
-
-#: lib/option.tcl:125
-msgid "Match Tracking Branches"
-msgstr "匹配跟踪分支"
-
-#: lib/option.tcl:126
-msgid "Number of Diff Context Lines"
-msgstr "Diff 上下文行数"
-
-#: lib/option.tcl:127
-#, fuzzy
-msgid "Commit Message Text Width"
-msgstr "提交描述:"
-
-#: lib/option.tcl:128
-msgid "New Branch Name Template"
-msgstr "新建分支命名模板"
-
-#: lib/option.tcl:192
-msgid "Spelling Dictionary:"
+msgid "Running %s requires a selected file."
 msgstr ""
 
-#: lib/option.tcl:216
-msgid "Change Font"
-msgstr "更改字体"
-
-#: lib/option.tcl:220
+#: lib/tools.tcl:92
 #, tcl-format
-msgid "Choose %s"
-msgstr "选择 %s"
-
-#: lib/option.tcl:226
-msgid "pt."
-msgstr "磅"
-
-#: lib/option.tcl:240
-msgid "Preferences"
-msgstr "首选项"
-
-#: lib/option.tcl:275
-msgid "Failed to completely save options:"
-msgstr "无法完全保存选项:"
-
-#: lib/remote_branch_delete.tcl:29 lib/remote_branch_delete.tcl:34
-msgid "Delete Remote Branch"
-msgstr "删除远端分支"
-
-#: lib/remote_branch_delete.tcl:47
-msgid "From Repository"
-msgstr "从版本库"
-
-#: lib/remote_branch_delete.tcl:50 lib/transport.tcl:123
-msgid "Remote:"
-msgstr "Remote:"
-
-#: lib/remote_branch_delete.tcl:66 lib/transport.tcl:138
-msgid "Arbitrary URL:"
-msgstr "任意 URL:"
-
-#: lib/remote_branch_delete.tcl:84
-msgid "Branches"
-msgstr "分支"
-
-#: lib/remote_branch_delete.tcl:109
-msgid "Delete Only If"
-msgstr "删除仅当"
-
-#: lib/remote_branch_delete.tcl:111
-msgid "Merged Into:"
-msgstr "合并到"
-
-#: lib/remote_branch_delete.tcl:119
-msgid "Always (Do not perform merge checks)"
-msgstr "总是合并 (不作合并检查)"
-
-#: lib/remote_branch_delete.tcl:152
-msgid "A branch is required for 'Merged Into'."
-msgstr "'合并到' 需要指定某个分支"
-
-#: lib/remote_branch_delete.tcl:184
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
 msgstr ""
-"下列分支没有被全部合并到 %s 中:\n"
-"\n"
-" - %s"
 
-#: lib/remote_branch_delete.tcl:189
+#: lib/tools.tcl:96
 #, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
+msgid "Are you sure you want to run %s?"
 msgstr ""
-"由于没有获取到必要的提交，一个或多个合并测试失败。请尝试从 %s 处先获取。"
 
-#: lib/remote_branch_delete.tcl:207
-msgid "Please select one or more branches to delete."
-msgstr "请选择某个或多个分支来删除"
-
-#: lib/remote_branch_delete.tcl:216
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
+#: lib/tools.tcl:118
+#, tcl-format
+msgid "Tool: %s"
 msgstr ""
-"恢复被删除的分支非常困难.\n"
-"\n"
-"是否要删除所选分支?"
 
-#: lib/remote_branch_delete.tcl:226
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr "从 %s 中删除分支"
-
-#: lib/remote_branch_delete.tcl:286
-msgid "No repository selected."
-msgstr "没有选择版本库"
-
-#: lib/remote_branch_delete.tcl:291
-#, tcl-format
-msgid "Scanning %s..."
+#: lib/tools.tcl:119
+#, fuzzy, tcl-format
+msgid "Running: %s"
 msgstr "正在扫描 %s..."
 
-#: lib/remote.tcl:165
-msgid "Prune from"
-msgstr "从..清除(prune)"
+#: lib/tools.tcl:158
+#, fuzzy, tcl-format
+msgid "Tool completed successfully: %s"
+msgstr "合并成功完成."
 
-#: lib/remote.tcl:170
-msgid "Fetch from"
-msgstr "从..获取(fetch)"
+#: lib/tools.tcl:160
+#, tcl-format
+msgid "Tool failed: %s"
+msgstr ""
 
-#: lib/remote.tcl:213
-msgid "Push to"
-msgstr "上传到(push)"
+#: lib/branch_checkout.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Checkout Branch"
+msgstr "Checkout 分支"
 
-#: lib/shortcut.tcl:20 lib/shortcut.tcl:61
-msgid "Cannot write shortcut:"
-msgstr "无法修改快捷方式:"
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
+msgstr "Checkout 分支"
 
-#: lib/shortcut.tcl:136
-msgid "Cannot write icon:"
-msgstr "无法修改图标:"
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
+msgstr "Checkout"
+
+#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
+msgid "Options"
+msgstr "选项..."
+
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
+msgstr "获取跟踪分支"
+
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
+msgstr "从本地分支脱离"
 
 #: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
@@ -1886,82 +1262,1600 @@ msgstr ""
 msgid "Unrecognized spell checker"
 msgstr ""
 
-#: lib/spellcheck.tcl:180
+#: lib/spellcheck.tcl:186
 msgid "No Suggestions"
 msgstr ""
 
-#: lib/spellcheck.tcl:381
+#: lib/spellcheck.tcl:388
 msgid "Unexpected EOF from spell checker"
 msgstr ""
 
-#: lib/spellcheck.tcl:385
+#: lib/spellcheck.tcl:392
 msgid "Spell Checker Failed"
 msgstr ""
 
-#: lib/status_bar.tcl:83
+#: lib/status_bar.tcl:87
 #, tcl-format
 msgid "%s ... %*i of %*i %s (%3i%%)"
 msgstr "%s ... %*i of %*i %s (%3i%%)"
 
-#: lib/transport.tcl:6
+#: lib/diff.tcl:77
+#, fuzzy, tcl-format
+msgid ""
+"No differences detected.\r\n"
+"\r\n"
+"%s has no changes.\r\n"
+"\r\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\r\n"
+"\r\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+"未检测到改动.\n"
+"\n"
+"该文件的修改日期被另一个程序所更新, 但其内容并没有变化.\n"
+"\n"
+"对于类似情况的其他文件的重新扫描将自动开始."
+
+#: lib/diff.tcl:117
+#, fuzzy, tcl-format
+msgid "Loading diff of %s..."
+msgstr "装载 %s 的 diff ..."
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr ""
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr ""
+
+#: lib/diff.tcl:220 lib/diff.tcl:357
 #, tcl-format
-msgid "fetch %s"
-msgstr "获取(fetch)"
+msgid "Unable to display %s"
+msgstr "无法显示 %s"
 
-#: lib/transport.tcl:7
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr "装载文件出错:"
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr "Git 版本库 (子项目)"
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr "* 二进制文件 (不显示内容)."
+
+#: lib/diff.tcl:243
+msgid "\r"
+msgstr ""
+
+#: lib/diff.tcl:250
 #, tcl-format
-msgid "Fetching new changes from %s"
-msgstr "从 %s 处获取新的改动"
+msgid ""
+"\r\n"
+"* Untracked file clipped here by %s.\r\n"
+"* To see the entire file, use an external editor.\r\n"
+msgstr ""
 
-#: lib/transport.tcl:18
+#: lib/diff.tcl:358 lib/blame.tcl:1128
+msgid "Error loading diff:"
+msgstr "装载 diff 错误:"
+
+#: lib/diff.tcl:580
+msgid "Failed to unstage selected hunk."
+msgstr "无法将选择的代码段从缓存中删除."
+
+#: lib/diff.tcl:587
+msgid "Failed to stage selected hunk."
+msgstr "无法缓存所选代码段."
+
+#: lib/diff.tcl:666
+#, fuzzy
+msgid "Failed to unstage selected line."
+msgstr "无法将选择的代码段从缓存中删除."
+
+#: lib/diff.tcl:674
+#, fuzzy
+msgid "Failed to stage selected line."
+msgstr "无法缓存所选代码段."
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr "上传到(push)"
+
+#: lib/remote.tcl:218
+#, fuzzy
+msgid "Remove Remote"
+msgstr "远端(remote)"
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr "从..清除(prune)"
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr "从..获取(fetch)"
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/choose_font.tcl:41
+msgid "Select"
+msgstr "选择"
+
+#: lib/choose_font.tcl:55
+msgid "Font Family"
+msgstr "字体族"
+
+#: lib/choose_font.tcl:76
+msgid "Font Size"
+msgstr "字体大小"
+
+#: lib/choose_font.tcl:93
+msgid "Font Example"
+msgstr "字体样例"
+
+#: lib/choose_font.tcl:105
+msgid ""
+"This is example text.\n"
+"If you like this text, it can be your font."
+msgstr ""
+"这是样例文本.\n"
+"如果你喜欢, 你可以设置该字体."
+
+#: lib/option.tcl:11
+#, fuzzy, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr "%s 中指定的字体无效:"
+
+#: lib/option.tcl:19
+#, fuzzy, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr "%s 中指定的字体无效:"
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr "恢复默认值"
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr "保存"
+
+#: lib/option.tcl:133
 #, tcl-format
-msgid "remote prune %s"
-msgstr "清除远端 %s"
+msgid "%s Repository"
+msgstr "%s 版本库"
 
-#: lib/transport.tcl:19
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr "全局 (所有版本库)"
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr "用户名"
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr "Email 地址"
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr "概述合并提交:"
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr "合并冗余度"
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr "在合并后显示 Diffstat"
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr ""
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr "相信文件的改动时间"
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr "获取时清除跟踪分支"
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr "匹配跟踪分支"
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr ""
+
+#: lib/option.tcl:153
+#, fuzzy
+msgid "Maximum Length of Recent Repositories List"
+msgstr "最近版本库"
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr ""
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr ""
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr "Diff 上下文行数"
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+#, fuzzy
+msgid "Commit Message Text Width"
+msgstr "提交描述:"
+
+#: lib/option.tcl:159
+msgid "New Branch Name Template"
+msgstr "新建分支命名模板"
+
+#: lib/option.tcl:160
+msgid "Default File Contents Encoding"
+msgstr ""
+
+#: lib/option.tcl:161
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
+#: lib/database.tcl:57
 #, tcl-format
-msgid "Pruning tracking branches deleted from %s"
-msgstr "清除"
+msgid "%s:"
+msgstr ""
 
-#: lib/transport.tcl:25 lib/transport.tcl:71
+#: lib/option.tcl:210
+#, fuzzy
+msgid "Change"
+msgstr "更改字体"
+
+#: lib/option.tcl:254
+msgid "Spelling Dictionary:"
+msgstr ""
+
+#: lib/option.tcl:284
+msgid "Change Font"
+msgstr "更改字体"
+
+#: lib/option.tcl:288
 #, tcl-format
-msgid "push %s"
-msgstr "上传 %s"
+msgid "Choose %s"
+msgstr "选择 %s"
 
-#: lib/transport.tcl:26
+#: lib/option.tcl:294
+msgid "pt."
+msgstr "磅"
+
+#: lib/option.tcl:308
+msgid "Preferences"
+msgstr "首选项"
+
+#: lib/option.tcl:345
+msgid "Failed to completely save options:"
+msgstr "无法完全保存选项:"
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr ""
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:14
 #, tcl-format
-msgid "Pushing changes to %s"
-msgstr "上传改动到 %s"
+msgid ""
+"Note that the diff shows only conflicting changes.\r\n"
+"\r\n"
+"%s will be overwritten.\r\n"
+"\r\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
 
-#: lib/transport.tcl:72
+#: lib/mergetool.tcl:45
 #, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr "上传 %s %s 到 %s"
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
 
-#: lib/transport.tcl:89
-msgid "Push Branches"
-msgstr "上传分支"
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr ""
 
-#: lib/transport.tcl:103
-msgid "Source Branches"
-msgstr "源端分支:"
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
 
-#: lib/transport.tcl:120
-msgid "Destination Repository"
-msgstr "目标版本库"
+#: lib/mergetool.tcl:146
+#, fuzzy
+msgid "Conflict file does not exist"
+msgstr "分支 '%s' 并不存在."
 
-#: lib/transport.tcl:158
-msgid "Transfer Options"
-msgstr "传输选项"
+#: lib/mergetool.tcl:246
+#, fuzzy, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr "不是一个 Git 版本库: %s"
 
-#: lib/transport.tcl:160
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr "强制覆盖已有的分支 (可能会丢失改动)"
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr ""
 
-#: lib/transport.tcl:164
-msgid "Use thin pack (for slow network connections)"
-msgstr "使用 thin pack (适用于低速网络连接)"
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr ""
 
-#: lib/transport.tcl:168
-msgid "Include tags"
-msgstr "包含标签"
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr ""
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+#, fuzzy
+msgid "Merge tool failed."
+msgstr "中止失败"
+
+#: lib/tools_dlg.tcl:22
+#, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr ""
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr ""
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr ""
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr ""
+
+#: lib/tools_dlg.tcl:60
+#, fuzzy
+msgid "Command:"
+msgstr "提交:"
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr ""
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr ""
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:118
+#, fuzzy
+msgid "Please supply a name for the tool."
+msgstr "请提供分支名字."
+
+#: lib/tools_dlg.tcl:126
+#, fuzzy, tcl-format
+msgid "Tool '%s' already exists."
+msgstr "文件 %s 已经存在."
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:187
+#, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr ""
+
+#: lib/tools_dlg.tcl:198
+#, fuzzy
+msgid "Remove"
+msgstr "远端(remote)"
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:283
+#, tcl-format
+msgid "%s (%s):"
+msgstr ""
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr ""
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr ""
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr ""
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr ""
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr ""
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr "创建桌面图标"
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr "无法修改快捷方式:"
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr "无法修改图标:"
+
+#: lib/branch_rename.tcl:15
+#, fuzzy, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr "更改分支名:"
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr "更改分支名:"
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr "更名..."
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr "分支:"
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr "新名字:"
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr "请选择分支更名."
+
+#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
+msgid "Please supply a branch name."
+msgstr "请提供分支名字."
+
+#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr "'%s'不是一个可接受的分支名."
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr "无法更名 '%s'."
+
+#: lib/remote_branch_delete.tcl:29
+#, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:34
+#, fuzzy
+msgid "Delete Branch Remotely"
+msgstr "删除分支"
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr "从版本库"
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr "分支"
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr "删除仅当"
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr "合并到"
+
+#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
+msgid "Always (Do not perform merge checks)"
+msgstr "总是合并 (不作合并检查)"
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr "'合并到' 需要指定某个分支"
+
+#: lib/remote_branch_delete.tcl:185
+#, fuzzy, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\r\n"
+"\r\n"
+" - %s"
+msgstr ""
+"下列分支没有被全部合并到 %s 中:\n"
+"\n"
+" - %s"
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+"由于没有获取到必要的提交，一个或多个合并测试失败。请尝试从 %s 处先获取。"
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr "请选择某个或多个分支来删除"
+
+#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+"恢复被删除的分支非常困难.\n"
+"\n"
+"是否要删除所选分支?"
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr "从 %s 中删除分支"
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr "没有选择版本库"
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr "正在扫描 %s..."
+
+#: lib/choose_repository.tcl:33
+msgid "Git Gui"
+msgstr "Git Gui"
+
+#: lib/choose_repository.tcl:92 lib/choose_repository.tcl:415
+msgid "Create New Repository"
+msgstr "创建新的版本库"
+
+#: lib/choose_repository.tcl:98
+msgid "New..."
+msgstr "新建..."
+
+#: lib/choose_repository.tcl:105 lib/choose_repository.tcl:499
+msgid "Clone Existing Repository"
+msgstr "克隆已有版本库"
+
+#: lib/choose_repository.tcl:116
+msgid "Clone..."
+msgstr "克隆..."
+
+#: lib/choose_repository.tcl:123 lib/choose_repository.tcl:1067
+msgid "Open Existing Repository"
+msgstr "打开已有版本库"
+
+#: lib/choose_repository.tcl:129
+msgid "Open..."
+msgstr "打开..."
+
+#: lib/choose_repository.tcl:142
+msgid "Recent Repositories"
+msgstr "最近版本库"
+
+#: lib/choose_repository.tcl:152
+msgid "Open Recent Repository:"
+msgstr "打开最近版本库"
+
+#: lib/choose_repository.tcl:319 lib/choose_repository.tcl:326
+#: lib/choose_repository.tcl:333
+#, tcl-format
+msgid "Failed to create repository %s:"
+msgstr "无法创建版本库 %s:"
+
+#: lib/choose_repository.tcl:410 lib/branch_create.tcl:33
+msgid "Create"
+msgstr "新建"
+
+#: lib/choose_repository.tcl:420
+msgid "Directory:"
+msgstr "目录:"
+
+#: lib/choose_repository.tcl:450 lib/choose_repository.tcl:576
+#: lib/choose_repository.tcl:1101
+msgid "Git Repository"
+msgstr "Git 版本库"
+
+#: lib/choose_repository.tcl:475
+#, tcl-format
+msgid "Directory %s already exists."
+msgstr "目录 %s 已经存在."
+
+#: lib/choose_repository.tcl:479
+#, tcl-format
+msgid "File %s already exists."
+msgstr "文件 %s 已经存在."
+
+#: lib/choose_repository.tcl:494
+msgid "Clone"
+msgstr "克隆"
+
+#: lib/choose_repository.tcl:507
+msgid "Source Location:"
+msgstr ""
+
+#: lib/choose_repository.tcl:516
+#, fuzzy
+msgid "Target Directory:"
+msgstr "目录:"
+
+#: lib/choose_repository.tcl:526
+msgid "Clone Type:"
+msgstr "克隆类型:"
+
+#: lib/choose_repository.tcl:531
+msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
+msgstr "标准方式 (快速, 部分备份, 作硬连接)"
+
+#: lib/choose_repository.tcl:536
+msgid "Full Copy (Slower, Redundant Backup)"
+msgstr "全部复制 (较慢, 做备份)"
+
+#: lib/choose_repository.tcl:541
+msgid "Shared (Fastest, Not Recommended, No Backup)"
+msgstr "共享方式 (最快, 不推荐, 不做备份)"
+
+#: lib/choose_repository.tcl:548
+msgid "Recursively clone submodules too"
+msgstr ""
+
+#: lib/choose_repository.tcl:582 lib/choose_repository.tcl:629
+#: lib/choose_repository.tcl:775 lib/choose_repository.tcl:845
+#: lib/choose_repository.tcl:1107 lib/choose_repository.tcl:1115
+#, tcl-format
+msgid "Not a Git repository: %s"
+msgstr "不是一个 Git 版本库: %s"
+
+#: lib/choose_repository.tcl:618
+msgid "Standard only available for local repository."
+msgstr "标准方式仅当是本地版本库时有效."
+
+#: lib/choose_repository.tcl:622
+msgid "Shared only available for local repository."
+msgstr "共享方式仅当是本地版本库时有效."
+
+#: lib/choose_repository.tcl:643
+#, tcl-format
+msgid "Location %s already exists."
+msgstr "位置 %s 已经存在."
+
+#: lib/choose_repository.tcl:654
+msgid "Failed to configure origin"
+msgstr "无法配置 origin"
+
+#: lib/choose_repository.tcl:666
+msgid "Counting objects"
+msgstr "清点对象"
+
+#: lib/choose_repository.tcl:667
+#, fuzzy
+msgid "buckets"
+msgstr "水桶??"
+
+#: lib/choose_repository.tcl:691
+#, tcl-format
+msgid "Unable to copy objects/info/alternates: %s"
+msgstr "无法复制 objects/info/alternates: %s"
+
+#: lib/choose_repository.tcl:727
+#, tcl-format
+msgid "Nothing to clone from %s."
+msgstr "没有东西可从 %s 克隆."
+
+#: lib/choose_repository.tcl:729 lib/choose_repository.tcl:943
+#: lib/choose_repository.tcl:955
+msgid "The 'master' branch has not been initialized."
+msgstr "'master'分支尚未初始化."
+
+#: lib/choose_repository.tcl:742
+msgid "Hardlinks are unavailable.  Falling back to copying."
+msgstr "硬连接不可用. 使用复制."
+
+#: lib/choose_repository.tcl:754
+#, tcl-format
+msgid "Cloning from %s"
+msgstr "从 %s 克隆"
+
+#: lib/choose_repository.tcl:785
+msgid "Copying objects"
+msgstr "复制 objects"
+
+#: lib/choose_repository.tcl:786
+msgid "KiB"
+msgstr "KiB"
+
+#: lib/choose_repository.tcl:810
+#, tcl-format
+msgid "Unable to copy object: %s"
+msgstr "无法复制 object: %s"
+
+#: lib/choose_repository.tcl:820
+msgid "Linking objects"
+msgstr "链接 objects"
+
+#: lib/choose_repository.tcl:821
+msgid "objects"
+msgstr "objects"
+
+#: lib/choose_repository.tcl:829
+#, tcl-format
+msgid "Unable to hardlink object: %s"
+msgstr "无法硬链接 object: %s"
+
+#: lib/choose_repository.tcl:884
+msgid "Cannot fetch branches and objects.  See console output for details."
+msgstr "无法获取分支和对象. 请查看控制终端的输出."
+
+#: lib/choose_repository.tcl:895
+msgid "Cannot fetch tags.  See console output for details."
+msgstr "无法获取标签. 请查看控制终端的输出."
+
+#: lib/choose_repository.tcl:919
+msgid "Cannot determine HEAD.  See console output for details."
+msgstr "无法确定 HEAD. 请查看控制终端的输出."
+
+#: lib/choose_repository.tcl:928
+#, tcl-format
+msgid "Unable to cleanup %s"
+msgstr "无法清理 %s"
+
+#: lib/choose_repository.tcl:934
+msgid "Clone failed."
+msgstr "克隆失败."
+
+#: lib/choose_repository.tcl:941
+msgid "No default branch obtained."
+msgstr "没有获取缺省分支"
+
+#: lib/choose_repository.tcl:952
+#, tcl-format
+msgid "Cannot resolve %s as a commit."
+msgstr "无法解析 %s 为提交."
+
+#: lib/choose_repository.tcl:964
+msgid "Creating working directory"
+msgstr "创建工作目录"
+
+#: lib/choose_repository.tcl:965 lib/index.tcl:70 lib/index.tcl:136
+#: lib/index.tcl:207
+msgid "files"
+msgstr "文件"
+
+#: lib/choose_repository.tcl:984
+msgid "Cannot clone submodules."
+msgstr ""
+
+#: lib/choose_repository.tcl:993
+#, fuzzy
+msgid "Cloning submodules"
+msgstr "从 %s 克隆"
+
+#: lib/choose_repository.tcl:1018
+msgid "Initial file checkout failed."
+msgstr "初始的文件checkout失败"
+
+#: lib/choose_repository.tcl:1062
+msgid "Open"
+msgstr "打开"
+
+#: lib/choose_repository.tcl:1072
+msgid "Repository:"
+msgstr "版本库"
+
+#: lib/choose_repository.tcl:1121
+#, tcl-format
+msgid "Failed to open repository %s:"
+msgstr "无法打开版本库 %s:"
+
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
+msgstr "git-gui - Git 的图形化用户界面"
+
+#: lib/blame.tcl:73
+#, fuzzy, tcl-format
+msgid "%s (%s): File Viewer"
+msgstr "文件查看器"
+
+#: lib/blame.tcl:79
+msgid "Commit:"
+msgstr "提交:"
+
+#: lib/blame.tcl:280
+msgid "Copy Commit"
+msgstr "复制提交"
+
+#: lib/blame.tcl:284
+msgid "Find Text..."
+msgstr ""
+
+#: lib/blame.tcl:288
+#, fuzzy
+msgid "Goto Line..."
+msgstr "克隆..."
+
+#: lib/blame.tcl:297
+msgid "Do Full Copy Detection"
+msgstr ""
+
+#: lib/blame.tcl:301
+#, fuzzy
+msgid "Show History Context"
+msgstr "显示更多上下文"
+
+#: lib/blame.tcl:304
+#, fuzzy
+msgid "Blame Parent Commit"
+msgstr "修正上次提交"
+
+#: lib/blame.tcl:466
+#, tcl-format
+msgid "Reading %s..."
+msgstr "读取 %s..."
+
+#: lib/blame.tcl:594
+msgid "Loading copy/move tracking annotations..."
+msgstr "装载复制/移动跟踪标注..."
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr "标注行"
+
+#: lib/blame.tcl:806
+msgid "Loading original location annotations..."
+msgstr "装载原始位置标注..."
+
+#: lib/blame.tcl:809
+msgid "Annotation complete."
+msgstr "标注完成."
+
+#: lib/blame.tcl:839
+msgid "Busy"
+msgstr ""
+
+#: lib/blame.tcl:840
+msgid "Annotation process is already running."
+msgstr ""
+
+#: lib/blame.tcl:879
+msgid "Running thorough copy detection..."
+msgstr ""
+
+#: lib/blame.tcl:947
+msgid "Loading annotation..."
+msgstr "裝載标注..."
+
+#: lib/blame.tcl:1000
+msgid "Author:"
+msgstr "作者:"
+
+#: lib/blame.tcl:1004
+msgid "Committer:"
+msgstr "提交者:"
+
+#: lib/blame.tcl:1009
+msgid "Original File:"
+msgstr "原始文件:"
+
+#: lib/blame.tcl:1057
+msgid "Cannot find HEAD commit:"
+msgstr ""
+
+#: lib/blame.tcl:1112
+#, fuzzy
+msgid "Cannot find parent commit:"
+msgstr "PATH 中没有找到 git"
+
+#: lib/blame.tcl:1127
+#, fuzzy
+msgid "Unable to display parent"
+msgstr "无法显示 %s"
+
+#: lib/blame.tcl:1269
+msgid "Originally By:"
+msgstr "最初由:"
+
+#: lib/blame.tcl:1275
+msgid "In File:"
+msgstr "在文件:"
+
+#: lib/blame.tcl:1280
+msgid "Copied Or Moved Here By:"
+msgstr "由复制或移动至此:"
+
+#: lib/sshkey.tcl:31
+msgid "No keys found."
+msgstr ""
+
+#: lib/sshkey.tcl:34
+#, tcl-format
+msgid "Found a public key in: %s"
+msgstr ""
+
+#: lib/sshkey.tcl:40
+msgid "Generate Key"
+msgstr ""
+
+#: lib/sshkey.tcl:58
+msgid "Copy To Clipboard"
+msgstr ""
+
+#: lib/sshkey.tcl:72
+msgid "Your OpenSSH Public Key"
+msgstr ""
+
+#: lib/sshkey.tcl:80
+#, fuzzy
+msgid "Generating..."
+msgstr "开始..."
+
+#: lib/sshkey.tcl:86
+#, tcl-format
+msgid ""
+"Could not start ssh-keygen:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/sshkey.tcl:113
+#, fuzzy
+msgid "Generation failed."
+msgstr "克隆失败."
+
+#: lib/sshkey.tcl:120
+msgid "Generation succeeded, but no keys found."
+msgstr ""
+
+#: lib/sshkey.tcl:123
+#, tcl-format
+msgid "Your key is in: %s"
+msgstr ""
+
+#: lib/branch_create.tcl:23
+#, fuzzy, tcl-format
+msgid "%s (%s): Create Branch"
+msgstr "创建分支"
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr "新建分支"
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr "分支名"
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr "匹配跟踪分支名字"
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr "起始版本"
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr "更新已有分支:"
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr "号码"
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr "仅快速合并"
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr "在创建后Checkout"
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr "请选择某个跟踪分支."
+
+#: lib/branch_create.tcl:141
+#, tcl-format
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr "跟踪分支 %s 并不是远端版本库中的一个分支"
+
+#: lib/commit.tcl:9
+#, fuzzy
+msgid ""
+"There is nothing to amend.\r\n"
+"\r\n"
+"You are about to create the initial commit.  There is no commit before this "
+"to amend.\r\n"
+msgstr ""
+"没有改动需要修正.\n"
+"\n"
+"你正在创建最初的提交. 在此之前没有提交可以修正.\n"
+
+#: lib/commit.tcl:18
+#, fuzzy
+msgid ""
+"Cannot amend while merging.\r\n"
+"\r\n"
+"You are currently in the middle of a merge that has not been fully "
+"completed.  You cannot amend the prior commit unless you first abort the "
+"current merge activity.\r\n"
+msgstr ""
+"在合并时无法修正.\n"
+"\n"
+"你当前正在一次尚未完成的合并操作过程中. 除非中止当前合并活动,\n"
+"否则无法修正之前的提交.\n"
+
+#: lib/commit.tcl:50
+msgid "Error loading commit data for amend:"
+msgstr "为修正装载提交数据出错:"
+
+#: lib/commit.tcl:77
+msgid "Unable to obtain your identity:"
+msgstr "无法获知你的身份:"
+
+#: lib/commit.tcl:82
+msgid "Invalid GIT_COMMITTER_IDENT:"
+msgstr "无效的 GIT_COMMITTER_IDENT"
+
+#: lib/commit.tcl:132
+#, tcl-format
+msgid "warning: Tcl does not support encoding '%s'."
+msgstr "警告: Tcl 不支持编码方式 '%s'."
+
+#: lib/commit.tcl:152
+#, fuzzy
+msgid ""
+"Last scanned state does not match repository state.\r\n"
+"\r\n"
+"Another Git program has modified this repository since the last scan.  A "
+"rescan must be performed before another commit can be created.\r\n"
+"\r\n"
+"The rescan will be automatically started now.\r\n"
+msgstr ""
+"最后一次扫描的状态和当前版本库状态不符.\n"
+"\n"
+"另一 Git 程序自上次扫描后修改了本版本库. 在修改当前分支之前需要重新做一次扫"
+"描.\n"
+"\n"
+"重新扫描将自动开始.\n"
+
+#: lib/commit.tcl:176
+#, fuzzy, tcl-format
+msgid ""
+"Unmerged files cannot be committed.\r\n"
+"\r\n"
+"File %s has merge conflicts.  You must resolve them and stage the file "
+"before committing.\r\n"
+msgstr ""
+"尚未合并的文件没有办法提交.\n"
+"\n"
+"文件 %s 有合并冲突, 你必须解决这些冲突并缓存该文件作提交.\n"
+
+#: lib/commit.tcl:184
+#, fuzzy, tcl-format
+msgid ""
+"Unknown file state %s detected.\r\n"
+"\r\n"
+"File %s cannot be committed by this program.\r\n"
+msgstr ""
+"检测到未知文件状态 %s.\n"
+"\n"
+"文件 %s 无法由该程序提交.\n"
+
+#: lib/commit.tcl:192
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"You must stage at least 1 file before you can commit.\r\n"
+msgstr ""
+"没有需要提交的变动.\n"
+"\n"
+"提交前你必须首先缓存至少一个文件.\n"
+
+#: lib/commit.tcl:207
+#, fuzzy
+msgid ""
+"Please supply a commit message.\r\n"
+"\r\n"
+"A good commit message has the following format:\r\n"
+"\r\n"
+"- First line: Describe in one sentence what you did.\r\n"
+"- Second line: Blank\r\n"
+"- Remaining lines: Describe why this change is good.\r\n"
+msgstr ""
+"请提供一条提交信息.\n"
+"\n"
+"一条好的提交信息有下列格式:\n"
+"\n"
+"- 第一行: 一句话概括你做的修改.\n"
+"- 第二行: 空行\n"
+"- 剩余行: 请描述为什么你做的这些改动是好的.\n"
+
+#: lib/commit.tcl:238
+msgid "Calling pre-commit hook..."
+msgstr ""
+
+#: lib/commit.tcl:253
+msgid "Commit declined by pre-commit hook."
+msgstr ""
+
+#: lib/commit.tcl:272
+msgid ""
+"You are about to commit on a detached head.\r\n"
+"This is a potentially dangerous thing to do because if you switch\r\n"
+"to another branch you will lose your changes and it can be difficult\r\n"
+"to retrieve them later from the reflog. You should probably cancel this\r\n"
+"commit and create a new branch to continue.\n"
+"\r\n"
+"\n"
+"\r\n"
+"Do you really want to proceed with your Commit?"
+msgstr ""
+
+#: lib/commit.tcl:293
+msgid "Calling commit-msg hook..."
+msgstr ""
+
+#: lib/commit.tcl:308
+msgid "Commit declined by commit-msg hook."
+msgstr ""
+
+#: lib/commit.tcl:321
+msgid "Committing changes..."
+msgstr ""
+
+#: lib/commit.tcl:338
+msgid "write-tree failed:"
+msgstr "write-tree 失败:"
+
+#: lib/commit.tcl:339 lib/commit.tcl:389 lib/commit.tcl:416
+#, fuzzy
+msgid "Commit failed."
+msgstr "克隆失败."
+
+#: lib/commit.tcl:356
+#, tcl-format
+msgid "Commit %s appears to be corrupt"
+msgstr "提交 %s 似乎已损坏"
+
+#: lib/commit.tcl:361
+#, fuzzy
+msgid ""
+"No changes to commit.\r\n"
+"\r\n"
+"No files were modified by this commit and it was not a merge commit.\r\n"
+"\r\n"
+"A rescan will be automatically started now.\r\n"
+msgstr ""
+"没有改动提交.\n"
+"\n"
+"该提交没有改动任何文件也不是一个合并提交.\n"
+"\n"
+"重新扫描将自动开始.\n"
+
+#: lib/commit.tcl:368
+msgid "No changes to commit."
+msgstr "没有改动要提交."
+
+#: lib/commit.tcl:388
+msgid "commit-tree failed:"
+msgstr "commit-tree 失败:"
+
+#: lib/commit.tcl:415
+msgid "update-ref failed:"
+msgstr "update-ref 失败:"
+
+#: lib/commit.tcl:508
+#, tcl-format
+msgid "Created commit %s: %s"
+msgstr "创建了 commit %s: %s"
+
+#: lib/branch_delete.tcl:16
+#, fuzzy, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr "删除分支"
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr "删除本地分支"
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr "本地分支"
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr "仅在合并后删除"
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr "下列分支没有完全被合并到 %s:"
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+"无法删除分支:\n"
+"%s"
+
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr "无法解锁缓存 (index)"
+
+#: lib/index.tcl:17
+msgid "Index Error"
+msgstr "缓存(Index)错误"
+
+#: lib/index.tcl:19
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr "更新 Git 缓存(Index)失败, 重新扫描将自动开始以重新同步 git-gui."
+
+#: lib/index.tcl:30
+msgid "Continue"
+msgstr "继续"
+
+#: lib/index.tcl:33
+msgid "Unlock Index"
+msgstr "解锁 Index"
+
+#: lib/index.tcl:294
+#, fuzzy
+msgid "Unstaging selected files from commit"
+msgstr "从提交缓存中删除 %s"
+
+#: lib/index.tcl:298
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr "从提交缓存中删除 %s"
+
+#: lib/index.tcl:337
+#, fuzzy
+msgid "Ready to commit."
+msgstr "缓存为提交"
+
+#: lib/index.tcl:346
+msgid "Adding selected files"
+msgstr ""
+
+#: lib/index.tcl:350
+#, tcl-format
+msgid "Adding %s"
+msgstr "添加 %s"
+
+#: lib/index.tcl:380
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr ""
+
+#: lib/index.tcl:388
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:440
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr "撤销文件 %s 中的改动?"
+
+#: lib/index.tcl:442
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr "撤销这些 (%i个) 文件的改动?"
+
+#: lib/index.tcl:450
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr "任何未缓存的改动将在这次撤销中永久丢失."
+
+#: lib/index.tcl:453 lib/index.tcl:488
+msgid "Do Nothing"
+msgstr "不做操作"
+
+#: lib/index.tcl:475
+#, fuzzy, tcl-format
+msgid "Delete untracked file %s?"
+msgstr "从 %s 中删除分支"
+
+#: lib/index.tcl:477
+#, fuzzy, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr "撤销这些 (%i个) 文件的改动?"
+
+#: lib/index.tcl:485
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:489
+#, fuzzy
+msgid "Delete Files"
+msgstr "删除"
+
+#: lib/index.tcl:528
+#, fuzzy
+msgid "Reverting selected files"
+msgstr "撤销文件 %s 中的改动?"
+
+#: lib/index.tcl:532
+#, fuzzy, tcl-format
+msgid "Reverting %s"
+msgstr "撤销修改"
+
+#: lib/encoding.tcl:443
+#, fuzzy
+msgid "Default"
+msgstr "恢复默认值"
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr ""
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr ""
+
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr "无效的日期: %s"
+
+#: lib/choose_rev.tcl:52
+msgid "This Detached Checkout"
+msgstr "该脱节的Checkout"
+
+#: lib/choose_rev.tcl:60
+msgid "Revision Expression:"
+msgstr "版本表达式:"
+
+#: lib/choose_rev.tcl:72
+msgid "Local Branch"
+msgstr "本地分支"
+
+#: lib/choose_rev.tcl:77
+msgid "Tracking Branch"
+msgstr "跟踪分支:"
+
+#: lib/choose_rev.tcl:82 lib/choose_rev.tcl:544
+msgid "Tag"
+msgstr "标签"
+
+#: lib/choose_rev.tcl:321
+#, tcl-format
+msgid "Invalid revision: %s"
+msgstr "无效版本: %s"
+
+#: lib/choose_rev.tcl:342
+msgid "No revision selected."
+msgstr "没有选择版本."
+
+#: lib/choose_rev.tcl:350
+msgid "Revision expression is empty."
+msgstr "版本表达式为空."
+
+#: lib/choose_rev.tcl:537
+msgid "Updated"
+msgstr "已更新"
+
+#: lib/choose_rev.tcl:565
+msgid "URL"
+msgstr "URL"
+
+#: lib/database.tcl:42
+msgid "Number of loose objects"
+msgstr "松散对象的数量"
+
+#: lib/database.tcl:43
+msgid "Disk space used by loose objects"
+msgstr "松散对象所使用的磁盘空间"
+
+#: lib/database.tcl:44
+msgid "Number of packed objects"
+msgstr "压缩对象数量"
+
+#: lib/database.tcl:45
+msgid "Number of packs"
+msgstr "压缩包数量"
+
+#: lib/database.tcl:46
+msgid "Disk space used by packed objects"
+msgstr "压缩对象所使用的磁盘空间"
+
+#: lib/database.tcl:47
+msgid "Packed objects waiting for pruning"
+msgstr "压缩对象等待清理"
+
+#: lib/database.tcl:48
+msgid "Garbage files"
+msgstr "垃圾文件"
+
+#: lib/database.tcl:66
+#, fuzzy, tcl-format
+msgid "%s (%s): Database Statistics"
+msgstr "数据库统计信息"
+
+#: lib/database.tcl:72
+msgid "Compressing the object database"
+msgstr "压缩对象数据库"
+
+#: lib/database.tcl:83
+msgid "Verifying the object database with fsck-objects"
+msgstr "使用 fsck-objects 验证对象数据库"
+
+#: lib/database.tcl:107
+#, fuzzy, tcl-format
+msgid ""
+"This repository currently has approximately %i loose objects.\r\n"
+"\r\n"
+"To maintain optimal performance it is strongly recommended that you compress "
+"the database.\r\n"
+"\r\n"
+"Compress the database now?"
+msgstr ""
+"该版本库当前约有 %i 个松散对象.\n"
+"\n"
+"为达到较优的性能，强烈建议你在松散对象多于 %i 时压缩数据库.\n"
+"\n"
+"现在就压缩数据库么?"
+
+#: lib/error.tcl:20
+#, fuzzy, tcl-format
+msgid "%s: error"
+msgstr "错误"
+
+#: lib/error.tcl:36
+#, fuzzy, tcl-format
+msgid "%s: warning"
+msgstr "警告"
+
+#: lib/error.tcl:80
+#, tcl-format
+msgid "%s hook failed:"
+msgstr ""
+
+#: lib/error.tcl:96
+msgid "You must correct the above errors before committing."
+msgstr "你必须在提交前修正上述错误."
+
+#: lib/error.tcl:116
+#, tcl-format
+msgid "%s (%s): error"
+msgstr ""
+
+#~ msgid "Cannot use funny .git directory:"
+#~ msgstr "无法使用 .git 目录:"
+
+#~ msgid ""
+#~ "Unable to start gitk:\n"
+#~ "\n"
+#~ "%s does not exist"
+#~ msgstr ""
+#~ "无法启动 gitk:\n"
+#~ "\n"
+#~ "%s 不存在"
+
+#~ msgid "Apple"
+#~ msgstr "苹果"
+
+#~ msgid "Preferences..."
+#~ msgstr "首选项..."
+
+#~ msgid "Always (Do not perform merge test.)"
+#~ msgstr "总是合并 (不作合并测试.)"
+
+#~ msgid "URL:"
+#~ msgstr "URL:"
+
+#~ msgid "Delete Remote Branch"
+#~ msgstr "删除远端分支"


### PR DESCRIPTION
My development environment sometimes makes automatic changes
that I don't want to keep. In some cases, this involves new
files being added that I don't want to commit or keep. I have
typically had to explicitly delete those files externally to
Git Gui, and I want to be able to just select those newly-
created untracked files and "revert" them into oblivion.

This change updates the revert_helper function to check for
untracked files as well as changes, and then any changes to be
reverted and untracked files are handled by independent
blocks of code. The user is prompted independently for
untracked files, since the underlying action is fundamentally
different (rm -f). If after deleting untracked files, the
directory containing them becomes empty, then the directory is
removed as well.

This introduces some new strings as well, so I reran
`make update-po`, which has produced lots of little changes to
the files in the po subdirectory. :-)